### PR TITLE
fix: preserve UTF-8 BOM through edits (supersedes #26)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Entries link to the originating spec issue in [pi-hashline-edit-lsz](https://git
 
 ## [Unreleased]
 
+### Fixed
+
+- Preserve a stripped UTF-8 BOM across `ctx.fs`-backed `edit` and `undo_last_edit` writes while retaining the file's original line endings (#23).
+
 ## [0.3.1] - 2026-08-21
 
 ### Changed

--- a/src/fs-bridge.ts
+++ b/src/fs-bridge.ts
@@ -17,7 +17,7 @@
 
 import { readFile } from "node:fs/promises";
 import type { Context } from "@deepseek-ai/cordis";
-import type { FileSystem } from "@deepseek-ai/dsh-fs";
+import type { FileSystem, FsTarget } from "@deepseek-ai/dsh-fs";
 import type { ToolExecution } from "@deepseek-ai/dsh-tools";
 import type { SandboxExecutionPolicy } from "@deepseek-ai/dsh-sandbox";
 import { writeAtomic } from "./fs-write.js";
@@ -106,6 +106,44 @@ export function mapFsError(error: unknown, displayPath: string): never {
 	throw error;
 }
 
+/**
+ * Restore a UTF-8 BOM consumed by a backend's {@link TextDecoder}. The raw
+ * byte seam reads whole files rather than prefixes, so first use stat size to
+ * narrow the expensive probe to the only possible BOM case: exactly three
+ * storage bytes are missing from the decoded UTF-8 representation.
+ */
+async function restoreStrippedUtf8Bom(
+	fs: FileSystem,
+	target: FsTarget,
+	text: string,
+	signal?: AbortSignal,
+): Promise<string> {
+	if (text.startsWith("\uFEFF")) return text;
+
+	const info = await fs.stat(target, signal);
+	if (
+		info?.size === undefined ||
+		info.size !== Buffer.byteLength(text, "utf-8") + 3
+	) {
+		return text;
+	}
+
+	const bytes = await fs.readBytes(target, signal, info.size);
+	const encodedText = Buffer.from(text, "utf-8");
+	if (
+		bytes.length !== encodedText.length + 3 ||
+		bytes[0] !== 0xef ||
+		bytes[1] !== 0xbb ||
+		bytes[2] !== 0xbf
+	) {
+		return text;
+	}
+	for (let i = 0; i < encodedText.length; i += 1) {
+		if (bytes[i + 3] !== encodedText[i]) return text;
+	}
+	return `\uFEFF${text}`;
+}
+
 /** FileIO over the deployment's `ctx.fs` service. */
 export function ctxFsIO(fs: FileSystem, ctx: Context): FileIO {
 	return {
@@ -121,7 +159,8 @@ export function ctxFsIO(fs: FileSystem, ctx: Context): FileIO {
 				const target = await fs.resolve(absolutePath, {
 					...(signal !== undefined ? { signal } : {}),
 				});
-				return await fs.readText(target, signal);
+				const text = await fs.readText(target, signal);
+				return await restoreStrippedUtf8Bom(fs, target, text, signal);
 			} catch (error) {
 				return mapFsError(error, absolutePath);
 			}

--- a/src/fs-bridge.ts
+++ b/src/fs-bridge.ts
@@ -106,11 +106,21 @@ export function mapFsError(error: unknown, displayPath: string): never {
 	throw error;
 }
 
+const UTF8_BOM = "\uFEFF";
+const UTF8_BOM_BYTES = [0xef, 0xbb, 0xbf] as const;
+const UTF8_BOM_LEN = UTF8_BOM_BYTES.length;
+
 /**
  * Restore a UTF-8 BOM consumed by a backend's {@link TextDecoder}. The raw
  * byte seam reads whole files rather than prefixes, so first use stat size to
  * narrow the expensive probe to the only possible BOM case: exactly three
  * storage bytes are missing from the decoded UTF-8 representation.
+ *
+ * Compensation for upstream BOM stripping: `dsh-fs-local` decodes with
+ * `TextDecoder("utf-8",{fatal:true})` (`ignoreBOM:false` by default) and
+ * swallows leading `EF BB BF`.
+ * https://github.com/deepseek-ai/deepseek-harness/discussions/1026
+ * https://github.com/Rianico/dsh-better-edit/issues/23
  */
 async function restoreStrippedUtf8Bom(
 	fs: FileSystem,
@@ -118,12 +128,12 @@ async function restoreStrippedUtf8Bom(
 	text: string,
 	signal?: AbortSignal,
 ): Promise<string> {
-	if (text.startsWith("\uFEFF")) return text;
+	if (text.startsWith(UTF8_BOM)) return text;
 
 	const info = await fs.stat(target, signal);
 	if (
 		info?.size === undefined ||
-		info.size !== Buffer.byteLength(text, "utf-8") + 3
+		info.size !== Buffer.byteLength(text, "utf-8") + UTF8_BOM_LEN
 	) {
 		return text;
 	}
@@ -131,17 +141,17 @@ async function restoreStrippedUtf8Bom(
 	const bytes = await fs.readBytes(target, signal, info.size);
 	const encodedText = Buffer.from(text, "utf-8");
 	if (
-		bytes.length !== encodedText.length + 3 ||
-		bytes[0] !== 0xef ||
-		bytes[1] !== 0xbb ||
-		bytes[2] !== 0xbf
+		bytes.length !== encodedText.length + UTF8_BOM_LEN ||
+		bytes[0] !== UTF8_BOM_BYTES[0] ||
+		bytes[1] !== UTF8_BOM_BYTES[1] ||
+		bytes[2] !== UTF8_BOM_BYTES[2]
 	) {
 		return text;
 	}
 	for (let i = 0; i < encodedText.length; i += 1) {
-		if (bytes[i + 3] !== encodedText[i]) return text;
+		if (bytes[i + UTF8_BOM_LEN] !== encodedText[i]) return text;
 	}
-	return `\uFEFF${text}`;
+	return `${UTF8_BOM}${text}`;
 }
 
 /** FileIO over the deployment's `ctx.fs` service. */

--- a/test/core/edit-engine.e2e.test.ts
+++ b/test/core/edit-engine.e2e.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from "vitest";
-import { readFile } from "node:fs/promises";
+import { readFile, stat as nodeStat, writeFile } from "node:fs/promises";
+import { isAbsolute, resolve as resolvePath } from "node:path";
 import {
 	withTempFile,
+	withTempBytes,
 	setupIntegrationTest,
 	getText,
 } from "../support/fixtures.js";
+import { ctxFsIO, type FileIO } from "../../src/fs-bridge.js";
 
 type Tool = {
 	execute: (
@@ -26,6 +29,67 @@ function undoTool(
 }
 
 const CONTENT = "line one\nline two\nline three\n";
+
+/**
+ * Disk-backed ctx.fs double with the host decoder's BOM-stripping semantics.
+ * Raw reads enforce the real API's whole-file maxBytes contract.
+ */
+function bomStrippingCtxIO(): FileIO {
+	const fs = {
+		sandboxMode: undefined,
+		resolve: async (path: string, opts?: { cwd?: string }) => {
+			const absolutePath = isAbsolute(path)
+				? path
+				: resolvePath(opts?.cwd ?? process.cwd(), path);
+			return { targetKey: absolutePath, displayPath: absolutePath };
+		},
+		processPath: (target: { displayPath: string }) => target.displayPath,
+		readText: async (target: { displayPath: string }) =>
+			new TextDecoder("utf-8", { fatal: true }).decode(
+				await readFile(target.displayPath),
+			),
+		readBytes: async (
+			target: { displayPath: string },
+			signal: AbortSignal | undefined,
+			maxBytes: number,
+		) => {
+			signal?.throwIfAborted();
+			const bytes = await readFile(target.displayPath);
+			if (bytes.length > maxBytes) {
+				throw Object.assign(new Error("file exceeds byte limit"), {
+					code: "FS_TOO_LARGE",
+				});
+			}
+			return bytes;
+		},
+		stat: async (target: { displayPath: string }) => {
+			const info = await nodeStat(target.displayPath);
+			return {
+				version: `${info.mtimeMs}:${info.size}`,
+				type: "file",
+				size: info.size,
+			};
+		},
+		writeText: async (
+			target: { displayPath: string },
+			content: string,
+		) => {
+			await writeFile(target.displayPath, content, "utf-8");
+			const info = await nodeStat(target.displayPath);
+			return {
+				version: `${info.mtimeMs}:${info.size}`,
+				operation: "update",
+				before: null,
+				after: content,
+			};
+		},
+	};
+	const ctx = {
+		waterfall: async () => undefined,
+		emit: () => undefined,
+	};
+	return ctxFsIO(fs as never, ctx as never);
+}
 
 /** Read through the hashline `read` tool so anchors are served, then parse rows. */
 async function servedRows(
@@ -100,6 +164,31 @@ describe("edit-sequence engine — end-to-end through the tool builders", () => 
 			const res = await undoTool(harness).execute("undo_last_edit", { path: "t.txt" });
 			expect(getText(res)).toContain("Undone last edit on t.txt.");
 			expect(await readFile(path, "utf-8")).toBe(CONTENT);
+		});
+	});
+
+	it("ctxFsIO preserves exact UTF-8 BOM and CRLF bytes through edit and undo", async () => {
+		const original = Buffer.from("\uFEFFline one\r\nline two\r\n", "utf-8");
+		await withTempBytes("t.txt", original, async ({ cwd, path }) => {
+			const harness = setupIntegrationTest(cwd, bomStrippingCtxIO());
+			const served = await servedRows(harness, "t.txt");
+			const one = served.find((r) => r.content === "line one")!;
+
+			await harness.editTool.execute("edit", {
+				path: "t.txt",
+				remove_from: one.hash,
+				remove_to: one.hash,
+				replacement_text: "line ONE",
+			});
+			expect(await readFile(path)).toEqual(
+				Buffer.from("\uFEFFline ONE\r\nline two\r\n", "utf-8"),
+			);
+
+			const res = await undoTool(harness).execute("undo_last_edit", {
+				path: "t.txt",
+			});
+			expect(getText(res)).toContain("Undone last edit on t.txt.");
+			expect(await readFile(path)).toEqual(original);
 		});
 	});
 

--- a/test/core/fs-bridge.policy.test.ts
+++ b/test/core/fs-bridge.policy.test.ts
@@ -21,6 +21,7 @@ function makeFs(overrides: Partial<Record<string, unknown>> = {}) {
 		})),
 		processPath: vi.fn(() => "/abs/file.txt"),
 		readText: vi.fn(async () => "hello\n"),
+		readBytes: vi.fn(async () => new Uint8Array()),
 		writeText: vi.fn(async () => ({
 			version: "v2",
 			operation: "update",
@@ -61,6 +62,124 @@ function makeCtx() {
 }
 
 const exec = { agent: { session: { id: "sess-1" } } } as never;
+
+describe("ctxFsIO readText", () => {
+	it("restores a UTF-8 BOM stripped by the backend decoder", async () => {
+		const text = "hello\r\n";
+		const bytes = Buffer.from(`\uFEFF${text}`, "utf-8");
+		const { fs } = makeFs({
+			readText: vi.fn(async () => text),
+			stat: vi.fn(async () => ({
+				version: "v1",
+				type: "file",
+				size: bytes.length,
+			})),
+			readBytes: vi.fn(async () => bytes),
+		});
+		const { ctx } = makeCtx();
+		const io: FileIO = ctxFsIO(fs as never, ctx);
+
+		await expect(io.readText("/abs/file.txt")).resolves.toBe(`\uFEFF${text}`);
+		expect(fs.readBytes).toHaveBeenCalledWith(
+			expect.objectContaining({ targetKey: "tk-1" }),
+			undefined,
+			bytes.length,
+		);
+	});
+
+	it("does not read raw bytes when stat size matches the decoded UTF-8 text", async () => {
+		const text = "hello\r\n";
+		const { fs } = makeFs({
+			readText: vi.fn(async () => text),
+			stat: vi.fn(async () => ({
+				version: "v1",
+				type: "file",
+				size: Buffer.byteLength(text, "utf-8"),
+			})),
+		});
+		const { ctx } = makeCtx();
+		const io: FileIO = ctxFsIO(fs as never, ctx);
+
+		await expect(io.readText("/abs/file.txt")).resolves.toBe(text);
+		expect(fs.readBytes).not.toHaveBeenCalled();
+	});
+
+	it("does not invent a BOM when the three-byte size gap is not a BOM", async () => {
+		const text = "hello\n";
+		const bytes = Buffer.from(`xyz${text}`, "utf-8");
+		const { fs } = makeFs({
+			readText: vi.fn(async () => text),
+			stat: vi.fn(async () => ({
+				version: "v1",
+				type: "file",
+				size: bytes.length,
+			})),
+			readBytes: vi.fn(async () => bytes),
+		});
+		const { ctx } = makeCtx();
+		const io: FileIO = ctxFsIO(fs as never, ctx);
+
+		await expect(io.readText("/abs/file.txt")).resolves.toBe(text);
+		expect(fs.readBytes).toHaveBeenCalledOnce();
+	});
+
+	it("does not restore a BOM when the file changes between decoded and raw reads", async () => {
+		const text = "hello\n";
+		const changedBytes = Buffer.from("\uFEFFjello\n", "utf-8");
+		const { fs } = makeFs({
+			readText: vi.fn(async () => text),
+			stat: vi.fn(async () => ({
+				version: "v1",
+				type: "file",
+				size: changedBytes.length,
+			})),
+			readBytes: vi.fn(async () => changedBytes),
+		});
+		const { ctx } = makeCtx();
+		const io: FileIO = ctxFsIO(fs as never, ctx);
+
+		await expect(io.readText("/abs/file.txt")).resolves.toBe(text);
+		expect(fs.readBytes).toHaveBeenCalledOnce();
+	});
+
+	it("propagates stat failures from the integrity probe", async () => {
+		const error = new Error("stat failed");
+		const { fs } = makeFs({ stat: vi.fn(async () => Promise.reject(error)) });
+		const { ctx } = makeCtx();
+		const io: FileIO = ctxFsIO(fs as never, ctx);
+
+		await expect(io.readText("/abs/file.txt")).rejects.toBe(error);
+	});
+
+	it("propagates raw-read failures for BOM candidates", async () => {
+		const text = "hello\n";
+		const error = new Error("raw read failed");
+		const { fs } = makeFs({
+			readText: vi.fn(async () => text),
+			stat: vi.fn(async () => ({
+				version: "v1",
+				type: "file",
+				size: Buffer.byteLength(text, "utf-8") + 3,
+			})),
+			readBytes: vi.fn(async () => Promise.reject(error)),
+		});
+		const { ctx } = makeCtx();
+		const io: FileIO = ctxFsIO(fs as never, ctx);
+
+		await expect(io.readText("/abs/file.txt")).rejects.toBe(error);
+	});
+
+	it("keeps a BOM already preserved by the backend without probing metadata", async () => {
+		const text = "\uFEFFhello\n";
+		const { fs } = makeFs({ readText: vi.fn(async () => text) });
+		const { ctx } = makeCtx();
+		const io: FileIO = ctxFsIO(fs as never, ctx);
+
+		await expect(io.readText("/abs/file.txt")).resolves.toBe(text);
+		expect(fs.stat).not.toHaveBeenCalled();
+		expect(fs.readBytes).not.toHaveBeenCalled();
+	});
+});
 
 describe("ctxFsIO writeText", () => {
 	it("dispatches fs/write-intent with (target, exec, default) and passes the returned intent to writeText", async () => {

--- a/test/support/fixtures.ts
+++ b/test/support/fixtures.ts
@@ -214,8 +214,7 @@ function makeTestSandbox() {
 }
 
 /** Drive the dsh tool builders end-to-end over a temp cwd, with a stable session key. */
-export function setupIntegrationTest(cwd: string) {
-	const io: FileIO = localIO();
+export function setupIntegrationTest(cwd: string, io: FileIO = localIO()) {
 	const sessionKey = "test-session";
 	const makeExecFor = makeExec(cwd, sessionKey);
 	const sandbox = makeTestSandbox();


### PR DESCRIPTION
Supersedes #26 — same intent, hardened to respect `readBytes` contract (stat-gated, whole-file bounded read, byte-verified, fail-loud) with refinement.

Refinement in this superseder:
- extract hardcoded BOM bytes/char `EF BB BF`/`\uFEFF`/`3` into `UTF8_BOM`, `UTF8_BOM_BYTES`, `UTF8_BOM_LEN`
- annotate compensation for upstream `dsh-fs-local` `TextDecoder("utf-8",{fatal:true})` (`ignoreBOM:false` swallows `EF BB BF`) with links to upstream discussion and issue
- preserve original restoration logic and tests from #26

Upstream: https://github.com/deepseek-ai/deepseek-harness/discussions/1026
Issue: https://github.com/Rianico/dsh-better-edit/issues/23

Original PR: #26 by @Jstn-1g (f73fdfc)
Fixup: 36379ce (this branch)

Supersedes #26
Closes #23