### PR TITLE
fix: block served hash echoes in write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Entries link to the originating spec issue in [pi-hashline-edit-lsz](https://git
 
 ## [Unreleased]
 
+### Fixed
+
+- Refuse a built-in `write` before dispatch when a candidate line starts with the exact hashline anchor served for the same session, canonical path, and line. This prevents copied `HASH│` preview chains from entering Markdown while leaving the file byte-identical; unrelated hash-like text is not generically stripped (#29).
+
 ## [0.4.0] - 2026-08-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -255,6 +255,8 @@ Both engines preserved the external change and produced the expected final file 
 | `edit` | An object-root payload `{ "path": path, "edits": [[remove_from, remove_to, replacement_text], …] }`; the path may be `null` for anchor-based inference. A single item edits one range; several items batch same-file edits atomically (up to 32). Verifies every line of each inclusive range and reject-and-serve returns fresh anchors. |
 | `undo_last_edit` | `{ path }` restores the most recent successful edit with its original content, BOM, line endings, and anchors; persisted across restarts. |
 
+The built-in `write` remains available for full-file replacement. Before it runs, the plugin refuses only a candidate line that begins with the exact `HASH│` anchor served for the same session, canonical path, and line; the file stays unchanged and the response asks for a retry with file content only. It never generically strips hash-like text.
+
 `edit` accepts `{ "path": path, "edits": [[remove_from, remove_to, replacement_text], …] }`. The path
 position is a non-empty string or `null` for unique anchor-based inference. Each range is inclusive,
 and an empty replacement deletes the range. All items are checked before file I/O and applied
@@ -276,6 +278,7 @@ atomically to that one file — one item per call is the norm, several same-file
 | `[E_ACCESS]` | The path is not readable or writable. |
 | `[E_NOT_TEXT]` | The path is a directory, binary file, image, or UTF-16/UTF-32 encoded text; hashline editing only supports text files. |
 | `[E_NOT_OBSERVED]` | The file has not been observed in this session (read-before-write); call `read` first. |
+| `[E_WRITE_HASH_ECHO]` | A built-in `write` candidate copied a `HASH│` preview anchor served for the same session, path, and line. The write is refused before dispatch; remove the entire copied anchor chain and retry. |
 | `[E_UNDO_STALE]` | `undo_last_edit` refused: the file was modified or deleted after the last edit. |
 | `[E_UNDO_UNAVAILABLE]` | Undo history could not be persisted to the hash store; the `edit` was refused and the file was left unchanged. |
 | `[E_FILE_TOO_LARGE]` | The file exceeds the 238,328-line hashline limit. |
@@ -414,8 +417,9 @@ registration cannot replace them. This plugin:
 2. On `agent/session-start`, registers the hashline tools **and** the `tool:read` / `tool:edit`
    prompt sections on the agent's own scope layer — they shadow the preset's built-ins for that
    agent and unwind automatically when the agent is disposed.
-3. Leaves the built-in `write` in place, but a scoped `tools/post-execute` listener appends the
-   hashline auto-read to write results.
+3. Leaves the built-in `write` in place: a scoped `tools/pre-execute` listener rejects an exact
+   same-session/path/line served-anchor echo before dispatch, and `tools/post-execute` appends the
+   hashline auto-read to successful results.
 
 ## Store
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -267,6 +267,8 @@ token 基准测试衡量的是模型发出的负载——它假设模型每次�
 | `edit` | 对象根负载 `{ "path": path, "edits": [[remove_from, remove_to, replacement_text], …] }`；`path` 可为 `null` 以通过锚点推断。单个条目编辑一个范围；多条目对同一文件原子批量（最多 32）。对每个包含范围内的每一行校验，reject-and-serve 返回新锚点。 |
 | `undo_last_edit` | `{ path }` 撤销该文件上一次 hashline 编辑，仅当文件仍与存储的编辑后内容一致时生效；重启后依然有效。 |
 
+内置 `write` 仍用于整文件替换。执行前，插件只会在候选行以同一会话、规范路径及行位置所提供的精确 `HASH│` 锚点开头时拒绝；文件保持不变，并提示仅用文件正文重试。插件不会泛化地剥离类似哈希的文本。
+
 ### 错误码
 
 | 代码 | 含义 |
@@ -284,6 +286,7 @@ token 基准测试衡量的是模型发出的负载——它假设模型每次�
 | `[E_NOT_FOUND]` | 文件不存在。 |
 | `[E_NOT_OBSERVED]` | 该文件在本会话中尚未被观察（先读后写策略）；请先调用 `read`。 |
 | `[E_NOT_TEXT]` | 路径是目录、二进制或非 UTF-8 文件；hashline 只能编辑文本。 |
+| `[E_WRITE_HASH_ECHO]` | 内置 `write` 候选内容复制了同一会话、路径及行位置所提供的 `HASH│` 预览锚点。写入在执行前被拒绝；移除整条复制的锚点链后重试。 |
 | `[E_RANGE_STALE]` | 某行自被读取以来在磁盘上发生变化；范围以全新锚点回显。 |
 | `[E_RANGE_UNSERVED]` | 范围内包含从未提供给模型的行。 |
 | `[E_RANGE_UNVERIFIED]` | 边界锚点无法对照已提供状态验证。 |
@@ -298,7 +301,7 @@ dsh 的工具注册表按作用域解析：agent 看到的是 `agent → preset 
 
 1. 通过其 `cordis.patch.yml` bundle 补丁作为宿主层 Cordis 插件挂载。
 2. 在 `agent/session-start` 时，将 hashline 工具**以及** `tool:read` / `tool:edit` 提示词片段注册到 agent 自身的作用域层——从而为该 agent 遮蔽 preset 的内置工具，并在 agent 销毁时自动解除。
-3. 保留内置的 `write`，但通过一个作用域内的 `tools/post-execute` 监听器把 hashline 自动读取附加到 write 结果之后。
+3. 保留内置的 `write`，通过作用域内的 `tools/pre-execute` 监听器在执行前拒绝精确的同会话/同路径/同行锚点回显，并由 `tools/post-execute` 在成功结果后附加 hashline 自动读取。
 
 ## 存储
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,8 +7,8 @@
  * the AGENT's own scope layer, so they shadow the preset's built-in `read` /
  * `edit` for that agent (nearest layer wins in dsh's tool registry) and unwind
  * automatically when the agent is disposed. The built-in `write` stays in
- * place; a scoped `tools/post-execute` listener appends the fresh hashline
- * preview to write results.
+ * place; scoped pre/post listeners reject copied same-line served anchors
+ * before dispatch and append a fresh hashline preview after successful writes.
  *
  * The four `tool:*` guidance sections resolve per agent preset from override
  * files in the shared home (see `src/guidance.ts`); deployments without the

--- a/src/write-hook.ts
+++ b/src/write-hook.ts
@@ -1,25 +1,80 @@
 /**
- * Auto-read after `write`: when the built-in `write` tool succeeds, this scoped
- * `tools/post-execute` listener re-reads the written file and appends a fresh
- * hashline-anchored preview to the model-facing content, so the model gets new
- * anchors without an explicit read call (mirroring pi-hashline-edit-lsz).
+ * Guard + auto-read around `write`: a scoped `tools/pre-execute` listener
+ * rejects copied hashline preview rows before they can reach disk, then a
+ * `tools/post-execute` listener re-reads successful writes and appends fresh
+ * anchors to the model-facing content (mirroring pi-hashline-edit-lsz).
  * @module dsh-better-edit/write-hook
  */
 
 import type { Context } from '@deepseek-ai/cordis'
-import type { PostToolDecision, ToolExecution, ToolExecutionResult } from '@deepseek-ai/dsh-tools'
+import type { PostToolDecision, PreToolDecision, ToolExecution, ToolExecutionResult } from '@deepseek-ai/dsh-tools'
 import { readAndServe } from './read-and-serve.js'
 import type { FileIO } from './fs-bridge.js'
-import { execCwd, execSessionKey } from './session-view.js'
-import { withWorkspace } from './session-view.js'
+import { execCwd, execSessionKey, loadServed, withWorkspace } from './session-view.js'
+import { HASH_SEP } from './hashline/hash-assign.js'
+import { abortIf, splitLines } from './utils.js'
 
 const AUTO_READ_HEADING = '--- Auto-read (hashline anchors) ---'
 
+export interface ServedHashEcho {
+	/** One-based candidate line carrying the copied anchor. */
+	line: number
+	/** The exact anchor served for this session, path, and line. */
+	hash: string
+}
+
 /**
- * Register the post-write auto-read listener on the calling agent's scope.
- * Replaces the result content (never the canonical value) with the original
- * content plus the hashline preview; any failure falls back to the untouched
- * decision so a broken auto-read never breaks the write.
+ * Find a copied hashline prefix without treating arbitrary `3-char│` text as
+ * metadata. A match requires the exact hash currently recorded at the same
+ * line position for this session and canonical path.
+ */
+export function findServedHashEcho(
+	content: string,
+	served: readonly (string | null)[],
+): ServedHashEcho | undefined {
+	const lines = splitLines(content)
+	const compared = Math.min(lines.length, served.length)
+	for (let index = 0; index < compared; index += 1) {
+		const hash = served[index]
+		if (hash !== null && lines[index]!.startsWith(`${hash}${HASH_SEP}`)) {
+			return { line: index + 1, hash }
+		}
+	}
+	return undefined
+}
+
+/**
+ * Inspect one validated-looking built-in write request against session-scoped
+ * served state. Returns a pre-dispatch denial reason only for an exact
+ * same-session / same-canonical-path / same-line anchor echo.
+ */
+export async function servedHashEchoDenial(
+	io: FileIO,
+	rawPath: string,
+	content: string,
+	cwd: string,
+	sessionKey: string,
+	signal?: AbortSignal,
+): Promise<string | undefined> {
+	abortIf(signal)
+	const absolutePath = await io.resolve(rawPath, cwd, signal)
+	abortIf(signal)
+	const served = await loadServed(sessionKey, absolutePath)
+	const match = findServedHashEcho(content, served)
+	if (!match) return undefined
+	return (
+		`[E_WRITE_HASH_ECHO] Refused write to ${rawPath}: line ${match.line} begins with ` +
+		`the exact ${match.hash}${HASH_SEP} anchor served for this session, path, and line. ` +
+		`HASH${HASH_SEP} anchors are tool output, not file content. ` +
+		'Retry with file content only (remove the entire copied anchor chain). Nothing was written.'
+	)
+}
+
+/**
+ * Register the pre-write echo guard and post-write auto-read on the calling
+ * agent's scope. The guard denies before dispatch; the auto-read replaces only
+ * model-facing result content (never the canonical value). Infrastructure
+ * failures fail open so the plugin never breaks an otherwise valid write.
  * @param rootCtx - host context for diagnostics.
  * @param agentCtx - the agent's scoped context; the listener receives only
  *   this agent's tool results.
@@ -31,7 +86,41 @@ export function registerWriteHook(
 	agentCtx: Context,
 	io: FileIO,
 ): () => void {
-	return agentCtx.on(
+	const disposeGuard = agentCtx.on(
+		'tools/pre-execute',
+		async (
+			exec: ToolExecution,
+			next: () => Promise<PreToolDecision>,
+		): Promise<PreToolDecision> => {
+			if (exec.name !== 'write') return next()
+			const args = exec.arguments as Record<string, unknown> | undefined
+			const rawPath = args?.file_path ?? args?.path
+			const content = args?.content
+			if (typeof rawPath !== 'string' || typeof content !== 'string') return next()
+
+			const cwd = execCwd(exec)
+			return withWorkspace(cwd, async () => {
+				try {
+					const reason = await servedHashEchoDenial(
+						io,
+						rawPath,
+						content,
+						cwd,
+						execSessionKey(exec),
+						exec.signal,
+					)
+					return reason === undefined ? next() : { kind: 'deny', reason }
+				} catch (error) {
+					if (exec.signal.aborted) throw error
+					rootCtx.logger.warn(
+						`dsh-better-edit: pre-write hash-echo guard failed open: ${error instanceof Error ? error.message : String(error)}`,
+					)
+					return next()
+				}
+			})
+		},
+	)
+	const disposeAutoRead = agentCtx.on(
 		'tools/post-execute',
 		async (
 			exec: ToolExecution,
@@ -75,4 +164,8 @@ export function registerWriteHook(
 			})
 		},
 	)
+	return () => {
+		disposeGuard()
+		disposeAutoRead()
+	}
 }

--- a/test/core/write-hook.hash-echo.test.ts
+++ b/test/core/write-hook.hash-echo.test.ts
@@ -1,0 +1,162 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { Context } from "@deepseek-ai/cordis";
+import type {
+	PreToolDecision,
+	ToolExecution,
+} from "@deepseek-ai/dsh-tools";
+import { describe, expect, it, vi } from "vitest";
+import { readAndServe } from "../../src/read-and-serve.js";
+import { withWorkspace } from "../../src/session-view.js";
+import {
+	findServedHashEcho,
+	registerWriteHook,
+	servedHashEchoDenial,
+} from "../../src/write-hook.js";
+import { localIO } from "../../src/fs-bridge.js";
+import { withTempDir } from "../support/fixtures.js";
+
+type PreExecuteListener = (
+	exec: ToolExecution,
+	next: () => Promise<PreToolDecision>,
+) => Promise<PreToolDecision>;
+
+describe("write hash-echo guard", () => {
+	it("allows clean content and unrelated literal hash-like text", () => {
+		const served = ["Ab3", "Cd4", null];
+		expect(findServedHashEcho("# Notes\nbody\n", served)).toBeUndefined();
+		expect(
+			findServedHashEcho("Zz9│literal protocol text\nbody\n", served),
+		).toBeUndefined();
+		expect(
+			findServedHashEcho("prefix Ab3│is ordinary text\nbody\n", served),
+		).toBeUndefined();
+	});
+
+	it("matches only the exact served anchor at the same line", () => {
+		const served = ["Ab3", "Cd4"];
+		expect(findServedHashEcho("Ab3│# Notes\nbody\n", served)).toEqual({
+			line: 1,
+			hash: "Ab3",
+		});
+		expect(
+			findServedHashEcho("Cd4│wrong line\nAb3│wrong line\n", served),
+		).toBeUndefined();
+	});
+
+	it("catches a repeated historical chain when its outer anchor is current", () => {
+		expect(
+			findServedHashEcho("Ab3│nT2│CCd│UIA│## 1. H1\n", ["Ab3"]),
+		).toEqual({ line: 1, hash: "Ab3" });
+	});
+
+	it("rejects a copied current preview before the write body can change disk", async () => {
+		await withTempDir("write-hash-echo-red-", async (cwd) => {
+			const path = join(cwd, "notes.md");
+			const original = "# Notes\nbody\n";
+			await writeFile(path, original, "utf-8");
+			const beforeBytes = await readFile(path);
+
+			const io = localIO();
+			const sessionKey = "session-a";
+			const preview = await withWorkspace(cwd, () =>
+				readAndServe(io, path, cwd, { sessionKey }),
+			);
+			const listeners = new Map<string, unknown>();
+			const agentCtx = {
+				on(event: string, listener: unknown) {
+					listeners.set(event, listener);
+					return () => undefined;
+				},
+			} as unknown as Context;
+			const rootCtx = {
+				logger: { warn: vi.fn() },
+			} as unknown as Context;
+			registerWriteHook(rootCtx, agentCtx, io);
+
+			const listener = listeners.get("tools/pre-execute") as
+				| PreExecuteListener
+				| undefined;
+			expect(listener).toBeDefined();
+			if (!listener) return;
+
+			const next = vi.fn(async (): Promise<PreToolDecision> => ({
+				kind: "allow",
+			}));
+			const decision = await listener(
+				{
+					name: "write",
+					arguments: { file_path: path, content: preview.text },
+					signal: new AbortController().signal,
+					agent: {
+						id: sessionKey,
+						session: { id: sessionKey, header: { cwd } },
+					},
+				} as unknown as ToolExecution,
+				next,
+			);
+
+			expect(decision).toMatchObject({ kind: "deny" });
+			expect(
+				(decision as { reason?: string }).reason,
+			).toContain("[E_WRITE_HASH_ECHO]");
+			expect(next).not.toHaveBeenCalled();
+			expect(await readFile(path)).toEqual(beforeBytes);
+
+			const cleanNext = vi.fn(
+				async (): Promise<PreToolDecision> => ({ kind: "allow" }),
+			);
+			const cleanDecision = await listener(
+				{
+					name: "write",
+					arguments: { file_path: path, content: "# Updated\nbody\n" },
+					signal: new AbortController().signal,
+					agent: {
+						id: sessionKey,
+						session: { id: sessionKey, header: { cwd } },
+					},
+				} as unknown as ToolExecution,
+				cleanNext,
+			);
+			expect(cleanDecision).toEqual({ kind: "allow" });
+			expect(cleanNext).toHaveBeenCalledOnce();
+			expect(await readFile(path)).toEqual(beforeBytes);
+		});
+	});
+
+	it("does not reuse served state across sessions or canonical paths", async () => {
+		await withTempDir("write-hash-echo-scope-", async (cwd) => {
+			const io = localIO();
+			const servedPath = join(cwd, "served.md");
+			const otherPath = join(cwd, "other.md");
+			await writeFile(servedPath, "served line\n", "utf-8");
+			await writeFile(otherPath, "other line\n", "utf-8");
+			const preview = await withWorkspace(cwd, () =>
+				readAndServe(io, servedPath, cwd, { sessionKey: "session-a" }),
+			);
+
+			await expect(
+				withWorkspace(cwd, () =>
+					servedHashEchoDenial(
+						io,
+						servedPath,
+						preview.text,
+						cwd,
+						"session-b",
+					),
+				),
+			).resolves.toBeUndefined();
+			await expect(
+				withWorkspace(cwd, () =>
+					servedHashEchoDenial(
+						io,
+						otherPath,
+						preview.text,
+						cwd,
+						"session-a",
+					),
+				),
+			).resolves.toBeUndefined();
+		});
+	});
+});


### PR DESCRIPTION
Closes #29.

## What changed

- add a pre-dispatch guard for built-in `write`
- deny only when a candidate line starts with the exact `HASH│` anchor already served for the same session, canonical path, and line
- leave the file byte-identical and ask the model to retry without the copied anchor chain
- never generically strip hash-like text
- document the error contract in English and Chinese

The same-line binding is intentional to avoid false positives. Shifted or reordered copied preview rows remain outside this bounded fix.

## Verification

- regression reproduced red before the guard
- focused guard/error-contract tests: 7/7 passed
- unaffected tests: 581 passed, 5 skipped
- typecheck and build passed
- full Windows-suite failures match unchanged upstream's existing path/store-isolation failures; this patch adds none

Exact head: `c66926022b0aca263302af52b6e47a9afd8bf6b5`