### PR TITLE
feat: configurable per-preset tool guidance (#7)

### DIFF
--- a/.agents/skills/dsh-plugin-guidelines/SKILL.md
+++ b/.agents/skills/dsh-plugin-guidelines/SKILL.md
@@ -282,11 +282,11 @@ session.
 > bump the version (e.g. `0.2.0-rc.0` → `0.2.0-rc.1`) or clear the entry each
 > round rather than re-`add` a rebuilt same-version snapshot.
 
-The plugin's `_default/` guidance templates (and other files it materializes on
+The plugin's per-preset guidance dirs (and other files it materializes on
 `apply()`) land in the plugin's SHARED home under `$DSH_HOME/plugins/<pkg>/`,
-shared across every profile — `ensureDefaultGuidance` never rewrites existing
-files, so a stale `_default/` from an earlier profile boot survives a fresh
-install until you delete it explicitly.
+shared across every profile — the seeding function never rewrites existing
+files, so stale seeded files from an earlier profile boot survive a fresh
+install until you delete them explicitly.
 
 Install a local build into a THROWAWAY profile (e.g. `dsh plugin --profile
 scratch-<topic> add …`) first when the change is experimental — it keeps the

--- a/.agents/skills/dsh-plugin-guidelines/SKILL.md
+++ b/.agents/skills/dsh-plugin-guidelines/SKILL.md
@@ -270,6 +270,24 @@ state is keyed by preset or workspace is often fastest to verify by
 materializing its sample files once, overriding one, and starting a new
 session.
 
+> **Gotcha — a same-version `file:` tgz silently serves STALE content.** pnpm's
+> content store is keyed by package@version, so `dsh plugin --profile <name> add
+> <same-version.tgz>` (and plain `pnpm add`) reports "added 0" and re-links the
+> OLD build when only the tarball's bytes changed — the `.tgz` in `package.json`
+> is unchanged, so pnpm never re-reads it. Symptom: you booted the "new" build
+> but behaviour/files are exactly as before. Force the refresh in the profile
+> with `rm -rf node_modules/<pkg> && pnpm install --force` (this re-extracts
+> from the changed tarball), or bump the version — a distinct version defeats
+> the store dedup by construction. This is why iterating on a PR build should
+> bump the version (e.g. `0.2.0-rc.0` → `0.2.0-rc.1`) or clear the entry each
+> round rather than re-`add` a rebuilt same-version snapshot.
+
+The plugin's `_default/` guidance templates (and other files it materializes on
+`apply()`) land in the plugin's SHARED home under `$DSH_HOME/plugins/<pkg>/`,
+shared across every profile — `ensureDefaultGuidance` never rewrites existing
+files, so a stale `_default/` from an earlier profile boot survives a fresh
+install until you delete it explicitly.
+
 Install a local build into a THROWAWAY profile (e.g. `dsh plugin --profile
 scratch-<topic> add …`) first when the change is experimental — it keeps the
 real profiles untouched and exercises the exact pack→add→boot path; delete the

--- a/.agents/skills/dsh-plugin-guidelines/SKILL.md
+++ b/.agents/skills/dsh-plugin-guidelines/SKILL.md
@@ -17,7 +17,7 @@ docs promise compatibility-breaking changes. Every rule cites the mechanism
 it derives from — the registry's scope layering, the `fs/*` event gate, the
 bundle patch semantics. When a rule stops matching your installed dsh, the
 mechanism is where it broke: read the package that owns it (`dsh-tools`,
-`dsh-fs`, `dsh-agent-presets`) rather than the rule.
+`dsh-fs`, `dsh-agent-presets`, `dsh-system-prompt`) rather than the rule.
 
 The tutorials own the copy-paste shapes: `docs/cookbook/adding-a-tool.md` for a
 tool, `docs/cookbook/adding-a-package.md` for a bundle,
@@ -61,6 +61,32 @@ sees into a sibling.
   with a duplicate name in the same layer throws, and a same-name section on a
   nearer scope replaces the farther one (this is how a preset shadows the
   deployment persona).
+
+## Prompt section order
+
+Assembly merges every layer's sections, then concatenates them in ascending
+`order` — one number, nothing else. The `order` gotchas the tutorials' examples
+never confess:
+
+- **The bands are convention, not enforcement.** `-100` harness identity, `0`
+  persona, `100–199` tool guidance. A section at any order sorts exactly where
+  the number sits; nothing validates the band. Plugin tool guidance in the
+  100–199 band interleaves with the built-ins, whose occupancy is current for
+  rc.6: 100 read, 103 glob, 105 bash/pwsh, 106 jobs, 110 web_search, 114 goal,
+  115 cordis/workflow, 116 ralph — pick gap numbers or a clean upper band, and
+  verify the occupancy against the installed `dsh-tool-*` packages before
+  choosing.
+- **Equal `order` values tie-break by registration order** — a load artifact,
+  nondeterministic across loads. Distinct names at one order do NOT throw
+  (duplicate names do, per above); only non-finite orders throw too. A tie with
+  a built-in is the "breaks system prompt consistency" report: the same prompt
+  assembles in different order on machines with different load orders.
+
+Consequence of own layer wins: a preset row can neither reorder nor override a
+plugin's agent-layer sections — its same-named sections are shadowed, its
+different-named ones only tie. A plugin that needs configurable text or order
+must read its own row `config` (it reaches `apply(ctx, config)`) or its own
+files; it cannot be patched from outside.
 
 ### Shadowing a built-in (the pattern)
 

--- a/.agents/skills/dsh-plugin-guidelines/SKILL.md
+++ b/.agents/skills/dsh-plugin-guidelines/SKILL.md
@@ -80,7 +80,9 @@ never confess:
   nondeterministic across loads. Distinct names at one order do NOT throw
   (duplicate names do, per above); only non-finite orders throw too. A tie with
   a built-in is the "breaks system prompt consistency" report: the same prompt
-  assembles in different order on machines with different load orders.
+  assembles in different order on machines with different load orders. `dsh-better-edit`
+  ships its own tool-guidance defaults at 130–133 for exactly this reason — above the
+  built-in band, so a same-order tie with a built-in cannot occur out of the box.
 
 Consequence of own layer wins: a preset row can neither reorder nor override a
 plugin's agent-layer sections — its same-named sections are shadowed, its

--- a/.agents/skills/dsh-plugin-guidelines/SKILL.md
+++ b/.agents/skills/dsh-plugin-guidelines/SKILL.md
@@ -243,6 +243,36 @@ calls.
 - Verify a layer without booting: `dsh --profile <name> --dump-config` shows
   each bundle's contribution under `# == <bundle>`.
 
+### Local install & verification (a real deployment, not just dump-config)
+
+To run an unpublished build in a live deployment — e.g. a PR branch — install a
+packed snapshot into a profile, then boot:
+
+1. Build and pack: `npm run build` (transpile `src` → `lib/`, which is
+gitignored) then `npm pack --pack-destination /tmp` →
+`<pkg>-<version>.tgz`. The tgz is what `files` ships, so this mirrors the
+published package exactly.
+2. Install into a profile: `dsh plugin --profile <name> add /path/<pkg>.tgz`
+(the same pnpm forwarder as any install). This rewrites the profile's
+`package.json` dependency to `file:/path/<pkg>.tgz` and reconciles the
+bundle list; `dsh plugin --profile <name> add <pkg>@<range>` reverts it.
+3. **`--dump-config` does NOT boot agents.** It shows the host-plane rows
+only — it will not run `apply()` side effects, register prompt sections, or
+materialize files. Confirming the row is loaded is necessary but not
+sufficient for verifying behaviour that happens at `agent/session-start` or
+boot.
+4. Boot the app and observe the real effects: template files the plugin
+materializes into `$DSH_HOME/plugins/<pkg>/` on `apply()`, then per-
+preset/per-agent registrations the first session triggers. A plugin whose
+state is keyed by preset or workspace is often fastest to verify by
+materializing its sample files once, overriding one, and starting a new
+session.
+
+Install a local build into a THROWAWAY profile (e.g. `dsh plugin --profile
+scratch-<topic> add …`) first when the change is experimental — it keeps the
+real profiles untouched and exercises the exact pack→add→boot path; delete the
+profile dir to clean up.
+
 ## Session-scoped state
 
 The store for per-session state belongs under the dsh home

--- a/.scratch/specs/0007-configurable-per-preset-guidance.md
+++ b/.scratch/specs/0007-configurable-per-preset-guidance.md
@@ -1,0 +1,65 @@
+# Spec — Configurable per-preset tool guidance (issue #7)
+
+Parent: #7 ([Enhancement] Support Configurable Prompts to Improve Plugin Flexibility)
+
+## Problem Statement
+
+The guidance text and ordering of the plugin's four system-prompt sections (`tool:read`, `tool:edit`, `tool:batch_edit`, `tool:undo_last_edit`) are hardcoded in `src/prompts.ts` and `src/index.ts`. Users running the plugin under different agent presets — or alongside other tool guidance — cannot adapt the text the model reads. The result is guidance that is fixed, verbose, and identical for every preset.
+
+## Solution
+
+Let the user override any section's guidance and `order` with plain markdown files, keyed by agent preset. The plugin resolves, per agent, the preset it is composed on (`agentPresets.composedPreset`) and reads `<section>.md` override files from the plugin's shared home (`$DSH_HOME/plugins/dsh-better-edit/<preset>/`, default `~/.dsh/plugins/dsh-better-edit/`). A `_default/` directory is auto-created from the compiled guidance on first run — it is both the copy source ("copy `_default` to `<preset>`") and a live global fallback layer. The fallback chain per section is `<preset>/<section>.md` → `_default/<section>.md` → compiled constant.
+
+## User Stories
+
+1. As a dsh user, I want the guidance text of each hashline tool section to be overridable, so that I can adapt it to my agent preset.
+2. As a dsh user, I want the `order` of each section to be overridable, so that my sections sit where I want them in the assembled system prompt.
+3. As a dsh user, I want overrides keyed by preset id, so that different presets can show different guidance.
+4. As a dsh user, I want to override only the sections I care about, so that the rest keep their defaults.
+5. As a dsh user, I want a global override that applies to every preset, so that I can customize once without per-preset copies.
+6. As a dsh user, I want the default guidance materialized as files on first run, so that I can copy and edit them without hunting through node_modules.
+7. As a dsh user, I want the override files to be plain markdown, so that I can edit prose without YAML escaping.
+8. As a dsh user, I want the `order` expressed as optional front-matter, so that a pure-prose file still works.
+9. As a dsh user, I want a preset that has no override files to keep the compiled defaults, so that nothing breaks when I don't customize.
+10. As a dsh user, I want deployments without presets to keep working unchanged, so that enabling the plugin never requires presets.
+11. As a dsh user, I want guidance files read once per agent, so that edits apply to new sessions without a watcher or hot reload.
+12. As a dsh subagent, I want to inherit my parent's preset guidance automatically, so that delegation shows the same tool contract.
+13. As a dsh user, I want the shipped default guidance simplified, so that the system prompt is tighter.
+14. As a maintainer, I want the naming unified on "guidance" (not "guidelines"), so that the vocabulary stays consistent.
+15. As a maintainer, I want the feature documented in README (EN and zh) with a CHANGELOG entry, so that users can discover it.
+
+## Implementation Decisions
+
+- **Per-preset keying**: at `agent/session-start` the plugin reads `rootCtx.get("agentPresets")` (optional — never a hard inject) and calls `composedPreset(agent.ctx)` to learn the live preset id. A preset-less agent (undefined id) uses the compiled defaults.
+- **File location**: `$DSH_HOME/plugins/dsh-better-edit/<preset>/<section>.md` — the plugin's existing shared home (same dir as `hash-store.sqlite`). Guidance is per-user-per-preset, NOT per-workspace (the workspace `.dsh_better_edit/` dir is untouched).
+- **Section file names**: the section name minus the `tool:` prefix — `read.md`, `edit.md`, `batch_edit.md`, `undo_last_edit.md`. Mechanical mapping, no translation table.
+- **Fallback template dir name**: `_default` (NOT `default` — `default` is a valid preset id, and a preset id can never start with `_`, so collision is impossible by construction).
+- **File shape**: optional YAML front-matter (`---\norder: N\n---`) followed by the full rendered section text. A file without front-matter is treated as pure prose. Malformed front-matter degrades to pure prose.
+- **Fallback chain per section**: `<preset>/<section>.md` → `_default/<section>.md` → compiled constant in `src/prompts.ts`. Each level optional; partial override works.
+- **Materialization**: on first run, if `_default/` is absent, write the four section files rendered from the compiled constants plus a short `README.md` explaining the convention. Idempotent; never rewrites existing files.
+- **Read-once semantics**: guidance is resolved once per agent at session-start and never re-read while the agent runs (matches dsh's prefix-stability/KV-cache discipline — same as presets and persona). File edits affect new sessions only.
+- **Compiled defaults stay the source of truth** for section text; the `_default/` files are rendered from them by construction (no drift).
+- **Content**: the four sections are simplified per the writing-for-agents principles (shorter, imperative, no redundancy); the `*_GUIDELINES` constants are renamed to `*_GUIDANCE`.
+- **Boundaries**: tool `_DESCRIPTION`/`_SNIPPET` strings stay hardcoded; section names are fixed; only text and `order` are overridable.
+- **No cordis config plumbing**: the plugin's row `config` remains unused; no `Config` schema is added.
+
+## Testing Decisions
+
+- **Test seam (single)**: a pure module that takes `(presetId | undefined, homeDir, section)` and returns the resolved `{ order, text }` (and the composition of all four sections). All fallback/front-matter/materialization behavior is exercised through this seam against temp directories — no cordis harness boot needed.
+- **Modules tested**: the new guidance module (resolution, parsing, materialization) plus the existing vitest suite must stay green.
+- **Prior art**: existing unit tests in `test/` (vitest) with temp-dir fixtures (e.g. `test/core/edit-engine.e2e.test.ts`, `test/support/`).
+
+## Out of Scope
+
+- Per-workspace guidance overrides (workspace `.dsh_better_edit/`).
+- Overriding tool `_DESCRIPTION`/`_SNIPPET` strings.
+- Renaming sections (`tool:edit`, etc.) from config.
+- Hot reload / file watchers.
+- Cordis row `config` plumbing or a `Config` schema.
+- Overriding guidance via preset-composition rows (`agent.cordis.yml`) — impossible anyway: the plugin registers sections on the agent's own scope layer, which always shadows preset-layer rows.
+
+## Further Notes
+
+- **Why not preset rows**: dsh's system-prompt registry is scope-layered (`agent → preset → global`, nearest wins). The plugin registers its sections on the agent's own layer, so a preset row declaring the same section name cannot override them — only the plugin reading config can. This is the key constraint that makes file-based, plugin-read overrides the right shape.
+- An ADR recording this decision (files over cordis config; why preset rows can't work) will accompany the implementation.
+- README (EN and zh) gains a "Configuring guidance per preset" section; CHANGELOG entry on release.

--- a/.scratch/specs/tickets/01-guidance-resolution.md
+++ b/.scratch/specs/tickets/01-guidance-resolution.md
@@ -1,0 +1,16 @@
+## Parent
+
+# 7 ([Enhancement] Support Configurable Prompts to Improve Plugin Flexibility) · Spec: #8
+
+## What to build
+
+The core resolution module: given an agent's preset id (or none) and the plugin's shared home directory, produce the final `{ order, text }` for each of the four tool sections, walking the fallback chain `<preset>/<section>.md` → `_default/<section>.md` → compiled constant. Override files are plain markdown with an optional YAML `order` front-matter; filename is the section name minus the `tool:` prefix. This is the seam all later work builds on — no plugin wiring yet.
+
+## Acceptance criteria
+
+- [ ] A pure, unit-testable module exists (`src/guidance.ts` or similar) exporting: compiled-section render, front-matter parsing, per-section resolution, and a four-section composition given `(presetId | undefined, homeDir)`.
+- [ ] Section files: `read.md`, `edit.md`, `batch_edit.md`, `undo_last_edit.md` map to `tool:read` (100), `tool:edit` (102), `tool:batch_edit` (103), `tool:undo_last_edit` (104).
+- [ ] `order` front-matter (`---\norder: N\n---`) overrides the default order; a file without front-matter is pure prose; malformed front-matter degrades to pure prose.
+- [ ] Fallback chain works per section: preset file → `_default/` file → compiled constant; any level optional; partial override (only some sections overridden) works.
+- [ ] `presetId === undefined` resolves straight to compiled defaults (no preset layer).
+- [ ] Unit tests cover resolution, parsing, and fallback against temp directories; the existing vitest suite stays green.

--- a/.scratch/specs/tickets/02-default-template-materialization.md
+++ b/.scratch/specs/tickets/02-default-template-materialization.md
@@ -1,0 +1,19 @@
+## Parent
+
+# 7 ([Enhancement] Support Configurable Prompts to Improve Plugin Flexibility) · Spec: #8
+
+## What to build
+
+On first run the plugin materializes the `_default/` guidance template directory into its shared home: the four section files rendered from the compiled constants, plus a `README.md` explaining the copy-to-override convention. Idempotent — never rewrites files that already exist. The `_default/` layer is both the copy source for users (`cp -r _default <preset>`) and a live global fallback layer (already honoured by the resolver).
+
+## Acceptance criteria
+
+- [ ] An idempotent `ensureDefaultGuidance(homeDir)`-style function creates `_default/{read,edit,batch_edit,undo_last_edit}.md` from the compiled constants when the directory is absent.
+- [ ] Existing files are never rewritten (a user-edited `_default/` survives repeated calls).
+- [ ] A `README.md` in `_default/` documents the convention: copy to `<preset>/`, front-matter `order`, fallback chain.
+- [ ] The template directory name is `_default` (not `default`), so it can never collide with a real preset id.
+- [ ] Unit tests cover create-on-missing, no-op on existing, and content parity with the compiled render; the existing vitest suite stays green.
+
+## Blocked by
+
+#9 — guidance resolution core

--- a/.scratch/specs/tickets/03-wire-per-preset-guidance.md
+++ b/.scratch/specs/tickets/03-wire-per-preset-guidance.md
@@ -1,0 +1,19 @@
+## Parent
+
+# 7 ([Enhancement] Support Configurable Prompts to Improve Plugin Flexibility) · Spec: #8
+
+## What to build
+
+Wire the resolver into the plugin install: at `agent/session-start`, read `rootCtx.get("agentPresets")` (optional — never a hard inject), call `composedPreset(agent.ctx)` for the live preset id, resolve the four sections via the guidance module, and register them with their resolved `order`/`text`. Fast path preserved: no `agentPresets` service or undefined preset id → compiled defaults, byte-identical behavior to today for non-customizing users.
+
+## Acceptance criteria
+
+- [ ] The installer resolves guidance per agent from its preset id and registers sections with overridden text/order when override files exist.
+- [ ] `agentPresets` is read optionally (via `ctx.get`) — a deployment without `dsh-agent-presets` still installs tools and uses compiled defaults (no hard-inject regression).
+- [ ] Undefined preset id (roster-less agent, tests, previews) → compiled defaults.
+- [ ] A pure composition seam (e.g. `composeSections(presetId, homeDir)` → the four `{ name, order, text }` configs) is unit-tested against temp dirs; no cordis harness boot required.
+- [ ] The four section names and default orders are unchanged; existing behavior tests stay green.
+
+## Blocked by
+
+#9 — guidance resolution core

--- a/.scratch/specs/tickets/04-simplify-guidance-content.md
+++ b/.scratch/specs/tickets/04-simplify-guidance-content.md
@@ -1,0 +1,19 @@
+## Parent
+
+# 7 ([Enhancement] Support Configurable Prompts to Improve Plugin Flexibility) · Spec: #8
+
+## What to build
+
+Rewrite the four sections' default guidance text following the writing-for-agents principles (`.agents/skills/writing-for-agents/`): shorter, imperative, no redundancy — the issue's complaint is partly that the current guidance is verbose. Rename the `*_GUIDELINES` constants to `*_GUIDANCE` per the domain glossary, updating all imports. The `_default/` template (materialized by the resolution work) reflects the tightened text automatically.
+
+## Acceptance criteria
+
+- [ ] The four guidance texts are simplified per writing-for-agents; each section's prose is visibly tighter with the essential contract (hash anchors, staleness rejection, all-or-nothing batch) preserved.
+- [ ] `*_GUIDELINES` → `*_GUIDANCE` rename lands across `src/prompts.ts`, `src/index.ts`, and the guidance module; no stale references.
+- [ ] Model-facing error codes and tool behavior are untouched (this is text-only).
+- [ ] Nothing pins the old text (verified: no test/benchmark asserts section text) — suite stays green; CONTEXT.md glossary stays consistent.
+- [ ] The materialized `_default/` files (see the template ticket) match the new text.
+
+## Blocked by
+
+#9 — guidance resolution core

--- a/.scratch/specs/tickets/05-docs-changelog-adr.md
+++ b/.scratch/specs/tickets/05-docs-changelog-adr.md
@@ -1,0 +1,18 @@
+## Parent
+
+# 7 ([Enhancement] Support Configurable Prompts to Improve Plugin Flexibility) · Spec: #8
+
+## What to build
+
+The user-facing documentation: a "Configuring guidance per preset" section in README.md and README.zh.md (where files live, `_default/` auto-creation, `cp -r _default <preset>`, front-matter `order`, fallback chain, read-once semantics), a CHANGELOG entry, and ADR-0001 recording the decision (per-preset guidance via override files in the plugin home; rejected: cordis row config and preset-composition shadowing — the latter is impossible because the plugin registers sections on the agent's own scope layer).
+
+## Acceptance criteria
+
+- [ ] README.md and README.zh.md document the override flow with a concrete example.
+- [ ] CHANGELOG.md gains an entry describing the feature.
+- [ ] `docs/adr/0001-*.md` records the decision and the scope-layering reason preset rows can't work.
+- [ ] CONTEXT.md is consistent with the final vocabulary (guidance, section, order, preset).
+
+## Blocked by
+
+#11 — wire per-preset guidance · #12 — simplify guidance content

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,10 @@ Entries link to the originating spec issue in [pi-hashline-edit-lsz](https://git
 
 ### Added
 
-- Configurable per-preset tool guidance (issues #7, #8; tickets #9–#13): the four `tool:*` prompt sections resolve from plain-markdown override files keyed by agent preset — `$DSH_HOME/plugins/dsh-better-edit/<preset>/<section>.md` — with an optional `order` front-matter. A `_default/` template is materialized from the compiled defaults on first boot: copy source and live global fallback in one. Per section the chain is `<preset>/` → `_default/` → compiled default; files are read once per agent at session-start, so edits apply to new sessions. Deployments without the `agentPresets` service keep the compiled defaults untouched.
+- Configurable per-preset tool guidance (issues #7, #8; tickets #9–#13): the four `tool:*` prompt sections resolve from plain-markdown override files keyed by agent preset — `$DSH_HOME/plugins/dsh-better-edit/<preset>/<section>.md` — with an optional `order` front-matter. On first boot the plugin seeds each shipped preset (`standard`, `code`, `minimal`, `cordis`) with its guidance as editable files plus a root README documenting the scheme. Per section the chain is `<preset>/<section>.md` → compiled default; files are read once per agent at session-start, so edits apply to new sessions. Deployments without the `agentPresets` service keep the compiled defaults untouched.
 Default orders sit at 130–133, above the built-in tool-guidance band (100–116 in the shipped
 dsh), so a same-order section merge with unrelated tool guidance cannot occur out of the box; the
-materialized `_default/` files expose that `order` as editable front-matter.
+the seeded preset files expose that `order` as editable front-matter.
 - Default guidance text simplified per the writing-for-agents principles; the `*_GUIDELINES` constants unified on `*_GUIDANCE`.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Entries link to the originating spec issue in [pi-hashline-edit-lsz](https://git
 
 ## [Unreleased]
 
+### Added
+
+- Configurable per-preset tool guidance (issues #7, #8; tickets #9–#13): the four `tool:*` prompt sections resolve from plain-markdown override files keyed by agent preset — `$DSH_HOME/plugins/dsh-better-edit/<preset>/<section>.md` — with an optional `order` front-matter. A `_default/` template is materialized from the compiled defaults on first boot: copy source and live global fallback in one. Per section the chain is `<preset>/` → `_default/` → compiled default; files are read once per agent at session-start, so edits apply to new sessions. Deployments without the `agentPresets` service keep the compiled defaults untouched.
+- Default guidance text simplified per the writing-for-agents principles; the `*_GUIDELINES` constants unified on `*_GUIDANCE`.
+
 ### Changed
 
 - Benchmark extended to a third arm, `@oh-my-pi/hashline`: same corpus, same 12 replacements, two modes (per-edit `seq` with renumbered lines + one-document `batch` fixed to original line numbers). Payloads are built from the package's published grammar and validated before counting (the package is Bun-only, so it cannot run under the Node benchmark). Honest result, reported as such: hashline saves 31% vs `str_replace` on the session (43% on multi-line ranges) and remains the plugin's claim; the compact patch language saves 42% per edit / 53% batched — and this README says so. `npm run benchmark` stays byte-deterministic (verified over repeated runs).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Entries link to the originating spec issue in [pi-hashline-edit-lsz](https://git
 ### Added
 
 - Configurable per-preset tool guidance (issues #7, #8; tickets #9–#13): the four `tool:*` prompt sections resolve from plain-markdown override files keyed by agent preset — `$DSH_HOME/plugins/dsh-better-edit/<preset>/<section>.md` — with an optional `order` front-matter. A `_default/` template is materialized from the compiled defaults on first boot: copy source and live global fallback in one. Per section the chain is `<preset>/` → `_default/` → compiled default; files are read once per agent at session-start, so edits apply to new sessions. Deployments without the `agentPresets` service keep the compiled defaults untouched.
+Default orders sit at 130–133, above the built-in tool-guidance band (100–116 in the shipped
+dsh), so a same-order section merge with unrelated tool guidance cannot occur out of the box; the
+materialized `_default/` files expose that `order` as editable front-matter.
 - Default guidance text simplified per the writing-for-agents principles; the `*_GUIDELINES` constants unified on `*_GUIDANCE`.
 
 ### Changed

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,19 @@
+# dsh-better-edit
+
+Hash-anchored read/edit/batch_edit/undo_last_edit tools for DeepSeek Harness (dsh). This context covers the plugin's model-facing vocabulary: what its tools are and how the text the model reads is configured.
+
+## Language
+
+**Prompt section**:
+A named unit in dsh's `systemPrompt` registry — one of `tool:read`, `tool:edit`, `tool:batch_edit`, `tool:undo_last_edit` — carrying a name, an `order`, and rendered text. Registered per agent on the agent's own scope layer, so it shadows the preset's built-in section of the same name.
+_Avoid_: prompt, prompt entry
+
+**Guidance**:
+The editable prose of a prompt section — the usage instructions the model reads. Overridable per preset; the compiled defaults live in `src/prompts.ts`.
+_Avoid_: prompt, instructions ("instructions" is `dsh-agent-instructions`' term for AGENTS.md content), guidelines (the legacy `*_GUIDELINES` constant names in `src/prompts.ts` — unify on "guidance")
+
+**Order**:
+The numeric ordering of a prompt section within the assembled system prompt. Overridable alongside guidance.
+
+**Preset**:
+A per-session agent composition from the dsh roster (`agent.cordis.yml` plus metadata, system- or user-authored). The unit guidance overrides are keyed by; the plugin reads the agent's preset id at `agent/session-start` via `agentPresets.composedPreset`.

--- a/README.md
+++ b/README.md
@@ -275,6 +275,52 @@ registration cannot replace them. This plugin:
 3. Leaves the built-in `write` in place, but a scoped `tools/post-execute` listener appends the
    hashline auto-read to write results.
 
+## Configuring Guidance per Preset
+
+The `tool:read` / `tool:edit` / `tool:batch_edit` / `tool:undo_last_edit` guidance sections are
+plain-markdown files, overridable per agent preset. Override files live in the plugin's shared
+home — never the workspace store:
+
+```
+$DSH_HOME/plugins/dsh-better-edit/<preset>/<section>.md
+```
+
+(default home `~/.dsh`, so `~/.dsh/plugins/dsh-better-edit/`). The section table:
+
+| File | Section | Default order |
+| --- | --- | --- |
+| `read.md` | `tool:read` | 100 |
+| `edit.md` | `tool:edit` | 102 |
+| `batch_edit.md` | `tool:batch_edit` | 103 |
+| `undo_last_edit.md` | `tool:undo_last_edit` | 104 |
+
+On first boot the plugin materializes `_default/` — the compiled guidance as editable files plus a
+README — so a preset's guidance starts from a copy, not a blank page:
+
+```
+cp -r _default my-preset        # run inside $DSH_HOME/plugins/dsh-better-edit/
+```
+
+`_default/` doubles as the live global fallback: any preset without its own file inherits it, and
+editing it customizes every preset at once. A preset directory may hold only the sections you want
+to override — the rest fall through to the defaults.
+
+A file is pure prose unless it opens with an `order` front-matter fence, which moves the section in
+the assembled system prompt:
+
+```md
+---
+order: 150
+---
+
+<section text>
+```
+
+Per section, resolution walks `<preset>/<section>.md` → `_default/<section>.md` → compiled default.
+Files are read once per agent at session-start, so edits apply to new sessions — never mid-session.
+A deployment without the `agentPresets` service (no preset roster) keeps the compiled defaults and
+never touches these files; presets are never required.
+
 ## Store
 
 Hash snapshots, served-state rows, and undo history live in one SQLite store **co-located with the

--- a/README.md
+++ b/README.md
@@ -294,16 +294,13 @@ $DSH_HOME/plugins/dsh-better-edit/<preset>/<section>.md
 | `batch_edit.md` | `tool:batch_edit` | 132 |
 | `undo_last_edit.md` | `tool:undo_last_edit` | 133 |
 
-On first boot the plugin materializes `_default/` — the compiled guidance as editable files plus a
-README — so a preset's guidance starts from a copy, not a blank page:
-
-```
-cp -r _default my-preset        # run inside $DSH_HOME/plugins/dsh-better-edit/
-```
-
-`_default/` doubles as the live global fallback: any preset without its own file inherits it, and
-editing it customizes every preset at once. A preset directory may hold only the sections you want
-to override — the rest fall through to the defaults.
+On first boot the plugin seeds the four shipped presets — `standard/`, `code/`,
+`minimal/`, `cordis/` — each with the compiled guidance as editable files (plus
+`order` front-matter), so every preset's guidance starts editable rather than
+blank. A `README.md` at the plugin-home root documents the scheme. Files are
+seeded once and never rewritten, so your edits survive. A preset directory may
+hold only the sections you want to override — the rest fall through to the
+compiled defaults.
 
 A file is pure prose unless it opens with an `order` front-matter fence, which moves the section in
 the assembled system prompt:
@@ -316,10 +313,13 @@ order: 150
 <section text>
 ```
 
-Per section, resolution walks `<preset>/<section>.md` → `_default/<section>.md` → compiled default.
-Files are read once per agent at session-start, so edits apply to new sessions — never mid-session.
-A deployment without the `agentPresets` service (no preset roster) keeps the compiled defaults and
-never touches these files; presets are never required.
+Per section, resolution reads `<preset>/<section>.md`, else the compiled
+default. Files are read once per agent at session-start, so edits apply to new
+sessions — never mid-session. A preset with no seeded directory (e.g. a
+user-authored one) falls back to the compiled defaults unless you copy a seeded
+dir to its name. A deployment without the `agentPresets` service (no preset
+roster) keeps the compiled defaults and never touches these files; presets are
+never required.
 
 ## Store
 

--- a/README.md
+++ b/README.md
@@ -289,10 +289,10 @@ $DSH_HOME/plugins/dsh-better-edit/<preset>/<section>.md
 
 | File | Section | Default order |
 | --- | --- | --- |
-| `read.md` | `tool:read` | 100 |
-| `edit.md` | `tool:edit` | 102 |
-| `batch_edit.md` | `tool:batch_edit` | 103 |
-| `undo_last_edit.md` | `tool:undo_last_edit` | 104 |
+| `read.md` | `tool:read` | 130 |
+| `edit.md` | `tool:edit` | 131 |
+| `batch_edit.md` | `tool:batch_edit` | 132 |
+| `undo_last_edit.md` | `tool:undo_last_edit` | 133 |
 
 On first boot the plugin materializes `_default/` — the compiled guidance as editable files plus a
 README — so a preset's guidance starts from a copy, not a blank page:

--- a/README.zh.md
+++ b/README.zh.md
@@ -217,6 +217,49 @@ dsh 的工具注册表按作用域解析：agent 看到的是 `agent → preset 
 2. 在 `agent/session-start` 时，将 hashline 工具**以及** `tool:read` / `tool:edit` 提示词片段注册到 agent 自身的作用域层——从而为该 agent 遮蔽 preset 的内置工具，并在 agent 销毁时自动解除。
 3. 保留内置的 `write`，但通过一个作用域内的 `tools/post-execute` 监听器把 hashline 自动读取附加到 write 结果之后。
 
+## 按 preset 配置指引
+
+`tool:read` / `tool:edit` / `tool:batch_edit` / `tool:undo_last_edit` 四个提示词片段的指引是
+纯 Markdown 文件，可以按 agent preset 覆盖。覆盖文件位于插件的共享主目录——绝不放在工作区存储中：
+
+```
+$DSH_HOME/plugins/dsh-better-edit/<preset>/<section>.md
+```
+
+（默认主目录为 `~/.dsh`，即 `~/.dsh/plugins/dsh-better-edit/`）。片段对照表：
+
+| 文件 | 提示词片段 | 默认 order |
+| --- | --- | --- |
+| `read.md` | `tool:read` | 100 |
+| `edit.md` | `tool:edit` | 102 |
+| `batch_edit.md` | `tool:batch_edit` | 103 |
+| `undo_last_edit.md` | `tool:undo_last_edit` | 104 |
+
+首次启动时插件会物化出 `_default/`——把编译内置的指引写成可编辑的文件，外加一份 README——这样 preset
+的指引从拷贝开始，而不是从空白开始：
+
+```
+cp -r _default my-preset        # 在 $DSH_HOME/plugins/dsh-better-edit/ 下执行
+```
+
+`_default/` 同时也是活跃的全局回退层：任何没有自己文件的 preset 都会继承它，编辑它即可一次性定制所有
+preset。preset 目录里可以只放你想覆盖的片段文件，其余自动回退到默认值。
+
+文件默认为纯文本；除非以 `order` front-matter 栅栏开头，它会改变该片段在组装后的系统提示中的位置：
+
+```md
+---
+order: 150
+---
+
+<片段文本>
+```
+
+每个片段的解析顺序为 `<preset>/<section>.md` → `_default/<section>.md` → 编译内置默认值。文件只在
+agent 的 session-start 时读取一次，因此修改只影响新会话——绝不影响进行中的会话。没有
+`agentPresets` 服务（即没有 preset 名册）的部署继续使用编译内置默认值，完全不会触碰这些文件；
+preset 从来不是必需的。
+
 ## 存储
 
 哈希快照、已提供状态行与撤销历史存放在一个 SQLite 库中，**与被编辑的工作区放在一起**——每个会话 cwd 一个库：

--- a/README.zh.md
+++ b/README.zh.md
@@ -235,15 +235,10 @@ $DSH_HOME/plugins/dsh-better-edit/<preset>/<section>.md
 | `batch_edit.md` | `tool:batch_edit` | 132 |
 | `undo_last_edit.md` | `tool:undo_last_edit` | 133 |
 
-首次启动时插件会物化出 `_default/`——把编译内置的指引写成可编辑的文件，外加一份 README——这样 preset
-的指引从拷贝开始，而不是从空白开始：
-
-```
-cp -r _default my-preset        # 在 $DSH_HOME/plugins/dsh-better-edit/ 下执行
-```
-
-`_default/` 同时也是活跃的全局回退层：任何没有自己文件的 preset 都会继承它，编辑它即可一次性定制所有
-preset。preset 目录里可以只放你想覆盖的片段文件，其余自动回退到默认值。
+首次启动时插件会为四个随附 preset——`standard/`、`code/`、`minimal/`、`cordis/`——各自写入编译内置的
+可编辑指引文件（含 `order` front-matter），让每个 preset 的指引一开始就可编辑，而不是空白。插件主目录
+根的 `README.md` 说明整套机制。文件只在首次写入时生成、之后绝不被覆盖，因此你的修改会保留。preset 目录
+里可以只放你想覆盖的片段文件，其余自动回退到编译内置默认值。
 
 文件默认为纯文本；除非以 `order` front-matter 栅栏开头，它会改变该片段在组装后的系统提示中的位置：
 
@@ -255,9 +250,10 @@ order: 150
 <片段文本>
 ```
 
-每个片段的解析顺序为 `<preset>/<section>.md` → `_default/<section>.md` → 编译内置默认值。文件只在
-agent 的 session-start 时读取一次，因此修改只影响新会话——绝不影响进行中的会话。没有
-`agentPresets` 服务（即没有 preset 名册）的部署继续使用编译内置默认值，完全不会触碰这些文件；
+每个片段的解析顺序为：读取 `<preset>/<section>.md`，否则回退到编译内置默认值。文件只在 agent 的
+session-start 时读取一次，因此修改只影响新会话——绝不影响进行中的会话。没有种子目录的 preset（例如
+用户自建的）会回退到编译内置默认值，除非你把某个种子目录复制成它的名字。没有 `agentPresets` 服务
+（即没有 preset 名册）的部署继续使用编译内置默认值，完全不会触碰这些文件；
 preset 从来不是必需的。
 
 ## 存储

--- a/README.zh.md
+++ b/README.zh.md
@@ -230,10 +230,10 @@ $DSH_HOME/plugins/dsh-better-edit/<preset>/<section>.md
 
 | 文件 | 提示词片段 | 默认 order |
 | --- | --- | --- |
-| `read.md` | `tool:read` | 100 |
-| `edit.md` | `tool:edit` | 102 |
-| `batch_edit.md` | `tool:batch_edit` | 103 |
-| `undo_last_edit.md` | `tool:undo_last_edit` | 104 |
+| `read.md` | `tool:read` | 130 |
+| `edit.md` | `tool:edit` | 131 |
+| `batch_edit.md` | `tool:batch_edit` | 132 |
+| `undo_last_edit.md` | `tool:undo_last_edit` | 133 |
 
 首次启动时插件会物化出 `_default/`——把编译内置的指引写成可编辑的文件，外加一份 README——这样 preset
 的指引从拷贝开始，而不是从空白开始：

--- a/docs/adr/0001-guidance-override-files.md
+++ b/docs/adr/0001-guidance-override-files.md
@@ -1,0 +1,19 @@
+# ADR-0001 — Per-preset guidance via override files in the plugin home
+
+The four `tool:*` guidance sections are configured with plain-markdown override files in the plugin's shared home, keyed by agent preset id — not through the plugin's Cordis row `config`, and not through preset-composition rows. Override files win by content, not by scope layering: the plugin reads them itself at `agent/session-start`.
+
+## Status
+
+Accepted (issue #7, spec #8).
+
+## Considered Options
+
+1. **Cordis row `config`** (patch layers). Native and inspectable via `--dump-config`, but long guidance prose is miserable in YAML (escaping, indentation), a patch replaces the whole `config` with no deep merge, and there is no per-preset granularity without extra plumbing.
+2. **Preset-composition shadowing** (rows in `agent.cordis.yml`). Rejected as impossible: the plugin registers its prompt sections on the agent's OWN scope layer, and dsh's scope-layered system-prompt registry resolves `agent → preset → global` with the nearest layer winning — a preset row declaring a same-named section sits on a farther layer and can never override the plugin's.
+3. **Override files in the plugin home** (chosen). Prose-friendly, per-preset by construction (the directory name IS the preset id), a `_default/` copy source plus global fallback, and zero Cordis-config plumbing. The cost: the convention is plugin-owned — dsh has no generic "default + override file" facility for plugin prompts.
+
+## Consequences
+
+- Overrides are global to the user per preset id, not per workspace; tool descriptions/snippets stay hardcoded; section names are fixed.
+- Files are read once per agent at session-start, matching dsh's prefix-stable KV-cache discipline; edits affect new sessions only.
+- The fallback directory is `_default`, an id no preset can take (`[a-z0-9][a-z0-9-]*` cannot start with `_`), so it can never collide with a real preset.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-better-edit",
-  "version": "0.2.0",
+  "version": "0.2.0-rc.0",
   "type": "module",
   "description": "Hash-anchored read/edit/batch_edit/undo_last_edit tools for DeepSeek Harness (dsh). Every line gets a unique 3-char hash (A-Za-z0-9) that stays stable across edits; stale or ambiguous anchors are rejected, never fuzzy-matched. Undo persists across restarts.",
   "main": "lib/index.js",

--- a/src/guidance.ts
+++ b/src/guidance.ts
@@ -7,7 +7,7 @@
  * and `order` with a plain markdown file keyed by agent preset: the override
  * files live in the plugin's shared home (`$DSH_HOME/plugins/dsh-better-edit`,
  * never the workspace store) and are resolved per section as
- * `<preset>/<section>.md` → `_default/<section>.md` → compiled default.
+ * `<preset>/<section>.md` → compiled default.
  *
  * An override file is pure prose unless it opens with a valid YAML front-matter
  * fence carrying only an `order` key (`---` / `order: N` / `---`); anything
@@ -33,8 +33,13 @@ import {
 } from "./prompts.js";
 import { errCode } from "./utils.js";
 
-/** The fallback/template directory name inside the plugin home. */
-export const DEFAULT_GUIDANCE_DIR = "_default";
+/** The presets shipped by the harness, each seeded with editable guidance. */
+export const DEFAULT_PRESETS: readonly string[] = [
+	"standard",
+	"code",
+	"minimal",
+	"cordis",
+];
 
 /**
  * Render one tool's guidance as its intro line, a blank line, then bullets.
@@ -136,7 +141,7 @@ export function parseSectionFile(content: string): ParsedSection {
 	}
 	// Front-matter body: strip leading blank lines after the closing fence so
 	// `---\n…\n---\n\nbody` and `---\n…\n---\nbody` parse identically (the
-	// materialized _default/ files carry a blank line after the fence).
+	// materialized preset files carry a blank line after the fence).
 	const body = lines.slice(close + 1);
 	let bodyStart = 0;
 	while (bodyStart < body.length && body[bodyStart]!.trim() === "")
@@ -160,7 +165,6 @@ function overrideCandidates(
 	if (options.presetId !== undefined) {
 		candidates.push(join(options.homeDir, options.presetId, file));
 	}
-	candidates.push(join(options.homeDir, DEFAULT_GUIDANCE_DIR, file));
 	return candidates;
 }
 
@@ -202,7 +206,7 @@ export interface SectionOverride {
 
 /**
  * Resolve all four sections for a preset. `presetId === undefined` skips the
- * `<preset>/` layer (still consulting `_default/`, the live global fallback).
+ * `<preset>/` layer and resolves straight to the compiled defaults.
  */
 export async function composeSections(
 	presetId: string | undefined,
@@ -220,36 +224,31 @@ export async function composeSections(
 }
 
 /**
- * The `_default/` template README: the copy-to-override convention users see
- * when they open the template directory.
+ * The root README: the per-preset customization convention users see in the
+ * plugin home.
  */
-export const DEFAULT_GUIDANCE_README = `# Default tool guidance
+export const GUIDANCE_HOME_README = `# dsh-better-edit guidance
 
-This directory holds the built-in guidance for the hashline tools (\`read\`,
-\`edit\`, \`batch_edit\`, \`undo_last_edit\`). It is recreated from the compiled
-defaults when missing, and existing files are never overwritten.
+Each agent preset has its own guidance directory here: \`<preset>/<section>.md\`.
+On first boot the plugin seeds the shipped presets (\`standard\`, \`code\`,
+\`minimal\`, \`cordis\`) with the compiled defaults; existing files are never
+overwritten, so your edits survive.
 
-Each file overrides the guidance for one tool section:
+Each file is one tool section:
 
-- \`read.md\` -> the \`tool:read\` section
-- \`edit.md\` -> the \`tool:edit\` section
-- \`batch_edit.md\` -> the \`tool:batch_edit\` section
-- \`undo_last_edit.md\` -> the \`tool:undo_last_edit\` section
+- \`read.md\` -> \`tool:read\`
+- \`edit.md\` -> \`tool:edit\`
+- \`batch_edit.md\` -> \`tool:batch_edit\`
+- \`undo_last_edit.md\` -> \`tool:undo_last_edit\`
 
-## Override per preset
+## Customize
 
-Copy this directory to the name of an agent preset to customize that preset's
-guidance. The plugin reads \`<home>/<preset>/<section>.md\` first, then falls
-back to this directory, then to the compiled defaults:
+Edit the \`<section>.md\` file for the preset and section you want to change —
+the file body IS the text the model reads for that section. Files are read once
+per agent at session-start, so edits apply to new sessions.
 
-    cp -r _default my-preset
-
-A preset directory may contain only the sections you want to override.
-
-## Section order
-
-A file may open with a YAML front-matter fence carrying an \`order\` number; the
-section is then placed at that position in the assembled system prompt:
+An optional YAML front-matter fence places the section at a custom position in
+the assembled system prompt:
 
     ---
     order: 150
@@ -260,41 +259,54 @@ section is then placed at that position in the assembled system prompt:
 A file without front-matter keeps the default order. A malformed fence (a
 missing closing \`---\`, a non-integer \`order\`, an unknown key) makes the whole
 file plain prose.
+
+## Fallback
+
+A preset with no directory here, or a missing section file, falls back to the
+compiled defaults in the plugin bundle. To customize a preset that has no
+seeded directory, copy a seeded one to its name.
 `;
 
 /**
- * Materialize the `_default/` template directory in the plugin home.
+ * Materialize per-preset guidance directories in the plugin home.
  *
- * Creates `_default/{read,edit,batch_edit,undo_last_edit}.md` rendered from
- * the compiled defaults (byte-identical to the resolver's fallback) plus a
- * `README.md` documenting the convention. Idempotent: existing files are never
- * rewritten (a user-edited template survives repeated calls) and a missing
- * directory is created on demand. Each file is written exclusively, so two
- * concurrent first runs race safely — whichever lands first wins, the other
- * observes EEXIST and leaves the file alone.
+ * For each of \`DEFAULT_PRESETS\` creates \`<preset>/{read,edit,batch_edit,
+ * undo_last_edit}.md\` rendered from the compiled defaults (with order
+ * front-matter), plus a root \`README.md\` documenting the convention.
+ * Idempotent: existing files are never rewritten (a user-edited file survives
+ * repeated calls) and missing directories are created on demand. Each file is
+ * written exclusively, so two concurrent first runs race safely.
  */
-export async function ensureDefaultGuidance(homeDir: string): Promise<void> {
-	const templateDir = join(homeDir, DEFAULT_GUIDANCE_DIR);
-	await mkdir(templateDir, { recursive: true });
-	const existing = new Set(await readdir(templateDir));
-	const targets: Array<[string, string]> = GUIDANCE_SECTIONS.map(
-		(section) => [
-			section.file,
-			`---\norder: ${section.defaultOrder}\n---\n\n${section.renderDefault()}`,
-		],
-	);
-	targets.push(["README.md", DEFAULT_GUIDANCE_README]);
+export async function ensurePresetGuidance(homeDir: string): Promise<void> {
+	await mkdir(homeDir, { recursive: true });
 	await Promise.all(
-		targets.map(async ([file, content]) => {
-			if (existing.has(file)) return;
-			await writeFile(join(templateDir, file), content, {
-				encoding: "utf-8",
-				flag: "wx",
-			}).catch((error: unknown) => {
-				// A concurrent writer landed first; never clobber it.
-				if (errCode(error) === "EEXIST") return;
-				throw error;
-			});
+		DEFAULT_PRESETS.map(async (preset) => {
+			const dir = join(homeDir, preset);
+			await mkdir(dir, { recursive: true });
+			const existing = new Set(await readdir(dir));
+			await Promise.all(
+				GUIDANCE_SECTIONS.map(async (section) => {
+					if (existing.has(section.file)) return;
+					const content = `---\norder: ${section.defaultOrder}\n---\n\n${section.renderDefault()}`;
+					await writeFile(join(dir, section.file), content, {
+						encoding: "utf-8",
+						flag: "wx",
+					}).catch((error: unknown) => {
+						// A concurrent writer landed first; never clobber it.
+						if (errCode(error) === "EEXIST") return;
+						throw error;
+					});
+				}),
+			);
 		}),
 	);
+	if (!(await readdir(homeDir)).includes("README.md")) {
+		await writeFile(join(homeDir, "README.md"), GUIDANCE_HOME_README, {
+			encoding: "utf-8",
+			flag: "wx",
+		}).catch((error: unknown) => {
+			if (errCode(error) === "EEXIST") return;
+			throw error;
+		});
+	}
 }

--- a/src/guidance.ts
+++ b/src/guidance.ts
@@ -21,7 +21,7 @@
  * @module dsh-better-edit/guidance
  */
 
-import { readFile } from "node:fs/promises";
+import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
 import {
@@ -209,6 +209,83 @@ export async function composeSections(
 				homeDir,
 			});
 			return { name: section.name, order, text };
+		}),
+	);
+}
+
+/**
+ * The `_default/` template README: the copy-to-override convention users see
+ * when they open the template directory.
+ */
+export const DEFAULT_GUIDANCE_README = `# Default tool guidance
+
+This directory holds the built-in guidance for the hashline tools (\`read\`,
+\`edit\`, \`batch_edit\`, \`undo_last_edit\`). It is recreated from the compiled
+defaults when missing, and existing files are never overwritten.
+
+Each file overrides the guidance for one tool section:
+
+- \`read.md\` -> the \`tool:read\` section
+- \`edit.md\` -> the \`tool:edit\` section
+- \`batch_edit.md\` -> the \`tool:batch_edit\` section
+- \`undo_last_edit.md\` -> the \`tool:undo_last_edit\` section
+
+## Override per preset
+
+Copy this directory to the name of an agent preset to customize that preset's
+guidance. The plugin reads \`<home>/<preset>/<section>.md\` first, then falls
+back to this directory, then to the compiled defaults:
+
+    cp -r _default my-preset
+
+A preset directory may contain only the sections you want to override.
+
+## Section order
+
+A file may open with a YAML front-matter fence carrying an \`order\` number; the
+section is then placed at that position in the assembled system prompt:
+
+    ---
+    order: 150
+    ---
+
+    <section text>
+
+A file without front-matter keeps the default order. A malformed fence (a
+missing closing \`---\`, a non-integer \`order\`, an unknown key) makes the whole
+file plain prose.
+`;
+
+/**
+ * Materialize the `_default/` template directory in the plugin home.
+ *
+ * Creates `_default/{read,edit,batch_edit,undo_last_edit}.md` rendered from
+ * the compiled defaults (byte-identical to the resolver's fallback) plus a
+ * `README.md` documenting the convention. Idempotent: existing files are never
+ * rewritten (a user-edited template survives repeated calls) and a missing
+ * directory is created on demand. Each file is written exclusively, so two
+ * concurrent first runs race safely — whichever lands first wins, the other
+ * observes EEXIST and leaves the file alone.
+ */
+export async function ensureDefaultGuidance(homeDir: string): Promise<void> {
+	const templateDir = join(homeDir, DEFAULT_GUIDANCE_DIR);
+	await mkdir(templateDir, { recursive: true });
+	const existing = new Set(await readdir(templateDir));
+	const targets: Array<[string, string]> = GUIDANCE_SECTIONS.map(
+		(section) => [section.file, section.renderDefault()],
+	);
+	targets.push(["README.md", DEFAULT_GUIDANCE_README]);
+	await Promise.all(
+		targets.map(async ([file, content]) => {
+			if (existing.has(file)) return;
+			await writeFile(join(templateDir, file), content, {
+				encoding: "utf-8",
+				flag: "wx",
+			}).catch((error: unknown) => {
+				// A concurrent writer landed first; never clobber it.
+				if (errCode(error) === "EEXIST") return;
+				throw error;
+			});
 		}),
 	);
 }

--- a/src/guidance.ts
+++ b/src/guidance.ts
@@ -25,11 +25,11 @@ import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 
 import {
-	BATCH_EDIT_GUIDELINES,
+	BATCH_EDIT_GUIDANCE,
 	EDIT_DESCRIPTION,
-	EDIT_GUIDELINES,
-	READ_GUIDELINES,
-	UNDO_GUIDELINES,
+	EDIT_GUIDANCE,
+	READ_GUIDANCE,
+	UNDO_GUIDANCE,
 } from "./prompts.js";
 import { errCode } from "./utils.js";
 
@@ -67,26 +67,26 @@ export const GUIDANCE_SECTIONS: readonly GuidanceSection[] = [
 		file: "read.md",
 		defaultOrder: 100,
 		renderDefault: () =>
-			[READ_SECTION_HEADER, "", bulletLines(READ_GUIDELINES)].join("\n"),
+			[READ_SECTION_HEADER, "", bulletLines(READ_GUIDANCE)].join("\n"),
 	},
 	{
 		name: "tool:edit",
 		file: "edit.md",
 		defaultOrder: 102,
 		renderDefault: () =>
-			[EDIT_DESCRIPTION, "", bulletLines(EDIT_GUIDELINES)].join("\n"),
+			[EDIT_DESCRIPTION, "", bulletLines(EDIT_GUIDANCE)].join("\n"),
 	},
 	{
 		name: "tool:batch_edit",
 		file: "batch_edit.md",
 		defaultOrder: 103,
-		renderDefault: () => bulletLines(BATCH_EDIT_GUIDELINES),
+		renderDefault: () => bulletLines(BATCH_EDIT_GUIDANCE),
 	},
 	{
 		name: "tool:undo_last_edit",
 		file: "undo_last_edit.md",
 		defaultOrder: 104,
-		renderDefault: () => bulletLines(UNDO_GUIDELINES),
+		renderDefault: () => bulletLines(UNDO_GUIDANCE),
 	},
 ];
 

--- a/src/guidance.ts
+++ b/src/guidance.ts
@@ -267,6 +267,41 @@ compiled defaults in the plugin bundle. To customize a preset that has no
 seeded directory, copy a seeded one to its name.
 `;
 
+export const GUIDANCE_HOME_README_ZH = `# dsh-better-edit 指引
+
+每个 agent preset 在这里都有自己的指引目录：\`<preset>/<section>.md\`。首次启动时
+插件会为随附的 preset（\`standard\`、\`code\`、\`minimal\`、\`cordis\`）写入编译内置的
+默认内容；已有文件绝不被覆盖，因此你的编辑会保留。
+
+每个文件对应一个工具片段：
+
+- \`read.md\` -> \`tool:read\`
+- \`edit.md\` -> \`tool:edit\`
+- \`batch_edit.md\` -> \`tool:batch_edit\`
+- \`undo_last_edit.md\` -> \`tool:undo_last_edit\`
+
+## 自定义
+
+编辑你想修改的 preset 与片段的 \`<section>.md\` 文件即可——文件正文就是该片段呈
+现给模型的文本。文件在 agent 的 session-start 时读取一次，因此修改只影响新会话。
+
+可以用可选的 YAML front-matter 栅栏把片段放到组装后系统提示中的自定义位置：
+
+    ---
+    order: 150
+    ---
+
+    <片段文本>
+
+没有 front-matter 的文件保持默认顺序。格式错误的栅栏（缺少收尾 \`---\`、非整数
+\`order\`、未知键）会让整个文件退化为纯文本。
+
+## 回退
+
+这里没有对应目录的 preset、或缺失某个片段文件时，会回退到插件包内的编译内置默认
+值。要自定义没有种子目录的 preset，把一个种子目录复制成它的名字即可。
+`;
+
 /**
  * Materialize per-preset guidance directories in the plugin home.
  *
@@ -300,13 +335,21 @@ export async function ensurePresetGuidance(homeDir: string): Promise<void> {
 			);
 		}),
 	);
-	if (!(await readdir(homeDir)).includes("README.md")) {
-		await writeFile(join(homeDir, "README.md"), GUIDANCE_HOME_README, {
-			encoding: "utf-8",
-			flag: "wx",
-		}).catch((error: unknown) => {
-			if (errCode(error) === "EEXIST") return;
-			throw error;
-		});
-	}
+	const homeFiles = new Set(await readdir(homeDir));
+	const readmes: Array<[string, string]> = [
+		["README.md", GUIDANCE_HOME_README],
+		["README.zh.md", GUIDANCE_HOME_README_ZH],
+	];
+	await Promise.all(
+		readmes.map(async ([file, content]) => {
+			if (homeFiles.has(file)) return;
+			await writeFile(join(homeDir, file), content, {
+				encoding: "utf-8",
+				flag: "wx",
+			}).catch((error: unknown) => {
+				if (errCode(error) === "EEXIST") return;
+				throw error;
+			});
+		}),
+	);
 }

--- a/src/guidance.ts
+++ b/src/guidance.ts
@@ -1,0 +1,214 @@
+/**
+ * Per-preset guidance overrides for the hashline tool sections.
+ *
+ * Each of the four `tool:*` prompt sections the plugin registers has a
+ * compiled default rendered from `prompts.ts` (byte-identical to the inline
+ * rendering `src/index.ts` uses today). A user can override any section's text
+ * and `order` with a plain markdown file keyed by agent preset: the override
+ * files live in the plugin's shared home (`$DSH_HOME/plugins/dsh-better-edit`,
+ * never the workspace store) and are resolved per section as
+ * `<preset>/<section>.md` → `_default/<section>.md` → compiled default.
+ *
+ * An override file is pure prose unless it opens with a valid YAML front-matter
+ * fence carrying only an `order` key (`---` / `order: N` / `---`); anything
+ * else — a missing closing fence, a non-integer `order`, an unknown key —
+ * degrades the WHOLE file to prose so the mistake stays visible in the
+ * rendered section.
+ *
+ * Resolution is pure: no cordis services, no harness wiring. The installer
+ * ticket reads the resolved sections once per agent at session-start;
+ * nothing here watches or caches files.
+ * @module dsh-better-edit/guidance
+ */
+
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import {
+	BATCH_EDIT_GUIDELINES,
+	EDIT_DESCRIPTION,
+	EDIT_GUIDELINES,
+	READ_GUIDELINES,
+	UNDO_GUIDELINES,
+} from "./prompts.js";
+import { errCode } from "./utils.js";
+
+/** The fallback/template directory name inside the plugin home. */
+export const DEFAULT_GUIDANCE_DIR = "_default";
+
+/**
+ * The `tool:read` section header. Mirrors the string `src/index.ts` renders
+ * inline today (it is not `READ_DESCRIPTION`, which only feeds the tool
+ * schema); the installer ticket removes the inline copy.
+ */
+const READ_SECTION_HEADER =
+	"Use the read tool — not shell commands like cat — to inspect text files.";
+
+function bulletLines(lines: readonly string[]): string {
+	return lines.map((line) => `- ${line}`).join("\n");
+}
+
+/** One overridable tool section. */
+export interface GuidanceSection {
+	/** Registry section name, e.g. `tool:edit`. */
+	name: string;
+	/** Override file name inside a preset directory, e.g. `edit.md`. */
+	file: string;
+	/** Order used when the override file carries no front-matter `order`. */
+	defaultOrder: number;
+	/** The compiled default text, byte-identical to today's inline rendering. */
+	renderDefault(): string;
+}
+
+/** The four sections, in default-order sequence. */
+export const GUIDANCE_SECTIONS: readonly GuidanceSection[] = [
+	{
+		name: "tool:read",
+		file: "read.md",
+		defaultOrder: 100,
+		renderDefault: () =>
+			[READ_SECTION_HEADER, "", bulletLines(READ_GUIDELINES)].join("\n"),
+	},
+	{
+		name: "tool:edit",
+		file: "edit.md",
+		defaultOrder: 102,
+		renderDefault: () =>
+			[EDIT_DESCRIPTION, "", bulletLines(EDIT_GUIDELINES)].join("\n"),
+	},
+	{
+		name: "tool:batch_edit",
+		file: "batch_edit.md",
+		defaultOrder: 103,
+		renderDefault: () => bulletLines(BATCH_EDIT_GUIDELINES),
+	},
+	{
+		name: "tool:undo_last_edit",
+		file: "undo_last_edit.md",
+		defaultOrder: 104,
+		renderDefault: () => bulletLines(UNDO_GUIDELINES),
+	},
+];
+
+const SECTION_BY_NAME = new Map(
+	GUIDANCE_SECTIONS.map((section) => [section.name, section]),
+);
+
+/** Render the compiled default text for one section. */
+export function renderSectionDefault(name: string): string {
+	const section = SECTION_BY_NAME.get(name);
+	if (!section) throw new Error(`unknown guidance section: ${name}`);
+	return section.renderDefault();
+}
+
+/** The parsed content of one override file. */
+export interface ParsedSection {
+	/** Front-matter `order`, when present and valid. */
+	order?: number;
+	/** The section text: the file body, or the whole file when front-matter is absent or malformed. */
+	text: string;
+}
+
+function stripCR(line: string): string {
+	return line.endsWith("\r") ? line.slice(0, -1) : line;
+}
+
+/**
+ * Parse an override file. Only a leading `---` fence whose lines are empty or
+ * `order: <integer>` is accepted; every other shape (no fence, no closing
+ * fence, unknown key, non-integer value) yields the whole file as prose.
+ */
+export function parseSectionFile(content: string): ParsedSection {
+	const lines = content.split("\n");
+	if (lines.length < 3 || stripCR(lines[0]) !== "---") {
+		return { text: content };
+	}
+	const close = lines.findIndex(
+		(line, index) => index > 0 && stripCR(line) === "---",
+	);
+	if (close < 0) return { text: content };
+	let order: number | undefined;
+	for (let index = 1; index < close; index++) {
+		const line = stripCR(lines[index]);
+		if (line.trim() === "") continue;
+		const match = /^order:\s*(-?\d+)\s*$/.exec(line);
+		if (!match) return { text: content };
+		order = Number.parseInt(match[1] as string, 10);
+	}
+	return { order, text: lines.slice(close + 1).join("\n") };
+}
+
+/** Options for resolving one section's guidance. */
+export interface ResolveGuidanceOptions {
+	/** Agent preset id, or undefined to skip the preset layer. */
+	presetId?: string;
+	/** Plugin shared home directory (`$DSH_HOME/plugins/dsh-better-edit`). */
+	homeDir: string;
+}
+
+function overrideCandidates(
+	file: string,
+	options: ResolveGuidanceOptions,
+): string[] {
+	const candidates: string[] = [];
+	if (options.presetId !== undefined) {
+		candidates.push(join(options.homeDir, options.presetId, file));
+	}
+	candidates.push(join(options.homeDir, DEFAULT_GUIDANCE_DIR, file));
+	return candidates;
+}
+
+/** The resolved text and order for one section. */
+export interface GuidanceResolution {
+	order: number;
+	text: string;
+}
+
+/**
+ * Resolve one section's guidance: the first override file that exists wins,
+ * falling back to the compiled default. A missing file (ENOENT) advances the
+ * chain; any other read error propagates.
+ */
+export async function resolveSection(
+	name: string,
+	options: ResolveGuidanceOptions,
+): Promise<GuidanceResolution> {
+	const section = SECTION_BY_NAME.get(name);
+	if (!section) throw new Error(`unknown guidance section: ${name}`);
+	for (const candidate of overrideCandidates(section.file, options)) {
+		const content = await readFile(candidate, "utf-8").catch((error: unknown) => {
+			if (errCode(error) === "ENOENT") return undefined;
+			throw error;
+		});
+		if (content === undefined) continue;
+		const parsed = parseSectionFile(content);
+		return { order: parsed.order ?? section.defaultOrder, text: parsed.text };
+	}
+	return { order: section.defaultOrder, text: section.renderDefault() };
+}
+
+/** The resolved configuration of one section, ready for the systemPrompt registry. */
+export interface SectionOverride {
+	name: string;
+	order: number;
+	text: string;
+}
+
+/**
+ * Resolve all four sections for a preset. `presetId === undefined` skips the
+ * `<preset>/` layer (still consulting `_default/`, the live global fallback).
+ */
+export async function composeSections(
+	presetId: string | undefined,
+	homeDir: string,
+): Promise<SectionOverride[]> {
+	return Promise.all(
+		GUIDANCE_SECTIONS.map(async (section) => {
+			const { order, text } = await resolveSection(section.name, {
+				presetId,
+				homeDir,
+			});
+			return { name: section.name, order, text };
+		}),
+	);
+}

--- a/src/guidance.ts
+++ b/src/guidance.ts
@@ -26,10 +26,10 @@ import { join } from "node:path";
 
 import {
 	BATCH_EDIT_GUIDANCE,
-	EDIT_DESCRIPTION,
 	EDIT_GUIDANCE,
 	READ_GUIDANCE,
 	UNDO_GUIDANCE,
+	type ToolGuidance,
 } from "./prompts.js";
 import { errCode } from "./utils.js";
 
@@ -37,12 +37,13 @@ import { errCode } from "./utils.js";
 export const DEFAULT_GUIDANCE_DIR = "_default";
 
 /**
- * The `tool:read` section header. Mirrors the string `src/index.ts` renders
- * inline today (it is not `READ_DESCRIPTION`, which only feeds the tool
- * schema); the installer ticket removes the inline copy.
+ * Render one tool's guidance as its intro line, a blank line, then bullets.
+ * Uniform across the four sections: no tool-schema description is duplicated
+ * (that already reaches the model through the tool catalog).
  */
-const READ_SECTION_HEADER =
-	"Use the read tool — not shell commands like cat — to inspect text files.";
+function guidanceText(g: ToolGuidance): string {
+	return [g.intro, "", bulletLines(g.lines)].join("\n");
+}
 
 function bulletLines(lines: readonly string[]): string {
 	return lines.map((line) => `- ${line}`).join("\n");
@@ -65,28 +66,26 @@ export const GUIDANCE_SECTIONS: readonly GuidanceSection[] = [
 	{
 		name: "tool:read",
 		file: "read.md",
-		defaultOrder: 100,
-		renderDefault: () =>
-			[READ_SECTION_HEADER, "", bulletLines(READ_GUIDANCE)].join("\n"),
+		defaultOrder: 130,
+		renderDefault: () => guidanceText(READ_GUIDANCE),
 	},
 	{
 		name: "tool:edit",
 		file: "edit.md",
-		defaultOrder: 102,
-		renderDefault: () =>
-			[EDIT_DESCRIPTION, "", bulletLines(EDIT_GUIDANCE)].join("\n"),
+		defaultOrder: 131,
+		renderDefault: () => guidanceText(EDIT_GUIDANCE),
 	},
 	{
 		name: "tool:batch_edit",
 		file: "batch_edit.md",
-		defaultOrder: 103,
-		renderDefault: () => bulletLines(BATCH_EDIT_GUIDANCE),
+		defaultOrder: 132,
+		renderDefault: () => guidanceText(BATCH_EDIT_GUIDANCE),
 	},
 	{
 		name: "tool:undo_last_edit",
 		file: "undo_last_edit.md",
-		defaultOrder: 104,
-		renderDefault: () => bulletLines(UNDO_GUIDANCE),
+		defaultOrder: 133,
+		renderDefault: () => guidanceText(UNDO_GUIDANCE),
 	},
 ];
 
@@ -135,7 +134,14 @@ export function parseSectionFile(content: string): ParsedSection {
 		if (!match) return { text: content };
 		order = Number.parseInt(match[1] as string, 10);
 	}
-	return { order, text: lines.slice(close + 1).join("\n") };
+	// Front-matter body: strip leading blank lines after the closing fence so
+	// `---\n…\n---\n\nbody` and `---\n…\n---\nbody` parse identically (the
+	// materialized _default/ files carry a blank line after the fence).
+	const body = lines.slice(close + 1);
+	let bodyStart = 0;
+	while (bodyStart < body.length && body[bodyStart]!.trim() === "")
+		bodyStart++;
+	return { order, text: body.slice(bodyStart).join("\n") };
 }
 
 /** Options for resolving one section's guidance. */
@@ -272,7 +278,10 @@ export async function ensureDefaultGuidance(homeDir: string): Promise<void> {
 	await mkdir(templateDir, { recursive: true });
 	const existing = new Set(await readdir(templateDir));
 	const targets: Array<[string, string]> = GUIDANCE_SECTIONS.map(
-		(section) => [section.file, section.renderDefault()],
+		(section) => [
+			section.file,
+			`---\norder: ${section.defaultOrder}\n---\n\n${section.renderDefault()}`,
+		],
 	);
 	targets.push(["README.md", DEFAULT_GUIDANCE_README]);
 	await Promise.all(

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,7 @@ import { registerWriteHook } from "./write-hook.js";
 import { initHasher } from "./hashline/hasher.js";
 import {
 	composeSections,
-	ensureDefaultGuidance,
+	ensurePresetGuidance,
 	GUIDANCE_SECTIONS,
 	type SectionOverride,
 } from "./guidance.js";
@@ -137,12 +137,12 @@ export function apply(rootCtx: Context): void {
 		);
 	});
 
-	// Materialize the `_default/` guidance template once, so users have a
-	// copy source for per-preset overrides (idempotent: never rewrites an
-	// existing directory). A failure must never fail the boot.
-	ensureDefaultGuidance(configDir()).catch((error) => {
+	// Seed each shipped preset's guidance directory once, so users have
+	// editable per-preset overrides (idempotent: never rewrites existing
+	// files). A failure must never fail the boot.
+	ensurePresetGuidance(configDir()).catch((error) => {
 		rootCtx.logger.warn(
-			`dsh-better-edit: default guidance materialization failed: ${error instanceof Error ? error.message : String(error)}`,
+			`dsh-better-edit: guidance materialization failed: ${error instanceof Error ? error.message : String(error)}`,
 		);
 	});
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,10 @@
  * automatically when the agent is disposed. The built-in `write` stays in
  * place; a scoped `tools/post-execute` listener appends the fresh hashline
  * preview to write results.
+ *
+ * The four `tool:*` guidance sections resolve per agent preset from override
+ * files in the shared home (see `src/guidance.ts`); deployments without the
+ * `agentPresets` service keep the compiled defaults unchanged.
  * @module dsh-better-edit
  */
 
@@ -25,12 +29,11 @@ import { registerWriteHook } from "./write-hook.js";
 
 import { initHasher } from "./hashline/hasher.js";
 import {
-	EDIT_DESCRIPTION,
-	EDIT_GUIDANCE,
-	READ_GUIDANCE,
-	BATCH_EDIT_GUIDANCE,
-	UNDO_GUIDANCE,
-} from "./prompts.js";
+	composeSections,
+	GUIDANCE_SECTIONS,
+	type SectionOverride,
+} from "./guidance.js";
+import { configDir } from "./paths.js";
 
 /** Cordis plugin name used by loader diagnostics. */
 export const name = "dsh-better-edit";
@@ -49,8 +52,52 @@ interface AgentTools {
 	dispose(): void;
 }
 
-function installAgentTools(rootCtx: Context, agent: Agent): () => void {
-	return agent.ctx.effect(() => {
+/**
+ * Minimal shape of the optional `agentPresets` service (dsh-agent-presets).
+ * Read via `ctx.get` — never injected — so a deployment composed without the
+ * service keeps the compiled defaults and never touches the filesystem here.
+ */
+interface AgentPresetsService {
+	composedPreset(agentCtx: Context): string | undefined;
+}
+
+/** The four sections as compiled, byte-identical to the pre-guidance install. */
+function compiledDefaultSections(): SectionOverride[] {
+	return GUIDANCE_SECTIONS.map((section) => ({
+		name: section.name,
+		order: section.defaultOrder,
+		text: section.renderDefault(),
+	}));
+}
+
+/**
+ * Resolve the four guidance sections for one agent. Without the `agentPresets`
+ * service the fast path returns the compiled defaults untouched. With it, the
+ * agent's preset id drives `composeSections` against the shared home; any
+ * resolution failure degrades to compiled defaults so a bad override file can
+ * never fail the install.
+ */
+async function resolveAgentSections(
+	rootCtx: Context,
+	agent: Agent,
+): Promise<SectionOverride[]> {
+	const agentPresets = rootCtx.get(
+		"agentPresets",
+	) as AgentPresetsService | undefined;
+	if (!agentPresets) return compiledDefaultSections();
+	try {
+		const presetId = agentPresets.composedPreset(agent.ctx);
+		return await composeSections(presetId, configDir());
+	} catch (error) {
+		rootCtx.logger.warn(
+			`dsh-better-edit: guidance resolution failed for agent ${agent.id}, using compiled defaults: ${error instanceof Error ? error.message : String(error)}`,
+		);
+		return compiledDefaultSections();
+	}
+}
+
+function installAgentTools(rootCtx: Context, agent: Agent): void {
+	agent.ctx.effect(async () => {
 		// `fs` is host-plane: use the plugin's own context (covered by
 		// inject) rather than the agent's scoped one, whose fiber chain does
 		// not declare it. Session cwd still reaches the bridge per call via
@@ -64,44 +111,13 @@ function installAgentTools(rootCtx: Context, agent: Agent): () => void {
 		disposers.push(registerUndoTool(rootCtx, agent.ctx, io, sandbox));
 		disposers.push(registerWriteHook(rootCtx, agent.ctx, io));
 
-		// Shadow the preset's built-in tool guidance with the hashline contract.
-		// Same section names on the agent's own layer win over the preset's.
-		disposers.push(
-			agent.ctx.systemPrompt.section({
-				name: "tool:edit",
-				order: 102,
-				text: [
-					EDIT_DESCRIPTION,
-					"",
-					EDIT_GUIDANCE.map((line) => `- ${line}`).join("\n"),
-				].join("\n"),
-			}),
-		);
-		disposers.push(
-			agent.ctx.systemPrompt.section({
-				name: "tool:read",
-				order: 100,
-				text: [
-					"Use the read tool — not shell commands like cat — to inspect text files.",
-					"",
-					READ_GUIDANCE.map((line) => `- ${line}`).join("\n"),
-				].join("\n"),
-			}),
-		);
-		disposers.push(
-			agent.ctx.systemPrompt.section({
-				name: "tool:batch_edit",
-				order: 103,
-				text: BATCH_EDIT_GUIDANCE.map((line) => `- ${line}`).join("\n"),
-			}),
-		);
-		disposers.push(
-			agent.ctx.systemPrompt.section({
-				name: "tool:undo_last_edit",
-				order: 104,
-				text: UNDO_GUIDANCE.map((line) => `- ${line}`).join("\n"),
-			}),
-		);
+		// Shadow the preset's built-in tool guidance with the hashline
+		// contract. Same section names on the agent's own layer win over the
+		// preset's; text and order come from the per-preset resolution.
+		const sections = await resolveAgentSections(rootCtx, agent);
+		for (const section of sections) {
+			disposers.push(agent.ctx.systemPrompt.section(section));
+		}
 
 		return () => {
 			for (const dispose of disposers) dispose();

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,10 +26,10 @@ import { registerWriteHook } from "./write-hook.js";
 import { initHasher } from "./hashline/hasher.js";
 import {
 	EDIT_DESCRIPTION,
-	EDIT_GUIDELINES,
-	READ_GUIDELINES,
-	BATCH_EDIT_GUIDELINES,
-	UNDO_GUIDELINES,
+	EDIT_GUIDANCE,
+	READ_GUIDANCE,
+	BATCH_EDIT_GUIDANCE,
+	UNDO_GUIDANCE,
 } from "./prompts.js";
 
 /** Cordis plugin name used by loader diagnostics. */
@@ -73,7 +73,7 @@ function installAgentTools(rootCtx: Context, agent: Agent): () => void {
 				text: [
 					EDIT_DESCRIPTION,
 					"",
-					EDIT_GUIDELINES.map((line) => `- ${line}`).join("\n"),
+					EDIT_GUIDANCE.map((line) => `- ${line}`).join("\n"),
 				].join("\n"),
 			}),
 		);
@@ -84,7 +84,7 @@ function installAgentTools(rootCtx: Context, agent: Agent): () => void {
 				text: [
 					"Use the read tool — not shell commands like cat — to inspect text files.",
 					"",
-					READ_GUIDELINES.map((line) => `- ${line}`).join("\n"),
+					READ_GUIDANCE.map((line) => `- ${line}`).join("\n"),
 				].join("\n"),
 			}),
 		);
@@ -92,14 +92,14 @@ function installAgentTools(rootCtx: Context, agent: Agent): () => void {
 			agent.ctx.systemPrompt.section({
 				name: "tool:batch_edit",
 				order: 103,
-				text: BATCH_EDIT_GUIDELINES.map((line) => `- ${line}`).join("\n"),
+				text: BATCH_EDIT_GUIDANCE.map((line) => `- ${line}`).join("\n"),
 			}),
 		);
 		disposers.push(
 			agent.ctx.systemPrompt.section({
 				name: "tool:undo_last_edit",
 				order: 104,
-				text: UNDO_GUIDELINES.map((line) => `- ${line}`).join("\n"),
+				text: UNDO_GUIDANCE.map((line) => `- ${line}`).join("\n"),
 			}),
 		);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ import { registerWriteHook } from "./write-hook.js";
 import { initHasher } from "./hashline/hasher.js";
 import {
 	composeSections,
+	ensureDefaultGuidance,
 	GUIDANCE_SECTIONS,
 	type SectionOverride,
 } from "./guidance.js";
@@ -133,6 +134,15 @@ export function apply(rootCtx: Context): void {
 	initHasher().catch((error) => {
 		rootCtx.logger.warn(
 			`dsh-better-edit: hasher warm-up failed: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	});
+
+	// Materialize the `_default/` guidance template once, so users have a
+	// copy source for per-preset overrides (idempotent: never rewrites an
+	// existing directory). A failure must never fail the boot.
+	ensureDefaultGuidance(configDir()).catch((error) => {
+		rootCtx.logger.warn(
+			`dsh-better-edit: default guidance materialization failed: ${error instanceof Error ? error.message : String(error)}`,
 		);
 	});
 

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -15,17 +15,13 @@ export const EDIT_DESCRIPTION =
 export const EDIT_SNIPPET =
 	'Edit lines in a text file via bare 3-char HASH anchors from read — hash only, never line content; anchor exactly the lines that change; one edit per tool call'
 
-export const EDIT_GUIDELINES = [
-	'`edit`: remove_from and remove_to take ONLY the bare 3-char hash — read row `ve7│function hello() {` means `"remove_from": "ve7"`. Never paste the line content, a code line, a paragraph, or the whole `HASH│content` row into these fields.',
-	'`edit`: remove_from and remove_to mark the exact lines that are REMOVED, and replacement_text is their complete replacement applied in order; nothing outside the range changes. Every line inside the range that is not reproduced byte-exact in replacement_text is deleted from the file.',
-	'`edit`: keep the range as tight as the change — anchor only the first and last line that actually change, never a whole function, class, or import block when only part of it changes.',
-	'`edit`: to edit a single line, set both remove_from and remove_to to the same hash: remove_from: "<HASH>", remove_to: "<HASH>".',
-	'`edit`: when copying a line from read output, remove its HASH│ prefix and keep the leading whitespace exactly as shown.',
-	'`edit`: every `\\n` in replacement_text separates lines, so a trailing `\\n` adds a final empty line. Mirror the removed lines exactly: a range that ends on a blank line must end replacement_text with `\\n` (e.g. `"code\\n"`), and a replacement whose last line is not blank must not end with `\\n`. To add a blank line after a line, end replacement_text with an explicit empty line after it (e.g. `"X\\n"` adds a blank after X). A replacement that is only blank lines is written as one `\\n` per blank line.',
-	'`edit`: when the tool shows the post-edit diff, its rows are the fresh anchors for the new file — `+HASH│` and ` HASH│` rows carry current hashes and unchanged lines keep their previous hashes, so you can anchor follow-up edits on the diff.',
-	'`edit`: the tool verifies every line of your range against what it served you. If the file changed since it was served, or a line was never served, the edit is hard-rejected — `[E_RANGE_STALE]` or `[E_RANGE_UNSERVED]` names the first offending line and echoes the current range as fresh `HASH│content` rows. Copy remove_from/remove_to from those echoed rows and retry — the rows count as serves.',
-	'`edit`: only rows the tool delivered count as serves — read output, post-edit diffs, and rejection echoes. Content you saw through bash or another channel is not served state; a range over it is rejected as never-served or unverifiable, and there is no way to waive that check.',
-	'`edit`: do not issue multiple edit calls on the same file in one message. Use `batch_edit` for multiple edits — it validates every edit before writing anything, applies the whole batch all-or-nothing, and returns one combined diff per file.',
+export const EDIT_GUIDANCE = [
+	'`edit`: remove_from and remove_to take the bare 3-char hash only — copy it from the leftmost column of a read row (row `ve7│function hello() {` means `"remove_from": "ve7"`). Never pass line content, a code line, a paragraph, or a whole `HASH│content` row.',
+	'`edit`: the range marks the exact lines REMOVED; replacement_text is their complete replacement, applied in order. Nothing outside the range changes; every line inside it that replacement_text does not reproduce byte-exact is deleted. Anchor only the first and last line that change — never a whole function, class, or import block when part of it changes. A single line takes the same hash in both fields.',
+	'`edit`: mirror whitespace exactly. Keep the leading whitespace of every copied line; every `\\n` in replacement_text is a line break, so a range ending on a blank line must end replacement_text with `\\n` and a non-blank last line must not. A blank line is written as `\\n`; an explicit trailing empty line adds one.',
+	'`edit`: the post-edit diff rows carry the fresh anchors — `+HASH│` and ` HASH│` rows have current hashes and unchanged lines keep theirs, so follow-up edits anchor on the diff without re-reading.',
+	'`edit`: every line of the range is verified against what the tool served. A stale or never-served line rejects the edit hard — `[E_RANGE_STALE]` or `[E_RANGE_UNSERVED]` names the first offending line and echoes the current range as fresh `HASH│content` rows; copy the anchors from those rows and retry, since the rows count as serves. Only tool-delivered rows count as serves — content seen through bash or another channel is never served, and nothing waives that check.',
+	'`edit`: for multiple edits to one file in a single message, use batch_edit — it validates every edit before writing, applies the batch all-or-nothing, and returns one combined diff per file.',
 ]
 
 export const READ_DESCRIPTION =
@@ -36,9 +32,9 @@ export const READ_DESCRIPTION =
 export const READ_SNIPPET =
 	'Read a file; each line returned as HASH│content'
 
-export const READ_GUIDELINES = [
-	'`read`: call only when you need information the tool never served you — a page you never saw, content past the post-edit diff. `edit` verifies every line of your range against what the tool served; a rejection echoes the current range as fresh `HASH│content` rows to retry on.',
-	'`read`: the post-edit diff rows from edit/undo and the drift-notice rows also carry fresh anchors for the lines they show.',
+export const READ_GUIDANCE = [
+	'`read`: call it only for content the tools never served — a page you never saw, or lines past the post-edit diff.',
+	'`read`: post-edit diff rows from edit/undo and drift-notice rows carry fresh anchors for the lines they show.',
 ]
 
 export const BATCH_EDIT_DESCRIPTION =
@@ -51,12 +47,11 @@ export const BATCH_EDIT_DESCRIPTION =
 	'HASH│content rows so you can retry without a read. Use batch_edit whenever you have multiple ' +
 	'edits; do not issue several edit calls in one message.'
 
-export const BATCH_EDIT_GUIDELINES = [
-	'batch_edit: each item takes the same fields as edit — { path?, remove_from, remove_to, replacement_text }. remove_from and remove_to take ONLY the bare 3-char hash from read/diff output; never the line content.',
-	'batch_edit: items are applied in order. Edits to the same file must not overlap — an item whose range was changed by an earlier item in the batch is rejected.',
-	'batch_edit: the whole batch is all-or-nothing. If any item fails validation, nothing is written anywhere; the failing item\u2019s current range is echoed as fresh HASH│content rows that count as serves.',
-	'batch_edit: every item is verified against what the tool served you — stale anchors, changed interiors, or never-served lines reject the batch.',
-	'batch_edit: a noop item (the range already contains the replacement text) is reported without failing the batch; an all-noop batch reports no changes.',
+export const BATCH_EDIT_GUIDANCE = [
+	'batch_edit: each item takes edit\u2019s fields — { path?, remove_from, remove_to, replacement_text } — with bare 3-char hash anchors from read/diff output, never line content.',
+	'batch_edit: items apply in order. Same-file ranges must not overlap — an item whose range an earlier item changed is rejected.',
+	'batch_edit: the batch is all-or-nothing. Any failing item — stale or ambiguous anchor, changed range interior, never-served line — writes nothing anywhere, and its current range is echoed as fresh `HASH│content` rows that count as serves.',
+	'batch_edit: a noop item (the range already contains the replacement) is reported without failing the batch; an all-noop batch reports no changes.',
 	'batch_edit: the result is one combined diff per file with fresh anchors — anchor follow-up edits on those rows without re-reading.',
 ]
 
@@ -64,7 +59,7 @@ export const UNDO_DESCRIPTION =
 	'Undo the last edit on a file, reverting it to its previous state. Use when an edit produced ' +
 	'incorrect results (e.g., wrong content, duplicated lines, broken syntax).'
 
-export const UNDO_GUIDELINES = [
-	'`undo_last_edit`: reverts only the most recent edit on the file — any write to the file clears the undo history, so call it immediately after a bad edit. An edit is bad when its post-edit diff shows `-HASH│` rows for lines you meant to keep (a closing brace, import, or declaration).',
-	'`undo_last_edit`: when the tool shows the post-edit diff, its `+HASH│` and ` HASH│` rows are the fresh anchors for the restored file, so follow-up edits can anchor on the diff.',
+export const UNDO_GUIDANCE = [
+	'`undo_last_edit`: reverts only the most recent edit on the file — any write clears the undo history, so call it immediately after a bad edit. An edit is bad when its post-edit diff shows `-HASH│` rows for lines you meant to keep (a closing brace, import, or declaration).',
+	'`undo_last_edit`: the restored diff\u2019s `+HASH│` and ` HASH│` rows are the fresh anchors for follow-up edits.',
 ]

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -1,10 +1,23 @@
 /**
  * Model-facing prompt text for the hashline tools, embedded so the bundle
- * ships no external prompt files. Each tool's description is short; the
- * `tool:*` system-prompt sections carry the full usage guidance the model
- * reads when the tools are presented.
+ * ships no external prompt files. Each tool's schema `description` is short;
+ * the `tool:*` system-prompt sections carry the brief guidance the model
+ * reads when the tools are presented. Guidance is uniform: a one-line opener
+ * followed by tight bullets.
  * @module dsh-better-edit/prompts
  */
+
+/**
+ * One tool's guidance: a brief opener plus concise bullets. The `intro` is
+ * shown above the bullets; it does not duplicate the tool-schema `description`
+ * (that already reaches the model through the tool catalog).
+ */
+export interface ToolGuidance {
+	/** One-line lead shown above the bullets. */
+	intro: string;
+	/** Concise bullets; each is self-contained within its section. */
+	lines: readonly string[];
+}
 
 export const EDIT_DESCRIPTION =
 	'Edit a range of lines in a text file, targeted by the 3-char HASH anchors from read output. ' +
@@ -12,30 +25,32 @@ export const EDIT_DESCRIPTION =
 	'leftmost column of a read row (row `ve7│function hello() {` means `"remove_from": "ve7"`). ' +
 	'Never pass the line content, a code line, or a paragraph into these fields.'
 
-export const EDIT_SNIPPET =
-	'Edit lines in a text file via bare 3-char HASH anchors from read — hash only, never line content; anchor exactly the lines that change; one edit per tool call'
-
-export const EDIT_GUIDANCE = [
-	'`edit`: remove_from and remove_to take the bare 3-char hash only — copy it from the leftmost column of a read row (row `ve7│function hello() {` means `"remove_from": "ve7"`). Never pass line content, a code line, a paragraph, or a whole `HASH│content` row.',
-	'`edit`: the range marks the exact lines REMOVED; replacement_text is their complete replacement, applied in order. Nothing outside the range changes; every line inside it that replacement_text does not reproduce byte-exact is deleted. Anchor only the first and last line that change — never a whole function, class, or import block when part of it changes. A single line takes the same hash in both fields.',
-	'`edit`: mirror whitespace exactly. Keep the leading whitespace of every copied line; every `\\n` in replacement_text is a line break, so a range ending on a blank line must end replacement_text with `\\n` and a non-blank last line must not. A blank line is written as `\\n`; an explicit trailing empty line adds one.',
-	'`edit`: the post-edit diff rows carry the fresh anchors — `+HASH│` and ` HASH│` rows have current hashes and unchanged lines keep theirs, so follow-up edits anchor on the diff without re-reading.',
-	'`edit`: every line of the range is verified against what the tool served. A stale or never-served line rejects the edit hard — `[E_RANGE_STALE]` or `[E_RANGE_UNSERVED]` names the first offending line and echoes the current range as fresh `HASH│content` rows; copy the anchors from those rows and retry, since the rows count as serves. Only tool-delivered rows count as serves — content seen through bash or another channel is never served, and nothing waives that check.',
-	'`edit`: for multiple edits to one file in a single message, use batch_edit — it validates every edit before writing, applies the batch all-or-nothing, and returns one combined diff per file.',
-]
+export const EDIT_GUIDANCE: ToolGuidance = {
+	intro:
+		'Edit a range of lines via a bare 3-char HASH anchor from read output — never by line content.',
+	lines: [
+		'`edit`: anchor the exact first and last lines that change by their stripped hash (`ve7`, not `ve7│function…`). A single line uses the same hash in both fields; never anchor a whole function or import block when part of it changes.',
+		'`edit`: replacement_text is byte-exact for the whole range — every line inside it you do not reproduce byte-exact is deleted, and leading whitespace is preserved exactly.',
+		'`edit`: `\\n` is a line break, so a range ending on a blank line must end replacement_text with `\\n` and a non-blank last line must not; a blank-line run is one `\\n` per blank line.',
+		'`edit`: the post-edit diff rows carry fresh anchors for follow-ups. A stale or never-served range is hard-rejected (`[E_RANGE_STALE]` / `[E_RANGE_UNSERVED]`); copy the echoed rows and retry — only tool-served rows count.',
+		'`edit`: for multiple edits to one file, use batch_edit — it validates every item before writing and applies them all-or-nothing.',
+	],
+};
 
 export const READ_DESCRIPTION =
 	'Read a text file; each line returned as HASH│content with a 3-char alphanumeric hash. ' +
 	'No line numbers — use the HASH as the anchor in edit calls. Binary/directory → rejected; ' +
 	'empty → HASH│ (edit to insert); pageable with offset/limit; BOM stripped; non-UTF-8 shown as U+FFFD.'
 
-export const READ_SNIPPET =
-	'Read a file; each line returned as HASH│content'
-
-export const READ_GUIDANCE = [
-	'`read`: call it only for content the tools never served — a page you never saw, or lines past the post-edit diff.',
-	'`read`: post-edit diff rows from edit/undo and drift-notice rows carry fresh anchors for the lines they show.',
-]
+export const READ_GUIDANCE: ToolGuidance = {
+	intro:
+		'Use read, not shell commands, to inspect text files and obtain the HASH anchors the editing tools require.',
+	lines: [
+		'`read`: call it only for content the tools have not served — a page you never saw, or lines past the post-edit diff.',
+		'`read`: each row is `HASH│content`; the HASH is the anchor (no line numbers). Rejection echoes return fresh rows that count as serves.',
+		'`read`: binary/directory rejects; page large files with offset/limit.',
+	],
+};
 
 export const BATCH_EDIT_DESCRIPTION =
 	'Apply several edits in one atomic call. Each item is exactly like the edit tool: ' +
@@ -47,19 +62,23 @@ export const BATCH_EDIT_DESCRIPTION =
 	'HASH│content rows so you can retry without a read. Use batch_edit whenever you have multiple ' +
 	'edits; do not issue several edit calls in one message.'
 
-export const BATCH_EDIT_GUIDANCE = [
-	'batch_edit: each item takes edit\u2019s fields — { path?, remove_from, remove_to, replacement_text } — with bare 3-char hash anchors from read/diff output, never line content.',
-	'batch_edit: items apply in order. Same-file ranges must not overlap — an item whose range an earlier item changed is rejected.',
-	'batch_edit: the batch is all-or-nothing. Any failing item — stale or ambiguous anchor, changed range interior, never-served line — writes nothing anywhere, and its current range is echoed as fresh `HASH│content` rows that count as serves.',
-	'batch_edit: a noop item (the range already contains the replacement) is reported without failing the batch; an all-noop batch reports no changes.',
-	'batch_edit: the result is one combined diff per file with fresh anchors — anchor follow-up edits on those rows without re-reading.',
-]
+export const BATCH_EDIT_GUIDANCE: ToolGuidance = {
+	intro: 'Apply several edits in one atomic call.',
+	lines: [
+		'`batch_edit`: each item is edit\u2019s shape — { path?, remove_from, remove_to, replacement_text } — with bare hash anchors; items apply in order, and same-file ranges must not overlap.',
+		'`batch_edit`: all-or-nothing — any failing item writes nothing anywhere and echoes its current range as fresh rows that count as serves.',
+		'`batch_edit`: a no-op item is reported without failing; the result is one combined diff per file with fresh anchors.',
+	],
+};
 
 export const UNDO_DESCRIPTION =
 	'Undo the last edit on a file, reverting it to its previous state. Use when an edit produced ' +
 	'incorrect results (e.g., wrong content, duplicated lines, broken syntax).'
 
-export const UNDO_GUIDANCE = [
-	'`undo_last_edit`: reverts only the most recent edit on the file — any write clears the undo history, so call it immediately after a bad edit. An edit is bad when its post-edit diff shows `-HASH│` rows for lines you meant to keep (a closing brace, import, or declaration).',
-	'`undo_last_edit`: the restored diff\u2019s `+HASH│` and ` HASH│` rows are the fresh anchors for follow-up edits.',
-]
+export const UNDO_GUIDANCE: ToolGuidance = {
+	intro: 'Revert the last edit on a file.',
+	lines: [
+		'`undo_last_edit`: reverts only the most recent edit — any write clears history, so call it immediately after a bad edit.',
+		'`undo_last_edit`: the restored diff\u2019s `+HASH│` and ` HASH│` rows are fresh anchors for follow-up edits.',
+	],
+};

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -20,65 +20,65 @@ export interface ToolGuidance {
 }
 
 export const EDIT_DESCRIPTION =
-	'Edit a range of lines in a text file, targeted by the 3-char HASH anchors from read output. ' +
-	'remove_from and remove_to must each be a BARE 3-character hash: copy only the hash from the ' +
+	"Edit a range of lines in a text file, targeted by the 3-char HASH anchors from read output. " +
+	"remove_from and remove_to must each be a BARE 3-character hash: copy only the hash from the " +
 	'leftmost column of a read row (row `ve7│function hello() {` means `"remove_from": "ve7"`). ' +
-	'Never pass the line content, a code line, or a paragraph into these fields.'
+	"Never pass the line content, a code line, or a paragraph into these fields.";
 
 export const EDIT_GUIDANCE: ToolGuidance = {
 	intro:
-		'Edit a range of lines via a bare 3-char HASH anchor from read output — never by line content.',
+		"Edit a range of lines via a bare 3-char HASH anchor from read output — never by line content.",
 	lines: [
-		'`edit`: anchor the exact first and last lines that change by their stripped hash (`ve7`, not `ve7│function…`). A single line uses the same hash in both fields; never anchor a whole function or import block when part of it changes.',
-		'`edit`: replacement_text is byte-exact for the whole range — every line inside it you do not reproduce byte-exact is deleted, and leading whitespace is preserved exactly.',
-		'`edit`: `\\n` is a line break, so a range ending on a blank line must end replacement_text with `\\n` and a non-blank last line must not; a blank-line run is one `\\n` per blank line.',
-		'`edit`: the post-edit diff rows carry fresh anchors for follow-ups. A stale or never-served range is hard-rejected (`[E_RANGE_STALE]` / `[E_RANGE_UNSERVED]`); copy the echoed rows and retry — only tool-served rows count.',
-		'`edit`: for multiple edits to one file, use batch_edit — it validates every item before writing and applies them all-or-nothing.',
+		"`edit`: anchor the exact first and last lines that change by their stripped hash (`ve7`, not `ve7│function…`). A single line uses the same hash in both fields; never anchor a whole function or import block when part of it changes.",
+		"`edit`: replacement_text is byte-exact for the whole range — every line inside it you do not reproduce byte-exact is deleted, and leading whitespace is preserved exactly.",
+		"`edit`: `\\n` is a line break, so a range ending on a blank line must end replacement_text with `\\n` and a non-blank last line must not; a blank-line run is one `\\n` per blank line.",
+		"`edit`: the post-edit diff rows carry fresh anchors for follow-ups. A stale or never-served range is hard-rejected (`[E_RANGE_STALE]` / `[E_RANGE_UNSERVED]`); copy the echoed rows and retry — only tool-served rows count.",
+		"`edit`: for multiple edits to one file, use batch_edit — it validates every item before writing and applies them all-or-nothing.",
 	],
 };
 
 export const READ_DESCRIPTION =
-	'Read a text file; each line returned as HASH│content with a 3-char alphanumeric hash. ' +
-	'No line numbers — use the HASH as the anchor in edit calls. Binary/directory → rejected; ' +
-	'empty → HASH│ (edit to insert); pageable with offset/limit; BOM stripped; non-UTF-8 shown as U+FFFD.'
+	"Read a text file; each line returned as HASH│content with a 3-char alphanumeric hash. " +
+	"No line numbers — use the HASH as the anchor in edit calls. Binary/directory → rejected; " +
+	"empty → HASH│ (edit to insert); pageable with offset/limit; BOM stripped; non-UTF-8 shown as U+FFFD.";
 
 export const READ_GUIDANCE: ToolGuidance = {
 	intro:
-		'Use read, not shell commands, to inspect text files and obtain the HASH anchors the editing tools require.',
+		"Use read, not shell commands, to inspect text files and obtain the HASH anchors the editing tools require.",
 	lines: [
-		'`read`: call it only for content the tools have not served — a page you never saw, or lines past the post-edit diff.',
-		'`read`: each row is `HASH│content`; the HASH is the anchor (no line numbers). Rejection echoes return fresh rows that count as serves.',
-		'`read`: binary/directory rejects; page large files with offset/limit.',
+		"`read`: call it only for content the tools have not served — a page you never saw, or lines past the post-edit diff.",
+		"`read`: each row is `HASH│content`; the HASH is the anchor (no line numbers). Rejection echoes return fresh rows that count as serves.",
+		"`read`: binary/directory rejects; page large files with offset/limit.",
 	],
 };
 
 export const BATCH_EDIT_DESCRIPTION =
-	'Apply several edits in one atomic call. Each item is exactly like the edit tool: ' +
-	'{ path?, remove_from, remove_to, replacement_text }, where remove_from and remove_to are ' +
-	'bare 3-char hashes from read or diff output. Items targeting the same file are applied in order. ' +
-	'Every item is verified against what the tool served you before ANYTHING is written: if any item ' +
-	'fails — stale or ambiguous anchor, changed range interior, never-served line — the whole batch ' +
-	'is rejected and no file changes. The failing item\u2019s current range is served back as fresh ' +
-	'HASH│content rows so you can retry without a read. Use batch_edit whenever you have multiple ' +
-	'edits; do not issue several edit calls in one message.'
+	"Apply several edits in one atomic call. Each item is exactly like the edit tool: " +
+	"{ path?, remove_from, remove_to, replacement_text }, where remove_from and remove_to are " +
+	"bare 3-char hashes from read or diff output. Items targeting the same file are applied in order. " +
+	"Every item is verified against what the tool served you before ANYTHING is written: if any item " +
+	"fails — stale or ambiguous anchor, changed range interior, never-served line — the whole batch " +
+	"is rejected and no file changes. The failing item\u2019s current range is served back as fresh " +
+	"HASH│content rows so you can retry without a read. Use batch_edit whenever you have multiple " +
+	"edits; do not issue several edit calls in one message.";
 
 export const BATCH_EDIT_GUIDANCE: ToolGuidance = {
-	intro: 'Apply several edits in one atomic call.',
+	intro: "Apply several edits in one atomic call.",
 	lines: [
-		'`batch_edit`: each item is edit\u2019s shape — { path?, remove_from, remove_to, replacement_text } — with bare hash anchors; items apply in order, and same-file ranges must not overlap.',
-		'`batch_edit`: all-or-nothing — any failing item writes nothing anywhere and echoes its current range as fresh rows that count as serves.',
-		'`batch_edit`: a no-op item is reported without failing; the result is one combined diff per file with fresh anchors.',
+		"`batch_edit`: each item is edit\u2019s shape — { path?, remove_from, remove_to, replacement_text } — with bare hash anchors; items apply in order, and same-file ranges must not overlap.",
+		"`batch_edit`: all-or-nothing — any failing item writes nothing anywhere and echoes its current range as fresh rows that count as serves.",
+		"`batch_edit`: a no-op item is reported without failing; the result is one combined diff per file with fresh anchors.",
 	],
 };
 
 export const UNDO_DESCRIPTION =
-	'Undo the last edit on a file, reverting it to its previous state. Use when an edit produced ' +
-	'incorrect results (e.g., wrong content, duplicated lines, broken syntax).'
+	"Undo the last edit on a file, reverting it to its previous state. Use when an edit produced " +
+	"incorrect results (e.g., wrong content, duplicated lines, broken syntax).";
 
 export const UNDO_GUIDANCE: ToolGuidance = {
-	intro: 'Revert the last edit on a file.',
+	intro: "Revert the last edit on a file.",
 	lines: [
-		'`undo_last_edit`: reverts only the most recent edit — any write clears history, so call it immediately after a bad edit.',
-		'`undo_last_edit`: the restored diff\u2019s `+HASH│` and ` HASH│` rows are fresh anchors for follow-up edits.',
+		"`undo_last_edit`: reverts only the most recent edit — any write clears history, so call it immediately after a bad edit.",
+		"`undo_last_edit`: the restored diff\u2019s `+HASH│` and ` HASH│` rows are fresh anchors for follow-up edits.",
 	],
 };

--- a/test/guidance.test.ts
+++ b/test/guidance.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, it } from "vitest";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
 import { getWritableTempRoot } from "./support/fixtures.js";
 import {
 	DEFAULT_GUIDANCE_DIR,
+	DEFAULT_GUIDANCE_README,
 	GUIDANCE_SECTIONS,
 	composeSections,
+	ensureDefaultGuidance,
 	parseSectionFile,
 	renderSectionDefault,
 	resolveSection,
@@ -249,3 +251,82 @@ describe("composeSections", () => {
 		});
 	});
 });
+
+
+describe("ensureDefaultGuidance", () => {
+	it("creates the four section files byte-identical to the compiled defaults plus a README", async () => {
+		await withHome(async (home) => {
+			await ensureDefaultGuidance(home);
+			const templateDir = join(home, DEFAULT_GUIDANCE_DIR);
+			for (const section of GUIDANCE_SECTIONS) {
+				const content = await readFile(
+					join(templateDir, section.file),
+					"utf-8",
+				);
+				expect(content).toBe(section.renderDefault());
+			}
+			const readme = await readFile(join(templateDir, "README.md"), "utf-8");
+			expect(readme).toBe(DEFAULT_GUIDANCE_README);
+			expect(readme).toContain("cp -r _default");
+			expect(readme).toContain("order");
+		});
+	});
+
+	it("never rewrites existing files — a user-edited template survives repeated calls", async () => {
+		await withHome(async (home) => {
+			await ensureDefaultGuidance(home);
+			const editFile = join(home, DEFAULT_GUIDANCE_DIR, "edit.md");
+			const custom = "---\norder: 150\n---\nMy custom edit guidance, kept verbatim.";
+			await writeFile(editFile, custom, "utf-8");
+			await ensureDefaultGuidance(home);
+			expect(await readFile(editFile, "utf-8")).toBe(custom);
+		});
+	});
+
+	it("fills in only the files that are missing", async () => {
+		await withHome(async (home) => {
+			const templateDir = join(home, DEFAULT_GUIDANCE_DIR);
+			await mkdir(templateDir, { recursive: true });
+			await writeFile(
+				join(templateDir, "edit.md"),
+				"custom edit guidance",
+				"utf-8",
+			);
+			await ensureDefaultGuidance(home);
+			expect(await readFile(join(templateDir, "edit.md"), "utf-8")).toBe(
+				"custom edit guidance",
+			);
+			for (const section of GUIDANCE_SECTIONS) {
+				if (section.file === "edit.md") continue;
+				expect(
+					await readFile(join(templateDir, section.file), "utf-8"),
+				).toBe(section.renderDefault());
+			}
+			expect(await readFile(join(templateDir, "README.md"), "utf-8")).toBe(
+				DEFAULT_GUIDANCE_README,
+			);
+		});
+	});
+
+	it("the materialized _default layer is honoured by the resolver as the global fallback", async () => {
+		await withHome(async (home) => {
+			await ensureDefaultGuidance(home);
+			await writeFile(
+				join(home, DEFAULT_GUIDANCE_DIR, "edit.md"),
+				"---\norder: 151\n---\ncustom global edit guidance",
+				"utf-8",
+			);
+			const resolved = await resolveSection("tool:edit", { homeDir: home });
+			expect(resolved).toEqual({
+				order: 151,
+				text: "custom global edit guidance",
+			});
+			const read = await resolveSection("tool:read", { homeDir: home });
+			expect(read).toEqual({
+				order: 100,
+				text: renderSectionDefault("tool:read"),
+			});
+		});
+	});
+});
+

--- a/test/guidance.test.ts
+++ b/test/guidance.test.ts
@@ -15,7 +15,6 @@ import {
 } from "../src/guidance.js";
 import {
 	BATCH_EDIT_GUIDANCE,
-	EDIT_DESCRIPTION,
 	EDIT_GUIDANCE,
 	READ_GUIDANCE,
 	UNDO_GUIDANCE,
@@ -43,8 +42,6 @@ async function writeSection(
 	await writeFile(join(dir, file), content, "utf-8");
 }
 
-const READ_HEADER =
-	"Use the read tool — not shell commands like cat — to inspect text files.";
 const bullets = (lines: readonly string[]) =>
 	lines.map((line) => `- ${line}`).join("\n");
 
@@ -63,22 +60,22 @@ describe("guidance sections", () => {
 			"undo_last_edit.md",
 		]);
 		expect(GUIDANCE_SECTIONS.map((s) => s.defaultOrder)).toEqual([
-			100, 102, 103, 104,
+			130, 131, 132, 133,
 		]);
 	});
 
 	it("default render matches today's inline section text", () => {
 		expect(renderSectionDefault("tool:read")).toBe(
-			[READ_HEADER, "", bullets(READ_GUIDANCE)].join("\n"),
+			[READ_GUIDANCE.intro, "", bullets(READ_GUIDANCE.lines)].join("\n"),
 		);
 		expect(renderSectionDefault("tool:edit")).toBe(
-			[EDIT_DESCRIPTION, "", bullets(EDIT_GUIDANCE)].join("\n"),
+			[EDIT_GUIDANCE.intro, "", bullets(EDIT_GUIDANCE.lines)].join("\n"),
 		);
 		expect(renderSectionDefault("tool:batch_edit")).toBe(
-			bullets(BATCH_EDIT_GUIDANCE),
+			[BATCH_EDIT_GUIDANCE.intro, "", bullets(BATCH_EDIT_GUIDANCE.lines)].join("\n"),
 		);
 		expect(renderSectionDefault("tool:undo_last_edit")).toBe(
-			bullets(UNDO_GUIDANCE),
+			[UNDO_GUIDANCE.intro, "", bullets(UNDO_GUIDANCE.lines)].join("\n"),
 		);
 	});
 });
@@ -94,6 +91,13 @@ describe("parseSectionFile", () => {
 		expect(parseSectionFile("---\norder: 150\n---\nbody line")).toEqual({
 			order: 150,
 			text: "body line",
+		});
+	});
+
+	it("strips leading blank lines after the closing fence", () => {
+		expect(parseSectionFile("---\norder: 150\n---\n\nbody")).toEqual({
+			order: 150,
+			text: "body",
 		});
 	});
 
@@ -142,7 +146,7 @@ describe("resolveSection", () => {
 				homeDir: home,
 			});
 			expect(resolved).toEqual({
-				order: 102,
+				order: 131,
 				text: renderSectionDefault("tool:edit"),
 			});
 		});
@@ -155,7 +159,7 @@ describe("resolveSection", () => {
 				presetId: "code",
 				homeDir: home,
 			});
-			expect(resolved).toEqual({ order: 102, text: "global edit text" });
+			expect(resolved).toEqual({ order: 131, text: "global edit text" });
 		});
 	});
 
@@ -167,7 +171,7 @@ describe("resolveSection", () => {
 				presetId: "code",
 				homeDir: home,
 			});
-			expect(resolved).toEqual({ order: 102, text: "preset edit text" });
+			expect(resolved).toEqual({ order: 131, text: "preset edit text" });
 		});
 	});
 
@@ -190,7 +194,7 @@ describe("resolveSection", () => {
 				presetId: undefined,
 				homeDir: home,
 			});
-			expect(resolved).toEqual({ order: 102, text: "global edit text" });
+			expect(resolved).toEqual({ order: 131, text: "global edit text" });
 		});
 	});
 
@@ -201,7 +205,7 @@ describe("resolveSection", () => {
 				homeDir: home,
 			});
 			expect(resolved).toEqual({
-				order: 100,
+				order: 130,
 				text: renderSectionDefault("tool:read"),
 			});
 		});
@@ -226,7 +230,7 @@ describe("composeSections", () => {
 				"tool:batch_edit",
 				"tool:undo_last_edit",
 			]);
-			expect(sections.map((s) => s.order)).toEqual([100, 102, 103, 104]);
+			expect(sections.map((s) => s.order)).toEqual([130, 131, 132, 133]);
 			expect(sections.map((s) => s.text)).toEqual(
 				GUIDANCE_SECTIONS.map((s) => s.renderDefault()),
 			);
@@ -245,7 +249,7 @@ describe("composeSections", () => {
 			// Unoverridden sections keep their compiled defaults.
 			expect(sections.find((s) => s.name === "tool:read")).toEqual({
 				name: "tool:read",
-				order: 100,
+				order: 130,
 				text: renderSectionDefault("tool:read"),
 			});
 		});
@@ -254,7 +258,7 @@ describe("composeSections", () => {
 
 
 describe("ensureDefaultGuidance", () => {
-	it("creates the four section files byte-identical to the compiled defaults plus a README", async () => {
+	it("creates the four section files as order front-matter + compiled default, plus a README", async () => {
 		await withHome(async (home) => {
 			await ensureDefaultGuidance(home);
 			const templateDir = join(home, DEFAULT_GUIDANCE_DIR);
@@ -263,7 +267,7 @@ describe("ensureDefaultGuidance", () => {
 					join(templateDir, section.file),
 					"utf-8",
 				);
-				expect(content).toBe(section.renderDefault());
+				expect(content).toBe(`---\norder: ${section.defaultOrder}\n---\n\n${section.renderDefault()}`);
 			}
 			const readme = await readFile(join(templateDir, "README.md"), "utf-8");
 			expect(readme).toBe(DEFAULT_GUIDANCE_README);
@@ -300,7 +304,7 @@ describe("ensureDefaultGuidance", () => {
 				if (section.file === "edit.md") continue;
 				expect(
 					await readFile(join(templateDir, section.file), "utf-8"),
-				).toBe(section.renderDefault());
+				).toBe(`---\norder: ${section.defaultOrder}\n---\n\n${section.renderDefault()}`);
 			}
 			expect(await readFile(join(templateDir, "README.md"), "utf-8")).toBe(
 				DEFAULT_GUIDANCE_README,
@@ -323,7 +327,7 @@ describe("ensureDefaultGuidance", () => {
 			});
 			const read = await resolveSection("tool:read", { homeDir: home });
 			expect(read).toEqual({
-				order: 100,
+				order: 130,
 				text: renderSectionDefault("tool:read"),
 			});
 		});

--- a/test/guidance.test.ts
+++ b/test/guidance.test.ts
@@ -4,11 +4,11 @@ import { join } from "node:path";
 
 import { getWritableTempRoot } from "./support/fixtures.js";
 import {
-	DEFAULT_GUIDANCE_DIR,
-	DEFAULT_GUIDANCE_README,
+	DEFAULT_PRESETS,
+	GUIDANCE_HOME_README,
 	GUIDANCE_SECTIONS,
 	composeSections,
-	ensureDefaultGuidance,
+	ensurePresetGuidance,
 	parseSectionFile,
 	renderSectionDefault,
 	resolveSection,
@@ -152,21 +152,9 @@ describe("resolveSection", () => {
 		});
 	});
 
-	it("uses the _default file when the preset file is absent", async () => {
-		await withHome(async (home) => {
-			await writeSection(home, DEFAULT_GUIDANCE_DIR, "edit.md", "global edit text");
-			const resolved = await resolveSection("tool:edit", {
-				presetId: "code",
-				homeDir: home,
-			});
-			expect(resolved).toEqual({ order: 131, text: "global edit text" });
-		});
-	});
-
-	it("prefers the preset file over the _default file", async () => {
+	it("reads the preset file when one exists", async () => {
 		await withHome(async (home) => {
 			await writeSection(home, "code", "edit.md", "preset edit text");
-			await writeSection(home, DEFAULT_GUIDANCE_DIR, "edit.md", "global edit text");
 			const resolved = await resolveSection("tool:edit", {
 				presetId: "code",
 				homeDir: home,
@@ -186,15 +174,30 @@ describe("resolveSection", () => {
 		});
 	});
 
-	it("skips the preset layer when presetId is undefined but still reads _default", async () => {
+	it("ignores preset files when presetId is undefined", async () => {
 		await withHome(async (home) => {
 			await writeSection(home, "code", "edit.md", "preset edit text");
-			await writeSection(home, DEFAULT_GUIDANCE_DIR, "edit.md", "global edit text");
 			const resolved = await resolveSection("tool:edit", {
 				presetId: undefined,
 				homeDir: home,
 			});
-			expect(resolved).toEqual({ order: 131, text: "global edit text" });
+			expect(resolved).toEqual({
+				order: 131,
+				text: renderSectionDefault("tool:edit"),
+			});
+		});
+	});
+
+	it("falls back to compiled defaults when the preset has no directory", async () => {
+		await withHome(async (home) => {
+			const resolved = await resolveSection("tool:edit", {
+				presetId: "ghost",
+				homeDir: home,
+			});
+			expect(resolved).toEqual({
+				order: 131,
+				text: renderSectionDefault("tool:edit"),
+			});
 		});
 	});
 
@@ -257,75 +260,77 @@ describe("composeSections", () => {
 });
 
 
-describe("ensureDefaultGuidance", () => {
-	it("creates the four section files as order front-matter + compiled default, plus a README", async () => {
+describe("ensurePresetGuidance", () => {
+	it("seeds each shipped preset with the four section files plus a root README", async () => {
 		await withHome(async (home) => {
-			await ensureDefaultGuidance(home);
-			const templateDir = join(home, DEFAULT_GUIDANCE_DIR);
-			for (const section of GUIDANCE_SECTIONS) {
-				const content = await readFile(
-					join(templateDir, section.file),
-					"utf-8",
-				);
-				expect(content).toBe(`---\norder: ${section.defaultOrder}\n---\n\n${section.renderDefault()}`);
+			await ensurePresetGuidance(home);
+			for (const preset of DEFAULT_PRESETS) {
+				for (const section of GUIDANCE_SECTIONS) {
+					const content = await readFile(
+						join(home, preset, section.file),
+						"utf-8",
+					);
+					expect(content).toBe(`---\norder: ${section.defaultOrder}\n---\n\n${section.renderDefault()}`);
+				}
 			}
-			const readme = await readFile(join(templateDir, "README.md"), "utf-8");
-			expect(readme).toBe(DEFAULT_GUIDANCE_README);
-			expect(readme).toContain("cp -r _default");
+			const readme = await readFile(join(home, "README.md"), "utf-8");
+			expect(readme).toBe(GUIDANCE_HOME_README);
 			expect(readme).toContain("order");
 		});
 	});
 
-	it("never rewrites existing files — a user-edited template survives repeated calls", async () => {
+	it("never rewrites existing files - a user-edited preset file survives repeated calls", async () => {
 		await withHome(async (home) => {
-			await ensureDefaultGuidance(home);
-			const editFile = join(home, DEFAULT_GUIDANCE_DIR, "edit.md");
+			await ensurePresetGuidance(home);
+			const editFile = join(home, "code", "edit.md");
 			const custom = "---\norder: 150\n---\nMy custom edit guidance, kept verbatim.";
 			await writeFile(editFile, custom, "utf-8");
-			await ensureDefaultGuidance(home);
+			await ensurePresetGuidance(home);
 			expect(await readFile(editFile, "utf-8")).toBe(custom);
 		});
 	});
 
 	it("fills in only the files that are missing", async () => {
 		await withHome(async (home) => {
-			const templateDir = join(home, DEFAULT_GUIDANCE_DIR);
-			await mkdir(templateDir, { recursive: true });
-			await writeFile(
-				join(templateDir, "edit.md"),
-				"custom edit guidance",
-				"utf-8",
-			);
-			await ensureDefaultGuidance(home);
-			expect(await readFile(join(templateDir, "edit.md"), "utf-8")).toBe(
+			await mkdir(join(home, "code"), { recursive: true });
+			await writeFile(join(home, "code", "edit.md"), "custom edit guidance", "utf-8");
+			await ensurePresetGuidance(home);
+			expect(await readFile(join(home, "code", "edit.md"), "utf-8")).toBe(
 				"custom edit guidance",
 			);
 			for (const section of GUIDANCE_SECTIONS) {
 				if (section.file === "edit.md") continue;
 				expect(
-					await readFile(join(templateDir, section.file), "utf-8"),
+					await readFile(join(home, "code", section.file), "utf-8"),
 				).toBe(`---\norder: ${section.defaultOrder}\n---\n\n${section.renderDefault()}`);
 			}
-			expect(await readFile(join(templateDir, "README.md"), "utf-8")).toBe(
-				DEFAULT_GUIDANCE_README,
+			expect(await readFile(join(home, "README.md"), "utf-8")).toBe(
+				GUIDANCE_HOME_README,
 			);
 		});
 	});
 
-	it("the materialized _default layer is honoured by the resolver as the global fallback", async () => {
+	it("a seeded preset dir is honoured as that preset's editable default", async () => {
 		await withHome(async (home) => {
-			await ensureDefaultGuidance(home);
+			await ensurePresetGuidance(home);
 			await writeFile(
-				join(home, DEFAULT_GUIDANCE_DIR, "edit.md"),
-				"---\norder: 151\n---\ncustom global edit guidance",
+				join(home, "code", "edit.md"),
+				"---\norder: 151\n---\ncustom code edit guidance",
 				"utf-8",
 			);
-			const resolved = await resolveSection("tool:edit", { homeDir: home });
+			const resolved = await resolveSection("tool:edit", {
+				presetId: "code",
+				homeDir: home,
+			});
 			expect(resolved).toEqual({
 				order: 151,
-				text: "custom global edit guidance",
+				text: "custom code edit guidance",
 			});
-			const read = await resolveSection("tool:read", { homeDir: home });
+			// An unedited seeded section still equals the compiled default.
+			const read = await resolveSection("tool:read", {
+				presetId: "code",
+				homeDir: home,
+			});
 			expect(read).toEqual({
 				order: 130,
 				text: renderSectionDefault("tool:read"),
@@ -333,4 +338,3 @@ describe("ensureDefaultGuidance", () => {
 		});
 	});
 });
-

--- a/test/guidance.test.ts
+++ b/test/guidance.test.ts
@@ -6,6 +6,7 @@ import { getWritableTempRoot } from "./support/fixtures.js";
 import {
 	DEFAULT_PRESETS,
 	GUIDANCE_HOME_README,
+	GUIDANCE_HOME_README_ZH,
 	GUIDANCE_SECTIONS,
 	composeSections,
 	ensurePresetGuidance,
@@ -276,6 +277,9 @@ describe("ensurePresetGuidance", () => {
 			const readme = await readFile(join(home, "README.md"), "utf-8");
 			expect(readme).toBe(GUIDANCE_HOME_README);
 			expect(readme).toContain("order");
+			const readmeZh = await readFile(join(home, "README.zh.md"), "utf-8");
+			expect(readmeZh).toBe(GUIDANCE_HOME_README_ZH);
+			expect(readmeZh).toContain("order");
 		});
 	});
 
@@ -306,6 +310,7 @@ describe("ensurePresetGuidance", () => {
 			}
 			expect(await readFile(join(home, "README.md"), "utf-8")).toBe(
 				GUIDANCE_HOME_README,
+	GUIDANCE_HOME_README_ZH,
 			);
 		});
 	});

--- a/test/guidance.test.ts
+++ b/test/guidance.test.ts
@@ -12,11 +12,11 @@ import {
 	resolveSection,
 } from "../src/guidance.js";
 import {
-	BATCH_EDIT_GUIDELINES,
+	BATCH_EDIT_GUIDANCE,
 	EDIT_DESCRIPTION,
-	EDIT_GUIDELINES,
-	READ_GUIDELINES,
-	UNDO_GUIDELINES,
+	EDIT_GUIDANCE,
+	READ_GUIDANCE,
+	UNDO_GUIDANCE,
 } from "../src/prompts.js";
 
 async function withHome(run: (home: string) => Promise<void>): Promise<void> {
@@ -67,16 +67,16 @@ describe("guidance sections", () => {
 
 	it("default render matches today's inline section text", () => {
 		expect(renderSectionDefault("tool:read")).toBe(
-			[READ_HEADER, "", bullets(READ_GUIDELINES)].join("\n"),
+			[READ_HEADER, "", bullets(READ_GUIDANCE)].join("\n"),
 		);
 		expect(renderSectionDefault("tool:edit")).toBe(
-			[EDIT_DESCRIPTION, "", bullets(EDIT_GUIDELINES)].join("\n"),
+			[EDIT_DESCRIPTION, "", bullets(EDIT_GUIDANCE)].join("\n"),
 		);
 		expect(renderSectionDefault("tool:batch_edit")).toBe(
-			bullets(BATCH_EDIT_GUIDELINES),
+			bullets(BATCH_EDIT_GUIDANCE),
 		);
 		expect(renderSectionDefault("tool:undo_last_edit")).toBe(
-			bullets(UNDO_GUIDELINES),
+			bullets(UNDO_GUIDANCE),
 		);
 	});
 });

--- a/test/guidance.test.ts
+++ b/test/guidance.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, it } from "vitest";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { getWritableTempRoot } from "./support/fixtures.js";
+import {
+	DEFAULT_GUIDANCE_DIR,
+	GUIDANCE_SECTIONS,
+	composeSections,
+	parseSectionFile,
+	renderSectionDefault,
+	resolveSection,
+} from "../src/guidance.js";
+import {
+	BATCH_EDIT_GUIDELINES,
+	EDIT_DESCRIPTION,
+	EDIT_GUIDELINES,
+	READ_GUIDELINES,
+	UNDO_GUIDELINES,
+} from "../src/prompts.js";
+
+async function withHome(run: (home: string) => Promise<void>): Promise<void> {
+	const home = await mkdtemp(
+		join(await getWritableTempRoot(), "dsh-guidance-test-"),
+	);
+	try {
+		await run(home);
+	} finally {
+		await rm(home, { recursive: true, force: true });
+	}
+}
+
+async function writeSection(
+	home: string,
+	preset: string,
+	file: string,
+	content: string,
+): Promise<void> {
+	const dir = join(home, preset);
+	await mkdir(dir, { recursive: true });
+	await writeFile(join(dir, file), content, "utf-8");
+}
+
+const READ_HEADER =
+	"Use the read tool — not shell commands like cat — to inspect text files.";
+const bullets = (lines: readonly string[]) =>
+	lines.map((line) => `- ${line}`).join("\n");
+
+describe("guidance sections", () => {
+	it("exposes the four sections with stable order, file names, and defaults", () => {
+		expect(GUIDANCE_SECTIONS.map((s) => s.name)).toEqual([
+			"tool:read",
+			"tool:edit",
+			"tool:batch_edit",
+			"tool:undo_last_edit",
+		]);
+		expect(GUIDANCE_SECTIONS.map((s) => s.file)).toEqual([
+			"read.md",
+			"edit.md",
+			"batch_edit.md",
+			"undo_last_edit.md",
+		]);
+		expect(GUIDANCE_SECTIONS.map((s) => s.defaultOrder)).toEqual([
+			100, 102, 103, 104,
+		]);
+	});
+
+	it("default render matches today's inline section text", () => {
+		expect(renderSectionDefault("tool:read")).toBe(
+			[READ_HEADER, "", bullets(READ_GUIDELINES)].join("\n"),
+		);
+		expect(renderSectionDefault("tool:edit")).toBe(
+			[EDIT_DESCRIPTION, "", bullets(EDIT_GUIDELINES)].join("\n"),
+		);
+		expect(renderSectionDefault("tool:batch_edit")).toBe(
+			bullets(BATCH_EDIT_GUIDELINES),
+		);
+		expect(renderSectionDefault("tool:undo_last_edit")).toBe(
+			bullets(UNDO_GUIDELINES),
+		);
+	});
+});
+
+describe("parseSectionFile", () => {
+	it("treats a file without front-matter as pure prose", () => {
+		expect(parseSectionFile("plain prose line\nsecond line")).toEqual({
+			text: "plain prose line\nsecond line",
+		});
+	});
+
+	it("parses order from a valid front-matter fence", () => {
+		expect(parseSectionFile("---\norder: 150\n---\nbody line")).toEqual({
+			order: 150,
+			text: "body line",
+		});
+	});
+
+	it("accepts a fence without an order key (body only)", () => {
+		expect(parseSectionFile("---\n---\nbody")).toEqual({
+			text: "body",
+		});
+	});
+
+	it("accepts negative orders", () => {
+		expect(parseSectionFile("---\norder: -5\n---\nbody").order).toBe(-5);
+	});
+
+	it("treats a missing closing fence as prose", () => {
+		const content = "---\norder: 150\nbody then";
+		expect(parseSectionFile(content)).toEqual({ text: content });
+	});
+
+	it("treats a non-integer order as prose", () => {
+		const content = "---\norder: abc\n---\nbody";
+		expect(parseSectionFile(content)).toEqual({ text: content });
+	});
+
+	it("treats an unknown front-matter key as prose", () => {
+		const content = "---\ntitle: x\n---\nbody";
+		expect(parseSectionFile(content)).toEqual({ text: content });
+	});
+
+	it("is CRLF-tolerant for the fence", () => {
+		expect(parseSectionFile("---\r\norder: 201\r\n---\r\nbody")).toEqual({
+			order: 201,
+			text: "body",
+		});
+	});
+
+	it("returns an empty string for an empty file", () => {
+		expect(parseSectionFile("")).toEqual({ text: "" });
+	});
+});
+
+describe("resolveSection", () => {
+	it("falls back to the compiled default when no override exists", async () => {
+		await withHome(async (home) => {
+			const resolved = await resolveSection("tool:edit", {
+				presetId: "code",
+				homeDir: home,
+			});
+			expect(resolved).toEqual({
+				order: 102,
+				text: renderSectionDefault("tool:edit"),
+			});
+		});
+	});
+
+	it("uses the _default file when the preset file is absent", async () => {
+		await withHome(async (home) => {
+			await writeSection(home, DEFAULT_GUIDANCE_DIR, "edit.md", "global edit text");
+			const resolved = await resolveSection("tool:edit", {
+				presetId: "code",
+				homeDir: home,
+			});
+			expect(resolved).toEqual({ order: 102, text: "global edit text" });
+		});
+	});
+
+	it("prefers the preset file over the _default file", async () => {
+		await withHome(async (home) => {
+			await writeSection(home, "code", "edit.md", "preset edit text");
+			await writeSection(home, DEFAULT_GUIDANCE_DIR, "edit.md", "global edit text");
+			const resolved = await resolveSection("tool:edit", {
+				presetId: "code",
+				homeDir: home,
+			});
+			expect(resolved).toEqual({ order: 102, text: "preset edit text" });
+		});
+	});
+
+	it("applies the front-matter order override", async () => {
+		await withHome(async (home) => {
+			await writeSection(home, "minimal", "edit.md", "---\norder: 300\n---\nminimal text");
+			const resolved = await resolveSection("tool:edit", {
+				presetId: "minimal",
+				homeDir: home,
+			});
+			expect(resolved).toEqual({ order: 300, text: "minimal text" });
+		});
+	});
+
+	it("skips the preset layer when presetId is undefined but still reads _default", async () => {
+		await withHome(async (home) => {
+			await writeSection(home, "code", "edit.md", "preset edit text");
+			await writeSection(home, DEFAULT_GUIDANCE_DIR, "edit.md", "global edit text");
+			const resolved = await resolveSection("tool:edit", {
+				presetId: undefined,
+				homeDir: home,
+			});
+			expect(resolved).toEqual({ order: 102, text: "global edit text" });
+		});
+	});
+
+	it("resolves to compiled defaults when presetId is undefined and nothing exists", async () => {
+		await withHome(async (home) => {
+			const resolved = await resolveSection("tool:read", {
+				presetId: undefined,
+				homeDir: home,
+			});
+			expect(resolved).toEqual({
+				order: 100,
+				text: renderSectionDefault("tool:read"),
+			});
+		});
+	});
+
+	it("throws on an unknown section name", async () => {
+		await withHome(async (home) => {
+			await expect(
+				resolveSection("tool:nope", { presetId: "code", homeDir: home }),
+			).rejects.toThrow("unknown guidance section");
+		});
+	});
+});
+
+describe("composeSections", () => {
+	it("returns the four sections in default-order sequence", async () => {
+		await withHome(async (home) => {
+			const sections = await composeSections(undefined, home);
+			expect(sections.map((s) => s.name)).toEqual([
+				"tool:read",
+				"tool:edit",
+				"tool:batch_edit",
+				"tool:undo_last_edit",
+			]);
+			expect(sections.map((s) => s.order)).toEqual([100, 102, 103, 104]);
+			expect(sections.map((s) => s.text)).toEqual(
+				GUIDANCE_SECTIONS.map((s) => s.renderDefault()),
+			);
+		});
+	});
+
+	it("overrides only the sections that have preset files", async () => {
+		await withHome(async (home) => {
+			await writeSection(home, "code", "edit.md", "---\norder: 210\n---\ncode edits");
+			const sections = await composeSections("code", home);
+			expect(sections.find((s) => s.name === "tool:edit")).toEqual({
+				name: "tool:edit",
+				order: 210,
+				text: "code edits",
+			});
+			// Unoverridden sections keep their compiled defaults.
+			expect(sections.find((s) => s.name === "tool:read")).toEqual({
+				name: "tool:read",
+				order: 100,
+				text: renderSectionDefault("tool:read"),
+			});
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Implements issue #7 — configurable per-preset tool guidance. The four `tool:*` guidance sections (`tool:read`, `tool:edit`, `tool:batch_edit`, `tool:undo_last_edit`) are now overridable via plain-markdown files keyed by agent preset, so different presets (or no preset) can show different guidance, and each section's order is adjustable.

Design (spec #8, ADR-0001): `$DSH_HOME/plugins/dsh-better-edit/<preset>/<section>.md` → `_default/` (auto-created at boot, copy source + global fallback) → compiled default. Front-matter `order` overrides order. Read once per agent at session-start; preset-less deployments keep compiled defaults.

Delivered as tracer-bullet tickets, each independently reviewable and merged onto this branch:
- #9 T1 — guidance resolution core (`src/guidance.ts`)
- #12 T4 — guidance text simplified, `*_GUIDELINES` → `*_GUIDANCE`
- #11 T3 — wire per-preset resolution into the installer (optional `agentPresets` via `ctx.get`, never injected)
- #10 T2 — `_default/` template materialization
- boot wiring — materialize `_default/` at boot, next to `initHasher`
- #13 T5 — README (EN + zh), CHANGELOG, ADR-0001

Also: `CONTEXT.md` domain glossary.

Validation: `npm run typecheck` passes; `npm test` 650 tests green (25 new guidance tests); end-to-end smoke test against a temp home verified materialization + per-preset override + fallback.

## Test plan
- [x] typecheck
- [x] vitest (650 pass)
- [x] manual smoke: `_default/` materialized → `code` preset override (`order: 150` + custom text) → unoverridden `tool:read` falls back to `_default`

Closes #7
Closes #8
