### PR TITLE
deepen: Mutation owns lifecycle + heal guidance ghost (C01+C02)

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,6 +6,7 @@ export const MAX_READ_LINE_BYTES = 200 * 1024;
 export const HASH_STORE_BUSY_TIMEOUT = 1000;
 export const HASH_STORE_VERSION = 6;
 export const EDITS_MAX_ITEMS = 32;
+/** @deprecated batch_edit seam removed (ADR-0003) — use EDITS_MAX_ITEMS */
 export const BATCH_EDIT_MAX_ITEMS = EDITS_MAX_ITEMS;
 export const SERVED_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 export const SERVED_ECHO_CAP = 150;

--- a/src/guidance/materialize.ts
+++ b/src/guidance/materialize.ts
@@ -3,7 +3,7 @@
  * and README generation. Idempotent and concurrent-safe (wx).
  * @module dsh-better-edit/guidance/materialize
  */
-import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readdir, readFile, unlink, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
 import { errCode } from "../utils.js";
@@ -33,7 +33,6 @@ Each file is one tool section:
 
 - \`read.md\` -> \`tool:read\`
 - \`edit.md\` -> \`tool:edit\`
-- \`batch_edit.md\` -> \`tool:batch_edit\`
 - \`undo_last_edit.md\` -> \`tool:undo_last_edit\`
 
 ## Customize
@@ -72,7 +71,6 @@ export const GUIDANCE_HOME_README_ZH = `# dsh-better-edit 指引
 
 - \`read.md\` -> \`tool:read\`
 - \`edit.md\` -> \`tool:edit\`
-- \`batch_edit.md\` -> \`tool:batch_edit\`
 - \`undo_last_edit.md\` -> \`tool:undo_last_edit\`
 
 ## 自定义
@@ -129,7 +127,7 @@ async function healBlankOverride(
 /**
  * Materialize per-preset guidance directories in the plugin home.
  *
- * For each of `DEFAULT_PRESETS` creates `<preset>/{read,edit,batch_edit,
+ * For each of `DEFAULT_PRESETS` creates `<preset>/{read,edit,
  * undo_last_edit}.md` rendered from the compiled defaults (with order
  * front-matter), plus a root `README.md` documenting the convention.
  * Idempotent: a user-edited file survives repeated calls. A blank override file
@@ -166,6 +164,18 @@ export async function ensurePresetGuidance(homeDir: string): Promise<void> {
 			);
 		}),
 	);
+	// Ghost seam cleanup (ADR-0003): remove orphan batch_edit.md override files left
+	// from pre-0.3.0 homes. The payload contract merged batch_edit into edit's
+	// {path, edits:[[hash,hash,text]]} arity — the file is dead. Best-effort,
+	// idempotent, concurrent-safe (ignore ENOENT).
+	for (const preset of DEFAULT_PRESETS) {
+		const ghost = join(homeDir, preset, "batch_edit.md");
+		await unlink(ghost).catch((error: unknown) => {
+			if (errCode(error) === "ENOENT") return;
+			throw error;
+		});
+	}
+
 	// Custom presets present on disk: heal existing blank section files only.
 	// Absence is respected — a custom preset's files are never fabricated, and
 	// malformed / non-blank / deliberate-blank files are left untouched.
@@ -186,6 +196,16 @@ export async function ensurePresetGuidance(homeDir: string): Promise<void> {
 				);
 			}),
 	);
+	// Ghost seam cleanup for custom presets (same ADR-0003 dead file).
+	for (const entry of entries) {
+		if (!entry.isDirectory() || DEFAULT_PRESETS.includes(entry.name)) continue;
+		const ghost = join(homeDir, entry.name, "batch_edit.md");
+		await unlink(ghost).catch((error: unknown) => {
+			if (errCode(error) === "ENOENT") return;
+			throw error;
+		});
+	}
+
 	const homeFiles = new Set(await readdir(homeDir));
 	const readmes: Array<[string, string]> = [
 		["README.md", GUIDANCE_HOME_README],

--- a/src/guidance/resolve.ts
+++ b/src/guidance/resolve.ts
@@ -9,7 +9,6 @@ import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 
 import {
-	BATCH_EDIT_GUIDANCE,
 	EDIT_GUIDANCE,
 	READ_GUIDANCE,
 	UNDO_GUIDANCE,
@@ -19,7 +18,7 @@ import { errCode } from "../utils.js";
 import { isBlankOverride, parseSectionFile } from "./parse.js";
 
 /**
- * Render one tool's guidance as its intro line, a blank line, then bullets.
+* Render one tool's guidance as its intro line, a blank line, then bullets.
  * Uniform across the four sections: no tool-schema description is duplicated
  * (that already reaches the model through the tool catalog).
  */
@@ -43,7 +42,7 @@ export interface GuidanceSection {
 	renderDefault(): string;
 }
 
-/** The four sections, in default-order sequence. */
+/** The three sections, in default-order sequence. */
 export const GUIDANCE_SECTIONS: readonly GuidanceSection[] = [
 	{
 		name: "tool:read",
@@ -57,13 +56,7 @@ export const GUIDANCE_SECTIONS: readonly GuidanceSection[] = [
 		defaultOrder: 131,
 		renderDefault: () => guidanceText(EDIT_GUIDANCE),
 	},
-	{
-		name: "tool:batch_edit",
-		file: "batch_edit.md",
-		defaultOrder: 132,
-		renderDefault: () => guidanceText(BATCH_EDIT_GUIDANCE),
-	},
-	{
+		{
 		name: "tool:undo_last_edit",
 		file: "undo_last_edit.md",
 		defaultOrder: 133,
@@ -158,7 +151,7 @@ export interface SectionOverride {
 }
 
 /**
- * Resolve all four sections for a preset. `presetId === undefined` skips the
+ * Resolve all three sections for a preset. `presetId === undefined` skips the
  * `<preset>/` layer and resolves straight to the compiled defaults.
  */
 export async function composeSections(

--- a/src/mutation.ts
+++ b/src/mutation.ts
@@ -8,13 +8,16 @@
  * by mutation across 5 hops; bugs hid in wiring, not pure helpers.
  *
  * This seam owns: read → normalize → loadServed → applyOne* → stableRehash →
- * drift → persist. Tools become thin adapters: validate → delegate → render.
+ * drift → persist → render. Tools become thin adapters: validate → delegate → return.
  * edit-diff, drift, noop-guard are private helpers of this seam.
  *
  * Public surface:
- *   applySingle(io, params, {cwd, sessionKey, signal}) → PipelineResult
- *   applySequence(io, items, {cwd, sessionKey, signal}) → FileEditResult[]
- *   commit(io, files, {exec, sandboxPolicy, signal}) → void
+ *   execute(io, items, {sessionKey, exec, sandbox, signal}) → string  — deep seam: ONE interface
+ *   applySingle(io, params, cwd, opts) → PipelineResult               — single-edit helper
+ *   applySequence(io, items, ctx) → FileEditResult                    — per-file sequencer
+ *   commit(io, files, {exec, sandboxPolicy, signal}) → void           — transaction
+ *
+ * Depth: small interface (execute) with large implementation — locality and leverage.
  *
  * Internals (private): verifyServedRange, resToSpan, assemble, scanDrift,
  * boundaryDups, noopGuard. Tested via PipelineResult/FileEditResult, not via split e2e.
@@ -41,7 +44,7 @@ import {
   recordEchoServes,
   type ServeRecordPolicy,
 } from "./hashline/anchor-pipeline.js";
-import { loadServed, sessionKeyFor, scanDrift } from "./session-view.js";
+import { loadServed, sessionKeyFor, scanDrift, recordServedTruncated } from "./session-view.js";
 import { abortIf, splitLines } from "./utils.js";
 import { applyOne } from "./edit-engine.js";
 import {
@@ -244,7 +247,125 @@ export { genDiff, restoreEndings, toLF, stripBOM };
 export { computeDrift, scanDrift };
 export { trackNoopPayload, clearNoopLoop, noopPayloadKey };
 
-// --- Deep seam: unified mutation API (one interface, twoAdapters) ---
+// --- Deep seam: unified mutation API (one interface, thin adapters) ---
+
+/**
+ * Deep seam: execute the full mutation lifecycle.
+ *
+ * Owns: applySequence → branch (single/multi × noop/applied) → commit →
+ * buildBatchResult → recordServedTruncated → return text.
+ *
+ * The tool layer (adapter) only validates and resolves the nullable path; all
+ * lifecycle branching concentrates here (locality). One interface serves N
+ * call sites (leverage). Deleting this module would scatter the lifecycle
+ * across every tool — it concentrates (deep).
+ */
+export async function execute(opts: {
+  io: FileIO;
+  items: PreparedItem[];
+  sessionKey: string;
+  signal?: AbortSignal;
+  exec: ToolExecution;
+  sandbox: FsSandboxController;
+  sandboxPolicy: SandboxExecutionPolicy | undefined;
+}): Promise<string> {
+  const { io, items, sessionKey, signal, exec, sandbox, sandboxPolicy } = opts;
+
+  const fileResult = await applySequence(io, items, { signal, sessionKey });
+
+  const toSection = (): BatchSection => ({
+    path: fileResult.displayPath,
+    originalNormalized: fileResult.originalNormalized,
+    result: fileResult.result,
+    originalHashes: fileResult.originalHashes,
+    resultHashes: fileResult.resultHashes,
+    warnings: fileResult.warnings,
+    driftNotice: fileResult.driftNotice,
+    appliedCount: fileResult.appliedCount,
+    noopCount: fileResult.noopCount,
+    totalAddedLines: fileResult.totalAddedLines,
+    totalRemovedLines: fileResult.totalRemovedLines,
+  });
+
+  const recordIfNeeded = async (built: ReturnType<typeof buildBatchResult>) => {
+    if (built.details.servedRows && built.details.servedRows.length > 0) {
+      const entry = built.details.servedByPath?.[0];
+      if (entry) {
+        await recordServedTruncated(
+          sessionKey,
+          fileResult.absolutePath,
+          entry.servedRows,
+          splitLines(fileResult.result).length,
+          fileResult.range.startLine - 1,
+        );
+      }
+    }
+  };
+
+  const isSingleCall = items.length === 1 && fileResult.appliedCount + fileResult.noopCount === 1;
+
+  if (isSingleCall) {
+    if (fileResult.appliedCount === 0) {
+      const built = buildBatchResult([toSection()]);
+      await recordIfNeeded(built);
+      return built.content[0]!.text;
+    }
+    await commit({
+      io,
+      files: [
+        {
+          absolutePath: fileResult.absolutePath,
+          displayPath: fileResult.displayPath,
+          originalNormalized: fileResult.originalNormalized,
+          bom: fileResult.bom,
+          originalEnding: fileResult.originalEnding,
+          originalHashes: fileResult.originalHashes,
+          result: fileResult.result,
+        },
+      ],
+      exec,
+      sandbox,
+      sandboxPolicy,
+      signal,
+      undoUnavailableMessage: (displayPath) =>
+        `[E_UNDO_UNAVAILABLE] Cannot persist undo history to the hash store; the edit was NOT applied and ${displayPath} is unchanged. Retry the edit, or use write if the store cannot be recovered.`,
+      restoreUnwrittenUndos: true,
+    });
+    const built = buildBatchResult([toSection()]);
+    await recordIfNeeded(built);
+    return built.content[0]!.text;
+  }
+
+  if (fileResult.appliedCount === 0 && fileResult.noopCount > 0) {
+    // all noops — no commit
+  } else if (fileResult.appliedCount > 0) {
+    await commit({
+      io,
+      files: [
+        {
+          absolutePath: fileResult.absolutePath,
+          displayPath: fileResult.displayPath,
+          originalNormalized: fileResult.originalNormalized,
+          bom: fileResult.bom,
+          originalEnding: fileResult.originalEnding,
+          originalHashes: fileResult.originalHashes,
+          result: fileResult.result,
+        },
+      ],
+      exec,
+      sandbox,
+      sandboxPolicy,
+      signal,
+      undoUnavailableMessage: () =>
+        "[E_UNDO_UNAVAILABLE] Cannot persist undo history to the hash store; the batch was NOT applied and no file was written. Retry the batch, or use write if the store cannot be recovered.",
+      restoreUnwrittenUndos: false,
+    });
+  }
+
+  const built = buildBatchResult([toSection()]);
+  await recordIfNeeded(built);
+  return built.content[0]!.text;
+}
 
 /** Apply a single edit — owns read→normalize→loadServed→applyOne→stableRehash→drift. */
 export async function applySingle(

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -56,6 +56,12 @@ export const UNDO_GUIDANCE: ToolGuidance = {
   ],
 };
 
-// legacy exports removed — batch_edit guidance deleted (ADR-0007). Keep alias for test shims that import BATCH_EDIT_GUIDANCE
+/**
+ * @deprecated batch_edit guidance seam was removed with ADR-0003 (payload contract
+ * merged batch_edit into edit's {path, edits:[[hash,hash,text]]} arity). This alias
+ * is kept for backwards compat — use EDIT_DESCRIPTION. The guidance system no
+ * longer includes tool:batch_edit.
+ */
 export const BATCH_EDIT_DESCRIPTION = EDIT_DESCRIPTION;
+/** @deprecated see BATCH_EDIT_DESCRIPTION — use EDIT_GUIDANCE */
 export const BATCH_EDIT_GUIDANCE: ToolGuidance = EDIT_GUIDANCE;

--- a/src/tool-edit.ts
+++ b/src/tool-edit.ts
@@ -11,18 +11,9 @@ import { defineTool } from "@deepseek-ai/dsh-tools";
 import {
   normalizeRequest as normReq,
   assertEditRequest,
-  editPathSchema,
-  editTupleSchema,
 } from "./contract.js";
-import { abortIf, isRec, splitLines } from "./utils.js";
-import { EDITS_MAX_ITEMS } from "./constants.js";
-import {
-  applySequence,
-  commit,
-  resolveMissingPath,
-} from "./mutation.js";
-import { buildBatchResult, buildChanged, type BatchSection } from "./mutation.js";
-import { recordServedTruncated } from "./session-view.js";
+import { abortIf } from "./utils.js";
+import { execute } from "./mutation.js";
 import { EDIT_DESCRIPTION } from "./prompts.js";
 import type { FileIO } from "./fs-bridge.js";
 import { execCwd, execSessionKey } from "./session-view.js";
@@ -84,7 +75,6 @@ export function buildEditTool(io: FileIO, sandbox: FsSandboxController) {
         const signal = exec.signal;
 
         const canonical = normReq(args);
-        // normalizeRequest marks valid tuple payload with symbol; assert checks it
         assertEditRequest(canonical);
         const req = canonical as unknown as { path: string | null; edits: Array<{ remove_from: string; remove_to: string; replacement_text: string }> & { [key: symbol]: unknown } };
         let resolvedPath = req.path;
@@ -105,7 +95,6 @@ export function buildEditTool(io: FileIO, sandbox: FsSandboxController) {
         );
 
         abortIf(signal);
-        // Build PreparedItems for the single-file batch
         const items: PreparedItem[] = [];
         for (let index = 0; index < req.edits.length; index++) {
           const e = req.edits[index]!;
@@ -120,136 +109,8 @@ export function buildEditTool(io: FileIO, sandbox: FsSandboxController) {
           });
         }
 
-        // Single call handles both single and batch atomically
-        const fileResult = await applySequence(io, items, { signal, sessionKey });
-
-        // For single-edit ergonomics, render as single diff; for multi, batch result
-        if (req.edits.length === 1 && fileResult.appliedCount + fileResult.noopCount === 1) {
-          // If noop, fileResult contains noop metadata but applySequence already handled warnings
-          // Reuse mutation's single-file rendering path? Use batch result with one file for uniformity,
-          // but for single we want buildChanged semantics when not batch? The batch result also works for single
-          // but to preserve old single-edit output shape, branch:
-          if (fileResult.appliedCount === 0) {
-            // noop case — buildBatchResult will produce noop classification, which matches old batch noop but single expected buildNoop.
-            // Use batch result for simplicity — it is accepted as "noop" classification and passes tests that check for "Classification: noop"
-            const section: BatchSection = {
-              path: fileResult.displayPath,
-              originalNormalized: fileResult.originalNormalized,
-              result: fileResult.result,
-              originalHashes: fileResult.originalHashes,
-              resultHashes: fileResult.resultHashes,
-              warnings: fileResult.warnings,
-              driftNotice: fileResult.driftNotice,
-              appliedCount: fileResult.appliedCount,
-              noopCount: fileResult.noopCount,
-              totalAddedLines: fileResult.totalAddedLines,
-              totalRemovedLines: fileResult.totalRemovedLines,
-            };
-            // Commit nothing for noop (no write)
-            const result = buildBatchResult([section]);
-            if (result.details.servedRows && result.details.servedRows.length > 0) {
-              const entry = result.details.servedByPath?.[0];
-              if (entry) {
-                await recordServedTruncated(sessionKey, fileResult.absolutePath, entry.servedRows, splitLines(fileResult.result).length, fileResult.range.startLine - 1);
-              }
-            }
-            if (fileResult.warnings.length === 0 && result.details.warnings) {
-              // preserve warnings?
-            }
-            return result.content[0]!.text;
-          }
-          // applied single
-          await commit({
-            io,
-            files: [
-              {
-                absolutePath: fileResult.absolutePath,
-                displayPath: fileResult.displayPath,
-                originalNormalized: fileResult.originalNormalized,
-                bom: fileResult.bom,
-                originalEnding: fileResult.originalEnding,
-                originalHashes: fileResult.originalHashes,
-                result: fileResult.result,
-              },
-            ],
-            exec,
-            sandbox,
-            sandboxPolicy,
-            signal,
-            undoUnavailableMessage: (displayPath) => `[E_UNDO_UNAVAILABLE] Cannot persist undo history to the hash store; the edit was NOT applied and ${displayPath} is unchanged. Retry the edit, or use write if the store cannot be recovered.`,
-            restoreUnwrittenUndos: true,
-          });
-          const section: BatchSection = {
-            path: fileResult.displayPath,
-            originalNormalized: fileResult.originalNormalized,
-            result: fileResult.result,
-            originalHashes: fileResult.originalHashes,
-            resultHashes: fileResult.resultHashes,
-            warnings: fileResult.warnings,
-            driftNotice: fileResult.driftNotice,
-            appliedCount: fileResult.appliedCount,
-            noopCount: fileResult.noopCount,
-            totalAddedLines: fileResult.totalAddedLines,
-            totalRemovedLines: fileResult.totalRemovedLines,
-          };
-          const result = buildBatchResult([section]);
-          // batch result for single file is similar to buildChanged but we need to ensure served truncation
-          if (result.details.servedRows && result.details.servedRows.length > 0) {
-            const entry = result.details.servedByPath?.[0];
-            if (entry) {
-              await recordServedTruncated(sessionKey, fileResult.absolutePath, entry.servedRows, splitLines(fileResult.result).length, fileResult.range.startLine - 1);
-            }
-          }
-          return result.content[0]!.text;
-        }
-
-        // Multi-edit batch
-        if (fileResult.appliedCount === 0 && fileResult.noopCount > 0) {
-          // all noops — no commit
-        } else if (fileResult.appliedCount > 0) {
-          await commit({
-            io,
-            files: [
-              {
-                absolutePath: fileResult.absolutePath,
-                displayPath: fileResult.displayPath,
-                originalNormalized: fileResult.originalNormalized,
-                bom: fileResult.bom,
-                originalEnding: fileResult.originalEnding,
-                originalHashes: fileResult.originalHashes,
-                result: fileResult.result,
-              },
-            ],
-            exec,
-            sandbox,
-            sandboxPolicy,
-            signal,
-            undoUnavailableMessage: () => "[E_UNDO_UNAVAILABLE] Cannot persist undo history to the hash store; the batch was NOT applied and no file was written. Retry the batch, or use write if the store cannot be recovered.",
-            restoreUnwrittenUndos: false,
-          });
-        }
-
-        const section: BatchSection = {
-          path: fileResult.displayPath,
-          originalNormalized: fileResult.originalNormalized,
-          result: fileResult.result,
-          originalHashes: fileResult.originalHashes,
-          resultHashes: fileResult.resultHashes,
-          warnings: fileResult.warnings,
-          driftNotice: fileResult.driftNotice,
-          appliedCount: fileResult.appliedCount,
-          noopCount: fileResult.noopCount,
-          totalAddedLines: fileResult.totalAddedLines,
-          totalRemovedLines: fileResult.totalRemovedLines,
-        };
-        const result = buildBatchResult([section]);
-        if (result.details.servedRows && result.details.servedRows.length > 0) {
-          const entry = result.details.servedByPath?.[0];
-          if (entry) {
-            await recordServedTruncated(sessionKey, fileResult.absolutePath, entry.servedRows, splitLines(fileResult.result).length, fileResult.range.startLine - 1);
-          }
-        }
-        return result.content[0]!.text;
+        // Deep seam: one interface, all lifecycle branching concentrates in Mutation
+        return execute({ io, items, sessionKey, signal, exec, sandbox, sandboxPolicy });
       });
     },
   });

--- a/test/guidance.test.ts
+++ b/test/guidance.test.ts
@@ -24,7 +24,6 @@ import {
 	resolveSection,
 } from "../src/guidance.js";
 import {
-	BATCH_EDIT_GUIDANCE,
 	EDIT_GUIDANCE,
 	READ_GUIDANCE,
 	UNDO_GUIDANCE,
@@ -56,21 +55,19 @@ const bullets = (lines: readonly string[]) =>
 	lines.map((line) => `- ${line}`).join("\n");
 
 describe("guidance sections", () => {
-	it("exposes the four sections with stable order, file names, and defaults", () => {
+	it("exposes the three sections with stable order, file names, and defaults", () => {
 		expect(GUIDANCE_SECTIONS.map((s) => s.name)).toEqual([
 			"tool:read",
 			"tool:edit",
-			"tool:batch_edit",
 			"tool:undo_last_edit",
 		]);
 		expect(GUIDANCE_SECTIONS.map((s) => s.file)).toEqual([
 			"read.md",
 			"edit.md",
-			"batch_edit.md",
 			"undo_last_edit.md",
 		]);
 		expect(GUIDANCE_SECTIONS.map((s) => s.defaultOrder)).toEqual([
-			130, 131, 132, 133,
+			130, 131, 133,
 		]);
 	});
 
@@ -80,11 +77,6 @@ describe("guidance sections", () => {
 		);
 		expect(renderSectionDefault("tool:edit")).toBe(
 			[EDIT_GUIDANCE.intro, "", bullets(EDIT_GUIDANCE.lines)].join("\n"),
-		);
-		expect(renderSectionDefault("tool:batch_edit")).toBe(
-			[BATCH_EDIT_GUIDANCE.intro, "", bullets(BATCH_EDIT_GUIDANCE.lines)].join(
-				"\n",
-			),
 		);
 		expect(renderSectionDefault("tool:undo_last_edit")).toBe(
 			[UNDO_GUIDANCE.intro, "", bullets(UNDO_GUIDANCE.lines)].join("\n"),
@@ -411,16 +403,15 @@ describe("resolveSection", () => {
 });
 
 describe("composeSections", () => {
-	it("returns the four sections in default-order sequence", async () => {
+	it("returns the three sections in default-order sequence", async () => {
 		await withHome(async (home) => {
 			const sections = await composeSections(undefined, home);
 			expect(sections.map((s) => s.name)).toEqual([
 				"tool:read",
 				"tool:edit",
-				"tool:batch_edit",
 				"tool:undo_last_edit",
 			]);
-			expect(sections.map((s) => s.order)).toEqual([130, 131, 132, 133]);
+			expect(sections.map((s) => s.order)).toEqual([130, 131, 133]);
 			expect(sections.map((s) => s.text)).toEqual(
 				GUIDANCE_SECTIONS.map((s) => s.renderDefault()),
 			);
@@ -452,7 +443,7 @@ describe("composeSections", () => {
 });
 
 describe("ensurePresetGuidance", () => {
-	it("seeds each shipped preset with the four section files plus a root README", async () => {
+	it("seeds each shipped preset with the section files plus a root README", async () => {
 		await withHome(async (home) => {
 			await ensurePresetGuidance(home);
 			for (const preset of DEFAULT_PRESETS) {
@@ -615,7 +606,7 @@ describe("ensurePresetGuidance", () => {
 		});
 	});
 
-	it("re-seeds all four section files after a shipped preset dir is deleted", async () => {
+	it("re-seeds all section files after a shipped preset dir is deleted", async () => {
 		await withHome(async (home) => {
 			await ensurePresetGuidance(home);
 			await rm(join(home, "standard"), { recursive: true, force: true });


### PR DESCRIPTION
# Deepen Mutation + heal guidance ghost (C01 + C02)

Architecture review `architecture-review-1787241029.html` flagged two **Strong** deepening opportunities — both shipped together (disjoint files, one PR, two commits).

## C02 — heal guidance ghost

`batch_edit` was merged into `edit`'s payload contract `{path, edits:[[hash,hash,text]]}` in ADR-0003, but its guidance seam survived: `GUIDANCE_SECTIONS` listed `tool:batch_edit`, `prompts.ts` kept a bare alias, and `materialize.ts` seeded `batch_edit.md` per preset. Four seams where three tools exist.

- `src/guidance/resolve.ts`: `GUIDANCE_SECTIONS` 4→3 (remove `tool:batch_edit` + `BATCH_EDIT_GUIDANCE` import). JSDoc "four"→"three". Order gap 132 left intentional (131→133) to avoid churn for existing front-matter `order` values.
- `src/guidance/materialize.ts`: `GUIDANCE_HOME_README` + `ZH` 4→3 lines. Fix JSDoc `{read,edit,batch_edit,undo_last_edit}`→`{read,edit,undo_last_edit}`. Add `unlink` ghost cleanup for shipped (`DEFAULT_PRESETS`) + custom presets (best-effort, ignore `ENOENT`, idempotent, concurrent-safe).
- `src/prompts.ts` / `src/constants.ts`: keep `BATCH_EDIT_*` aliases but mark `@deprecated` with ADR-0003 pointer.
- `test/guidance.test.ts`: 4→3 expectations, remove `tool:batch_edit` render check.

Verification: `GUIDANCE_SECTIONS.length===3`, seeded files per preset `3`, orphan `batch_edit.md` deleted for both shipped and custom presets (temp-home integration), `rg batch_edit src/` shows only migration/`@deprecated`/historical comments.

## C01 — deepen Mutation (collapse tool-edit orchestrator)

`tool-edit` was a shallow orchestrator duplicating `Mutation`'s lifecycle: three branches (single/multi/noop), three commit paths, three `recordServedTruncated` calls. Bugs hid in duplicated branching. The payload contract change left the old single-vs-batch split fossilized in `tool-edit`.

- `src/mutation.ts`: add `execute({io, items, sessionKey, exec, sandbox, sandboxPolicy}) → text` — **ONE interface**. Owns `applySequence → isSingleCall branch → commit (correct `undoUnavailableMessage`/`restoreUnwrittenUndos`) → `buildBatchResult → recordServedTruncated → text`. Private helpers `toSection()` + `recordIfNeeded()` stay inside the seam. Header docs updated: *depth: small interface, large implementation — locality and leverage. Deletion test: deleting Mutation scatters the lifecycle.*
- `src/tool-edit.ts`: 260→121 lines. Thin **adapter**: `assertEditRequest` → `resolveNullPath` → build `PreparedItem[]` → single `return execute(...)`. Removed duplicated `BatchSection`/`commit`/`buildBatchResult` code.

Kept all prior exports (`applySequence`, `commit`, etc.) for backward compat.

## Verification

```
npm run typecheck  # pass
npm test           # 47 files, 674 passed
npm run build      # pass
```

Behaviour preserved: single edit (applied/noop), multi-edit atomic batch, all-noop batch, drift notice, served truncation, sandbox policy, `pathWarning`.

## Execution

Both candidates were built in **isolated git worktrees** via parallel `worker` subagents (`worktree:true`), each verified before merge. This PR integrates the two disjoint worktrees as two atomic commits on `arch/deepen-mutation-guidance`.

Closes #TBD
