### PR TITLE
absorb: pi-better-edit f94fb88..6ec52f2 — one-by-one heal, fs-write, prompt, hash-echo, drift

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -1,0 +1,39 @@
+# Worktrunk project template — copy to .config/wt.toml and customize per project
+# This project config overrides ~/.config/worktrunk/config.toml (global).
+# See worktrunk-guide skill: worktrunk-guide/references/automation.md
+# Usage: wt config create --project && merge this template into .config/wt.toml
+
+[post-start]
+# Copy gitignored artifacts (node_modules, target, .cache) between worktrees — avoids cold start.
+copy = "wt step copy-ignored"
+
+[pre-merge]
+# Blocking gate — wt merge runs this before merging worktree into parent/main.
+# Authoritative for this skill: every merge must pass this gate.
+# Default recommendation: typecheck + tests + commitlint (conventional commits since base).
+# commitlint checks header/body/footer per Conventional Commits 1.0.0 — fail loud before squash.
+# Uses origin/{{ default_branch }} so fork's base may be remote; for local-only, use {{ target }}.
+gate = "npm run typecheck && npm test && npx commitlint --from=origin/{{ default_branch }} --to=HEAD --verbose"
+# Pipeline form for concurrent steps (wt 0.58+: table = concurrent, [[ ]] = serial):
+# [[pre-merge]]
+# typecheck = "npm run typecheck"
+# test = "npm test"
+# lint-msg = "npx commitlint --from=origin/{{ default_branch }} --to=HEAD --verbose"
+# Examples for other stacks:
+# gate = "cargo test && cargo clippy && npx commitlint --from=origin/{{ default_branch }} --to=HEAD --verbose"
+# gate = "uv run pytest && ruff check . && npx commitlint --from=origin/{{ default_branch }} --to=HEAD --verbose"
+
+[list]
+# Per-worktree dev server URL preview in `wt list` — hash_port assigns 10000–19999 from branch hash.
+
+url = "http://localhost:{{ branch | hash_port }}"
+
+[pre-remove]
+# Cleanup per-worktree dev server on `wt remove` — prevents port leak.
+cleanup = "lsof -ti :{{ branch | hash_port }} | xargs kill 2>/dev/null || true"
+
+# [post-start] per-worktree dev server (optional — uncomment if needed):
+# [post-start]
+# server = "npm run dev -- --port {{ branch | hash_port }}"
+
+# [post-merge] / [post-remove] hooks — add project-specific post actions as needed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,17 @@ Entries link to the originating spec issue in [pi-hashline-edit-lsz](https://git
 
 ### Features
 
+- **edit:** route drift signals to user-facing details (pi-better-edit@6ec52f2)
 - scaffold verify→release with biome+coverage 80%
 
 ### Bug Fixes
 
+- **tests:** align drift expectations with user-facing routing (6ec52f2)
+- **hashline:** add E_EDIT_HASH_ECHO guard for served echo (pi-better-edit@65b8eb1)
+- clarify HASH vs content without served
+- **edit:** clarify HASH vs HASH│content and downgrade bare prefix warnings (pi-better-edit@a837e9d)
+- **fs-write:** log stale-temp and sync failures (pi-better-edit@671c66d)
+- **hashline:** heal multi-line staleness and stable anchoring (f94fb88)
 - **git:** wire pre-push hook via husky path
 
 ## [0.4.1] - 2026-08-27

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -101,6 +101,18 @@ _Avoid_: optional path
 A fixed three-position JSON array `[remove_from, remove_to, replacement_text]` — one edit item inside the payload's `edits` array, the model-facing unit of mutation. The path is not part of the item; it is hoisted to the payload root.
 _Avoid_: patch language, array shorthand
 
+**served hash echo**:
+A candidate line that begins with the exact `HASH│` anchor served for the same session, canonical path, and line — tool output mistaken for file content. For `write` the check is absolute line `i` vs `served[i]`; for `edit` it is range-relative line `k` vs `served[startLine + k]` (AA: E1). Detected before dispatch/write, file stays byte-identical. Not a generic `^[A-Za-z0-9]{3}│` strip.
+_Avoid_: hash echo (without served qualification), anchor echo
+
+**E_WRITE_HASH_ECHO**:
+Refusal of a built-in `write` that copied a served hash echo — `[E_WRITE_HASH_ECHO] Refused write to ${path}: line ${n} begins with the exact ${hash}│ anchor served for this session, path, and line. Remove the entire copied anchor chain and retry. Nothing was written.`
+_Avoid_: E_HASH_ECHO (ambiguous between write/edit)
+
+**E_EDIT_HASH_ECHO**:
+Refusal of an `edit` whose `replacement_text` contains a served hash echo at the range-relative position — `[E_EDIT_HASH_ECHO] Refused edit to ${path}: replacement line ${k} begins with the exact ${hash}│ anchor served for this session, path, and range-relative line. Remove the copied anchors and retry. Nothing was written.` Deny, not strip — fail-loud, compensable (AA: A).
+_Avoid_: E_WRITE_HASH_ECHO (write-only), generic strip
+
 ### Guidance
 
 **Prompt section**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -54,8 +54,14 @@ The divergence between the served state and the current file: lines the model wa
 _Avoid_: modification, external change (the tool cannot know the source)
 
 **drift notice**:
-The informational section appended to a replace result (applied or noop, not undo) when drift lies in served territory outside the replacement range: the current content of the drifted lines, capped, with rows counting as serves. Fires once per drift episode — already-reported drift shrinks to a one-line pointer until a read re-serves the lines.
+The informational section appended to a replace result (applied or noop, not undo) when drift lies in served territory outside the replacement range: the current content of the drifted lines, capped, with rows counting as serves. Fires once per drift episode — already-reported drift shrinks to a one-line pointer until a read re-serves the lines. Classified as a user-facing signal (details only, not model content).
 _Avoid_: warning (the operation succeeded; it is information, not a warning)
+
+**model-facing signal**:
+A model-visible signal the tool must include in `content` for correctness (e.g. boundary staleness, range staleness, E_RANGE_*, E_EDIT_HASH_ECHO). The model needs it to retry correctly.
+
+**user-facing signal**:
+A model-visible signal informative for the human only, emitted in `details`/`warnings` and rendered collapsed in TUI (e.g. drift notice, Batch drift note). Not in model content.
 
 **orphaned serve**:
 An entry in served state whose hash no longer matches the current file at that position — the mirror retained a hash that the file has moved or removed elsewhere. Contrast with never-served. An orphan is drift, but at a single position rather than a range.

--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ atomically to that one file — one item per call is the norm, several same-file
 | `[E_AMBIGUOUS_ANCHOR]` | An anchor matches multiple lines; call `read` for fresh anchors. |
 | `[E_INVALID_PATCH]` | A `replacement_text` line is a diff-preview row (`+HASH│`, `-HASH│`, `-   │`). The marker is stripped automatically with a warning. |
 | `[E_BARE_HASH_PREFIX]` | A `replacement_text` line starts with a hash-like `HASH│` prefix. The prefix is stripped automatically with a warning. |
+| `[E_EDIT_HASH_ECHO]` | A `replacement_text` line begins with the exact `HASH│` anchor served for the same session, path, and range-relative line (`E1`). The edit is refused; remove the copied anchors and retry. Nothing was written. |
 | `[E_BAD_OP]` | Range start line is after range end line. The pair is swapped automatically with a warning. |
 | `[E_WOULD_EMPTY]` | An edit would empty a non-empty file; use `write` instead. |
 | `[E_NOT_FOUND]` | The path does not exist. |

--- a/docs/adr/0005-bounded-hash-echo-guard.md
+++ b/docs/adr/0005-bounded-hash-echo-guard.md
@@ -1,0 +1,33 @@
+# Bounded hash-echo guard for write and edit
+
+Date: 2026-08-27 (adapted for dsh-better-edit from pi-better-edit)
+
+## Status
+
+accepted (adapted for dsh-better-edit — same bounded rule; write guard in `write-hook.ts`, edit guard in `hashline/anchor-pipeline.ts`)
+
+## Context
+
+Downstream `dsh-better-edit#29` — after N `write` calls the file contained `lGp│nT2│CCd│UIA│## 1. H1` — the model copied the entire `HASH│content` preview chain into file content. `pi-better-edit` heals `remove_from`/`remove_to` via `stripBarePrefixes` (`E_BARE_HASH_PREFIX` → 50% `WARN_HEALED` in separator shootout), but `replacement_text` and built-in `write` `content` had no guard — hashes would enter disk. Grill with `keel` + `domain-modeling` agreed: keep `HASH│content` presentation, don't hide hashes; add a bounded, fail-loud guard.
+
+## Decision
+
+We add a pre-dispatch/write guard for both surfaces, same bounded rule:
+
+- **Same-session / same-canonical-path / same-line exact match** — a candidate line `k` that begins with `${hash}│` where `hash === served[pos]`. For `write` `pos = k` (absolute line `i` vs `served[i]`); for `edit` `pos = startLine + k` (range-relative `E1` alignment). Ported from `dsh@0.4.1` `findServedHashEcho` / `findEditHashEcho`.
+- **Deny, not strip (AA: A)** — `[E_WRITE_HASH_ECHO]` / `[E_EDIT_HASH_ECHO]`, file byte-identical, retry with bare content. Never generically strip `^[A-Za-z0-9]{3}│` — `Zz9│literal` stays valid.
+- `write` guard lives in `src/write-hook.ts` (`tools/pre-execute`); `edit` guard lives in `src/hashline/anchor-pipeline.ts:applyEdit` admission before `verifyServedRange` (via `findEditHashEcho`).
+
+## Considered Options
+
+- **E2 any-served-at-file** — any hash in served set at any line → catches reordered copies but false-positives on docs containing `Ab3│` where `Ab3` happens to be served elsewhere. Deferred.
+- **E3 generic strip** — `replace(/^[A-Za-z0-9]{3}│/, "")` on every `replacement_text` line — rejected, hides bug and corrupts legitimate `HASH│` literals in docs.
+- **Silent strip+warn (B)** — `boundaryDups` precedent (one duplicated boundary line, intent clear) — rejected for `N`-line chains; stripping `aB3│bC4│cD5│text` one layer leaves `bC4│cD5│text` still polluted; file write is irreversible, better to fail-loud.
+- **Hide hashes (plain-text read + content anchors)** — rejected, deletes `served state` fact authority (ADR-0001), worsens duplicate `}` disambiguation and token cost (hash 3 vs line 30-60).
+
+## Consequences
+
+- `CONTEXT.md` adds `[[served hash echo]]`, `[[E_WRITE_HASH_ECHO]]`, `[[E_EDIT_HASH_ECHO]]` — deny semantics, range-relative `E1`.
+- Prompt stays `replacement_text is bare content without HASH│`; error hint says `remove the entire copied anchor chain`.
+- Tests port `dsh/test/core/write-hook.hash-echo.test.ts` for `write` plus new `edit` cases (`S1` `Ab3│` at `s+k` → deny, clean retry → allow).
+- Separator stays `│` — strong delimiter, weak-space shootout irrelevant; guard is delimiter-agnostic (uses `HASH_SEP`).

--- a/docs/adr/0006-user-facing-drift-signals.md
+++ b/docs/adr/0006-user-facing-drift-signals.md
@@ -1,0 +1,37 @@
+# User-facing drift signals
+
+Date: 2026-08-28 (adapted for dsh-better-edit from pi-better-edit)
+
+## Status
+
+accepted (adapted for dsh-better-edit — drift routing via `edit-response.ts`, `mutation.ts`)
+
+## Context
+
+After `edit` the tool appended three informational signals to **model content** (`content.text`) via `edit-response.ts:finalizeResult` (`diff + warnBlock + driftBlock`): `driftNotice` (windowed rows, capped by `SERVED_ECHO_CAP`), `drift: already reported` (one-liner dedup), and `Batch drift note` (warning when `editedIntervals` are disjoint, `edit-engine.ts`/`mutation.ts`). All three are not needed for the model to retry — they describe changes outside the edited range that the next `edit` can ignore. In traces they dominated attention: a successful batch edit concatenated `diff + warnings + driftBlock` (4 sections repeating "re-read to see"), and the already-reported one-liner fired on every subsequent edit until re-read. Grill `Q1–Q9` agreed: `level` means audience — `model-facing signal` vs `user-facing signal` — and all three drift signals should be human-only.
+
+`CONTEXT.md` already defined `drift notice` but had no umbrella for audience. `model–tool boundary` says the tool owns verification; the model owns intent. Drift is informational drift, not a staleness rejection (`E_RANGE_*`, `E_EDIT_HASH_ECHO`).
+
+## Decision
+
+Route all drift signals to **user-facing only** — details, not model content — and keep `diff` / success summary / `noop` classification and all staleness/hash-echo rejections **model-facing**.
+
+- **Model content (`content.text`)** — `diff` + success summary (`Successfully edited… Added/removed`) + `noop` classification + `warnBlock` for non-drift warnings only. No `driftBlock`. Batch drift note filtered from `warnBlock` in model content.
+- **User-facing (`details`)** — `details.driftNotice` and `details.warnings` (including `Batch drift note`) remain, rendered collapsed in TUI (if present). `already reported` stays as a one-liner in `details`, once per episode (existing `driftReported` dedup).
+- **Batch drift note trigger unchanged** — `hasGap && editedIntervals.length > 1` still fires whenever batch intervals are disjoint (Q8 a); only routing changes. Per-interval gap drift (reporting drift inside gaps) remains future work as documented in `mutation.ts` phase diagram.
+- **Glossary** — `CONTEXT.md` adds `model-facing signal` / `user-facing signal`; `drift notice` is classified as `user-facing signal`.
+
+## Considered Options
+
+- **Keep drift in model content (status quo)** — simplest, but wastes attention on every success; model learns to ignore drift block and may miss real staleness that is co-located in the same text shape.
+- **Per-signal verbosity levels (`silent`/`brief`/`verbose`)** — rejected; `level` as defined in grill is binary audience, not verbosity. A `verbose` drift window still competes with `diff` in model context.
+- **New `verbosity` param on `edit`** — model-requested verbosity. Rejected for now; tool-side suppression + TUI collapse (`a + c` in Q4) achieves the same without enlarging the payload contract. Can be re-added if a model needs on-demand drift.
+- **Suppress already-reported entirely after first emission** — rejected; keep the one-liner user-facing so the human sees that drift is still pending, but not in model content.
+- **Make Batch drift note conditional on `served` gap occupancy** — more precise (only when gap contains served lines), but adds a scanning pass and conflates routing fix with correctness fix; deferred.
+
+## Consequences
+
+- `CONTEXT.md` adds `model-facing signal`, `user-facing signal`, and classifies `drift notice` as user-facing.
+- `src/edit-response.ts` — `finalizeResult` / `buildNoop` / `buildChanged` / `buildBatchResult` no longer append `driftBlock` to `content.text`; non-drift warnings still in `content`, `Batch drift note` filtered from `content` warn block. `driftNotice` stays in `details`.
+- `src/mutation.ts` — `Batch drift note` warning push unchanged; comment notes it is user-facing (details only).
+- Batch gap drift accuracy unchanged — still union `[minStart, maxEnd]` with gap treated as edited; the warning remains user-facing until per-interval drift is implemented.

--- a/src/edit-response.ts
+++ b/src/edit-response.ts
@@ -102,8 +102,11 @@ export interface FinalizeInput {
 }
 
 export function finalizeResult(input: FinalizeInput): string {
-	const base = input.diff + warnBlock(input.warnings);
-	return base + driftBlock(input.driftNotice);
+	const modelWarnings = input.warnings?.filter(
+		(w) => !w.startsWith("Batch drift note:"),
+	);
+	const base = input.diff + warnBlock(modelWarnings);
+	return base;
 }
 
 export function finalizeToolResult(details: EditDetails): {
@@ -132,8 +135,10 @@ export function buildNoop(input: NoopInput): TResult {
 	const noopDetailsText = noopEdit
 		? `Edit for ${noopEdit.loc} is identical to current content:\n  ${noopEdit.loc}: ${clipLine(noopEdit.currentContent)}`
 		: "The edit produced identical content.";
-	const noticeBlock = driftBlock(driftNotice);
-	const text = `No changes made to ${path}\nClassification: noop\n${noopDetailsText}${warnBlock(warnings)}${noticeBlock}`;
+	const modelWarnings = warnings?.filter(
+		(w) => !w.startsWith("Batch drift note:"),
+	);
+	const text = `No changes made to ${path}\nClassification: noop\n${noopDetailsText}${warnBlock(modelWarnings)}`;
 
 	const metrics = buildMetrics({
 		classification: "noop",
@@ -178,19 +183,21 @@ export function buildChanged(input: SuccessInput): TResult {
 	);
 	const addedLines = editMeta.addedLines;
 	const removedLines = editMeta.removedLines;
-	const warningsBlock = warnBlock(warnings);
+	const modelWarnings = warnings?.filter(
+		(w) => !w.startsWith("Batch drift note:"),
+	);
+	const warningsBlock = warnBlock(modelWarnings);
 	const successPrefix = `Successfully edited in ${path}.`;
 	const lineSummary =
 		addedLines > 0 || removedLines > 0
 			? ` Added ${addedLines} line(s), removed ${removedLines} line(s).`
 			: "";
-	const noticeBlock = driftBlock(driftNotice);
 	const text =
 		resultLines.length === 0
-			? "File is empty. Use edit to insert content." + noticeBlock
+			? "File is empty. Use edit to insert content."
 			: warningsBlock
-				? `${successPrefix}${lineSummary}${warningsBlock}${noticeBlock}`
-				: `${successPrefix}${lineSummary}${noticeBlock}`;
+				? `${successPrefix}${lineSummary}${warningsBlock}`
+				: `${successPrefix}${lineSummary}`;
 
 	const metrics = buildMetrics({
 		classification: "applied",
@@ -255,7 +262,10 @@ export function buildBatchResult(sections: BatchSection[]): TResult {
 		.join("\n\n");
 
 	if (allNoop) {
-		const text = `No changes made. All ${totalEdits} edit(s) in the batch produced identical content.\nClassification: noop${warnBlock(warnings)}${driftBlock(driftNotice)}`;
+		const modelWarnings = warnings.filter(
+			(w) => !w.startsWith("Batch drift note:"),
+		);
+		const text = `No changes made. All ${totalEdits} edit(s) in the batch produced identical content.\nClassification: noop${warnBlock(modelWarnings)}`;
 		return {
 			content: [{ type: "text", text }],
 			details: {
@@ -299,7 +309,10 @@ export function buildBatchResult(sections: BatchSection[]): TResult {
 			? ` Added ${addedLines} line(s), removed ${removedLines} line(s).`
 			: "";
 	const summary = `Successfully edited ${appliedFiles.length} file(s) — ${appliedTotal} of ${totalEdits} edit(s) applied${noopTotal > 0 ? ` (${noopTotal} noop)` : ""}.${lineSummary}`;
-	const text = `${summary}${warnBlock(warnings)}${driftBlock(driftNotice)}`;
+	const modelWarnings = warnings.filter(
+		(w) => !w.startsWith("Batch drift note:"),
+	);
+	const text = `${summary}${warnBlock(modelWarnings)}`;
 
 	return {
 		content: [{ type: "text", text }],

--- a/src/fs-write.ts
+++ b/src/fs-write.ts
@@ -32,10 +32,12 @@ async function sweepStaleTemps(dir: string): Promise<void> {
         if (now - stats.mtimeMs > STALE_TEMP_MS) {
           await rm(tempPath, { force: true });
         }
-      } catch {
+      } catch (error: unknown) {
+        console.error("[fs-write] failed to inspect stale temp", error);
       }
     }
-  } catch {
+  } catch (error: unknown) {
+    console.error("[fs-write] failed to sweep stale temps", error);
   }
 }
 
@@ -48,7 +50,8 @@ async function syncDir(dir: string): Promise<void> {
     } finally {
       await handle.close();
     }
-  } catch {
+  } catch (error: unknown) {
+    console.error("[fs-write] failed to sync directory", error);
   }
 }
 
@@ -85,7 +88,11 @@ export async function writeAtomic(
     await tempHandle.sync();
   } catch (error: unknown) {
     await tempHandle.close();
-    try { await rm(tempPath, { force: true }); } catch {}
+    try {
+      await rm(tempPath, { force: true });
+    } catch (error: unknown) {
+      console.error("[fs-write] failed to remove temp file", error);
+    }
     throw error;
   }
   try {
@@ -98,10 +105,18 @@ export async function writeAtomic(
         await writeFile(targetPath, content, "utf-8");
         return;
       } finally {
-        try { await rm(tempPath, { force: true }); } catch {}
+        try {
+          await rm(tempPath, { force: true });
+        } catch (error: unknown) {
+          console.error("[fs-write] failed to remove temp file", error);
+        }
       }
     }
-    try { await rm(tempPath, { force: true }); } catch {}
+    try {
+      await rm(tempPath, { force: true });
+    } catch (error: unknown) {
+      console.error("[fs-write] failed to remove temp file", error);
+    }
     throw error;
   }
 }

--- a/src/hashline/anchor-pipeline.ts
+++ b/src/hashline/anchor-pipeline.ts
@@ -38,6 +38,18 @@ function diagRef(ref: string): string {
 		return `[E_BAD_REF] Invalid anchor. Use the hash alone (e.g. "aB3") — no line numbers or trailing content.`;
 	}
 
+	if (trimmed.includes("│") && trimmed.includes("\n")) {
+		const lines = trimmed.split("\n");
+		const first = lines[0] ?? "";
+		const last = lines[lines.length - 1] ?? "";
+		const hashRe = new RegExp(HASH_CLASS);
+		const firstMatch = first.match(hashRe);
+		const lastMatch = last.match(hashRe);
+		const firstHash = firstMatch?.[0] ?? "wUp";
+		const lastHash = lastMatch?.[0] ?? "AU6";
+		const preview = first.slice(0, 60);
+		return `[E_BAD_REF] Invalid anchor — remove_from must be a single bare 3-char hash (e.g. "wUp"), not a block with HASH│. Received ${lines.length} lines starting "${preview}…" — use only the first hash "${firstHash}" as remove_from and "${lastHash}" as remove_to, and put the new content (without HASH│) in replacement_text.`;
+	}
 	if (trimmed.includes("│")) {
 		return `[E_BAD_REF] Invalid anchor "${trimmed}". remove_from and remove_to must contain the 3-char hash only — remove everything from "│" onward.`;
 	}
@@ -252,6 +264,15 @@ function assertItem(edit: Record<string, unknown>): void {
 }
 
 const ANCHOR_ROW_RE = new RegExp(`^([+-]?)(${HASH_CLASS})│`);
+function firstHashFromBlock(block: string): string | undefined {
+	for (const line of block.split("\n")) {
+		const m = line.match(ANCHOR_ROW_RE);
+		if (m) return m[2]!;
+		const bare = line.match(new RegExp(HASH_CLASS));
+		if (bare) return bare[0]!;
+	}
+	return undefined;
+}
 
 export function resEdit(edit: HTEdit, warnings?: string[]): HEdit {
 	assertItem(edit as Record<string, unknown>);
@@ -259,6 +280,14 @@ export function resEdit(edit: HTEdit, warnings?: string[]): HEdit {
 	const editLines = parseText(edit.replacement_text);
 	const bounds = [edit.remove_from, edit.remove_to].map((ref) => {
 		const trimmed = ref.trim();
+		if (trimmed.includes("\n")) {
+			const hash = firstHashFromBlock(trimmed);
+			if (hash) {
+				const lines = trimmed.split("\n").length;
+				warnings?.push(`[E_BAD_REF] extracted first hash "${hash}" from ${lines}-line block — use bare "${hash}" next time`);
+				return hash;
+			}
+		}
 		const match = trimmed.match(ANCHOR_ROW_RE);
 		if (match) {
 			let message: string;
@@ -308,9 +337,15 @@ function stripBarePrefixes(
 		.join(", ");
 	const matchedCount = stripped.filter((s) => s.matched).length;
 	const evidence = matchedCount === 0 ? "0 matched — verify literal 'HASH│' content" : `${matchedCount}/${stripped.length} matched`;
-	warnings.push(
-		`[E_BARE_HASH_PREFIX] stripped "HASH│" prefix from ${locations} (${evidence}).`,
-	);
+	if (matchedCount === stripped.length) {
+		warnings.push(
+			`[info E_BARE_HASH_PREFIX] stripped "HASH│" prefix from ${locations} (${evidence}) — use bare content without HASH│ next time.`,
+		);
+	} else {
+		warnings.push(
+			`[E_BARE_HASH_PREFIX] stripped "HASH│" prefix from ${locations} (${evidence}).`,
+		);
+	}
 	return { ...edit, content_lines: contentLines };
 }
 

--- a/src/hashline/anchor-pipeline.ts
+++ b/src/hashline/anchor-pipeline.ts
@@ -20,7 +20,7 @@
  */
 
 import { abortIf, splitLines, rejectUnknownFields, firstNonEmptyIndex, lastNonEmptyIndex, clipLine } from "../utils.js";
-import { HASH_CLASS, HL_BARE_PREFIX_RE, HL_PREFIX_PLUS_RE, HL_PREFIX_MINUS_RE, HASH_SEP, ANCHOR_LEN, ALPH_RE, canon, lineHashesPure } from "./hash-assign.js";
+import { HASH_CLASS, HL_BARE_PREFIX_RE, HL_PREFIX_PLUS_RE, HL_PREFIX_MINUS_RE, HASH_SEP, ANCHOR_LEN, ALPH_RE, canon, lineHashesPure, getCanonForHash, rememberHashCanon } from "./hash-assign.js";
 import { recordServed, servedPositionsOf } from "../served-store.js";
 import { SERVED_ECHO_CAP } from "../constants.js";
 import { NEW_CONTENT_NOT_STRING_MSG } from "../constants.js";
@@ -690,6 +690,19 @@ export function verifyServedRange(args: {
 		filePath,
 	} = args;
 	const where = filePath ? ` in ${filePath}` : "";
+	let isHealed = false;
+	for (let i = 0; i < fileHashes.length; i++) {
+		const h = fileHashes[i]!;
+		if (getCanonForHash(h) === undefined)
+			rememberHashCanon(h, canon(fileLines[i] ?? ""));
+	}
+	for (let i = 0; i < served.length; i++) {
+		const h = served[i];
+		if (h !== null && getCanonForHash(h) === undefined) {
+			const pos = fileHashes.indexOf(h);
+			if (pos >= 0) rememberHashCanon(h, canon(fileLines[pos] ?? ""));
+		}
+	}
 	const echoRows = buildRangeEcho(startLine, endLine, fileHashes);
 	const totalLen = endLine - startLine + 1;
 	const tail =
@@ -736,61 +749,204 @@ export function verifyServedRange(args: {
 		}
 	}
 	if (from === undefined || to === undefined) {
-		const problems: string[] = [];
-		if (startPositions.length === 0) {
-			problems.push(`remove_from "${startHash}" has no served position`);
-		} else if (startPositions.length > 1) {
-			problems.push(
-				`remove_from "${startHash}" was served at ${startPositions.length} positions`,
-			);
+		let healed: { from: number; to: number } | undefined;
+		if (startPositions.length === 1 && endPositions.length === 1) {
+			const sPos = startPositions[0]!;
+			const ePos = endPositions[0]!;
+			const servedFrom = Math.min(sPos, ePos);
+			const servedTo = Math.max(sPos, ePos);
+			const servedLen = servedTo - servedFrom + 1;
+			if (servedLen === currentLen) {
+				const expectedCanons: string[] = [];
+				let canBuild = true;
+				for (let k = 0; k < servedLen; k++) {
+					const h = served[servedFrom + k];
+					if (h === null) {
+						canBuild = false;
+						break;
+					}
+					const c = getCanonForHash(h);
+					if (c === undefined) {
+						canBuild = false;
+						break;
+					}
+					expectedCanons.push(c);
+				}
+				if (canBuild) {
+					const matches: number[] = [];
+					for (let i = 0; i <= fileLines.length - servedLen; i++) {
+						let ok = true;
+						for (let k = 0; k < servedLen; k++) {
+							if (canon(fileLines[i + k] ?? "") !== expectedCanons[k]) {
+								ok = false;
+								break;
+							}
+						}
+						if (ok) matches.push(i);
+						if (matches.length > 1) break;
+					}
+					if (matches.length === 1) {
+						healed = { from: matches[0]!, to: matches[0]! + servedLen - 1 };
+					}
+				}
+			}
 		}
-		if (endPositions.length === 0) {
-			problems.push(`remove_to "${endHash}" has no served position`);
-		} else if (endPositions.length > 1) {
-			problems.push(
-				`remove_to "${endHash}" was served at ${endPositions.length} positions`,
-			);
+		if (!healed) {
+			const hasServed = served.some((h) => h !== null);
+			const startInFile = fileHashes.includes(startHash);
+			const endInFile = fileHashes.includes(endHash);
+			if (hasServed && (!startInFile || !endInFile)) {
+				const startCanon = getCanonForHash(startHash);
+				const endCanon = getCanonForHash(endHash);
+				if (startCanon !== undefined && endCanon !== undefined) {
+					const startMatches: number[] = [];
+					const endMatches: number[] = [];
+					for (let i = 0; i < fileLines.length; i++) {
+						if (canon(fileLines[i] ?? "") === startCanon) startMatches.push(i);
+						if (canon(fileLines[i] ?? "") === endCanon) endMatches.push(i);
+						if (startMatches.length > 1 && endMatches.length > 1) break;
+					}
+					if (startMatches.length === 1 && endMatches.length === 1) {
+						const s = startMatches[0]!;
+						const e = endMatches[0]!;
+						const healedFrom = Math.min(s, e);
+						const healedTo = Math.max(s, e);
+						if (healedTo - healedFrom + 1 === currentLen) {
+							let interiorOk = true;
+							if (currentLen > 2) {
+								const healedCanons = [];
+								for (let k = 0; k < currentLen; k++)
+									healedCanons.push(canon(fileLines[healedFrom + k] ?? ""));
+								let count = 0;
+								for (let i = 0; i <= fileLines.length - currentLen; i++) {
+									let ok = true;
+									for (let k = 0; k < currentLen; k++)
+										if (canon(fileLines[i + k] ?? "") !== healedCanons[k]) {
+											ok = false;
+											break;
+										}
+									if (ok) count++;
+									if (count > 1) break;
+								}
+								if (count !== 1) interiorOk = false;
+							}
+							if (interiorOk) healed = { from: healedFrom, to: healedTo };
+						}
+					}
+				}
+			}
 		}
-		throw new ServedRejectionError({
-			code: "E_RANGE_UNVERIFIED",
-			message:
-				`[E_RANGE_UNVERIFIED] cannot verify range against served state${where}: ${problems.join("; ")}. ` +
-				`Current range:
-${echo}
-${retryHint()}`,
-			servedRows: echoRows,
-		});
-	}
-
-	for (let i = from; i <= to; i++) {
-		if (served[i] === null) {
+		if (healed) {
+			from = healed.from;
+			to = healed.to;
+			isHealed = true;
+		} else {
+			const problems: string[] = [];
+			if (startPositions.length === 0) {
+				problems.push(`remove_from "${startHash}" has no served position`);
+			} else if (startPositions.length > 1) {
+				problems.push(
+					`remove_from "${startHash}" was served at ${startPositions.length} positions`,
+				);
+			}
+			if (endPositions.length === 0) {
+				problems.push(`remove_to "${endHash}" has no served position`);
+			} else if (endPositions.length > 1) {
+				problems.push(
+					`remove_to "${endHash}" was served at ${endPositions.length} positions`,
+				);
+			}
 			throw new ServedRejectionError({
-				code: "E_RANGE_UNSERVED",
-				message: `[E_RANGE_UNSERVED] line ${i + 1}${where} was never served.\nCurrent range:\n${echo}\n${retryHint()}`,
-				firstOffendingLine: i + 1,
+				code: "E_RANGE_UNVERIFIED",
+				message:
+					`[E_RANGE_UNVERIFIED] cannot verify range against served state${where}: ${problems.join("; ")}. ` +
+					`No served span matched the current range (${currentLen} lines). ` +
+					`A full read will re-sync the served mirror — the echoed range below is current content, ` +
+					`but retrying without re-reading cannot clear a stale duplicate outside the echoed window.\n` +
+					`Current range:\n${echo}`,
 				servedRows: echoRows,
 			});
 		}
 	}
 
-	const servedLen = to - from + 1;
-	if (servedLen !== currentLen) {
-		throw new ServedRejectionError({
-			code: "E_RANGE_STALE",
-			message: `[E_RANGE_STALE] served span (${servedLen} lines) no longer matches current range (${currentLen} lines)${where}.\nCurrent range:\n${echo}\n${retryHint()}`,
-			firstOffendingLine: startLine,
-			servedRows: echoRows,
-		});
-	}
-	for (let k = 0; k < servedLen; k++) {
-		if (served[from + k] !== fileHashes[startLine - 1 + k]) {
-			const offendingLine = startLine + k;
-			throw new ServedRejectionError({
-				code: "E_RANGE_STALE",
-				message: `[E_RANGE_STALE] Line ${offendingLine}${where} differs from what you were served — the file changed on disk since it was read. Current range:\n${echo}\n${retryHint()}`,
-				firstOffendingLine: offendingLine,
-				servedRows: echoRows,
-			});
+	if (isHealed) {
+		for (let k = 0; k < currentLen; k++) {
+			const servedHash = served[from + k];
+			if (servedHash === null) continue;
+			const expectedCanon = getCanonForHash(servedHash);
+			const actualCanon = canon(fileLines[from + k] ?? "");
+			if (expectedCanon !== undefined && expectedCanon !== actualCanon) {
+				const offendingLine = from + k + 1;
+				throw new ServedRejectionError({
+					code: "E_RANGE_STALE",
+					message: `[E_RANGE_STALE] line ${offendingLine}${where} differs from what was served.\nCurrent range:\n${echo}\n${retryHint()}`,
+					firstOffendingLine: offendingLine,
+					servedRows: echoRows,
+				});
+			}
+		}
+	} else {
+		for (let i = from; i <= to; i++) {
+			if (served[i] === null) {
+				throw new ServedRejectionError({
+					code: "E_RANGE_UNSERVED",
+					message: `[E_RANGE_UNSERVED] line ${i + 1}${where} was never served.\nCurrent range:\n${echo}\n${retryHint()}`,
+					firstOffendingLine: i + 1,
+					servedRows: echoRows,
+				});
+			}
+		}
+		const servedLen = to - from + 1;
+		if (servedLen !== currentLen) {
+			let lenHealed = false;
+			const expectedCanons: string[] = [];
+			let canBuild = true;
+			for (let k = 0; k < servedLen; k++) {
+				const h = served[from + k];
+				if (h === null) {
+					canBuild = false;
+					break;
+				}
+				const c = getCanonForHash(h);
+				if (c === undefined) {
+					canBuild = false;
+					break;
+				}
+				expectedCanons.push(c);
+			}
+			if (canBuild) {
+				let matches = 0;
+				for (let i = 0; i <= fileLines.length - servedLen; i++) {
+					let ok = true;
+					for (let k = 0; k < servedLen; k++)
+						if (canon(fileLines[i + k] ?? "") !== expectedCanons[k]) {
+							ok = false;
+							break;
+						}
+					if (ok) matches++;
+					if (matches > 1) break;
+				}
+				if (matches === 1) lenHealed = true;
+			}
+			if (!lenHealed) {
+				throw new ServedRejectionError({
+					code: "E_RANGE_STALE",
+					message: `[E_RANGE_STALE] served span (${servedLen} lines) no longer matches current range (${currentLen} lines)${where}.\nCurrent range:\n${echo}\n${retryHint()}`,
+					firstOffendingLine: startLine,
+					servedRows: echoRows,
+				});
+			}
+		}
+		for (let k = 0; k < servedLen; k++) {
+			if (served[from + k] !== fileHashes[startLine - 1 + k]) {
+				const offendingLine = startLine + k;
+				throw new ServedRejectionError({
+					code: "E_RANGE_STALE",
+					message: `[E_RANGE_STALE] line ${offendingLine}${where} differs from what was served.\nCurrent range:\n${echo}\n${retryHint()}`,
+					firstOffendingLine: offendingLine,
+					servedRows: echoRows,
+				});
+			}
 		}
 	}
 }

--- a/src/hashline/anchor-pipeline.ts
+++ b/src/hashline/anchor-pipeline.ts
@@ -676,6 +676,27 @@ export function isAnchorMismatch(error: unknown): error is AnchorMismatchError {
 	return error instanceof AnchorMismatchError;
 }
 
+export function findEditHashEcho(
+	replacementLines: string[],
+	served: readonly (string | null)[],
+	startLine: number,
+): { k: number; hash: string } | undefined {
+	for (let k = 0; k < replacementLines.length; k++) {
+		const pos = startLine + k - 1;
+		if (pos < served.length && served[pos] !== null && replacementLines[k]!.startsWith(served[pos]! + HASH_SEP)) {
+			return { k: k + 1, hash: served[pos]! };
+		}
+	}
+	return undefined;
+}
+
+export class EditHashEchoError extends AnchorMismatchError {
+	constructor(message: string, servedRows: ServedRow[] = []) {
+		super(message, servedRows);
+		this.name = "EditHashEchoError";
+	}
+}
+
 export function buildRangeEcho(
 	startLine: number,
 	endLine: number,
@@ -1226,7 +1247,16 @@ export function applyEdit(
 		resolved = correctedResult.resolved;
 	}
 
-	if (served) {
+if (served) {
+		const startLineEcho = resolved.hash_bounds[0].line;
+		const rawEcho = findEditHashEcho(edit.content_lines, served, startLineEcho);
+		let echo = rawEcho;
+		if (!echo) echo = findEditHashEcho(resolved.content_lines, served, startLineEcho);
+		if (!echo) echo = findEditHashEcho(prefixFixed.content_lines, served, startLineEcho);
+		if (echo) {
+			const msg = `[E_EDIT_HASH_ECHO] Refused edit to ${filePath ?? "(unknown file)"}: replacement line ${echo.k} begins with the exact ${echo.hash}${HASH_SEP} anchor served for this session, path, and range-relative line. Remove the copied anchors and retry. Nothing was written.`;
+			throw new EditHashEchoError(msg, []);
+		}
 		const startAnchor = resolved.hash_bounds[0];
 		const endAnchor = resolved.hash_bounds[1];
 		verifyServedRange({

--- a/src/hashline/hash-assign.ts
+++ b/src/hashline/hash-assign.ts
@@ -75,6 +75,17 @@ function hashAt(idx: number): string {
   }
   return hash;
 }
+
+const hashToCanon = new Map<string, string>();
+
+export function rememberHashCanon(hash: string, canonText: string): void {
+  if (!hashToCanon.has(hash)) hashToCanon.set(hash, canonText);
+}
+
+export function getCanonForHash(hash: string): string | undefined {
+  return hashToCanon.get(hash);
+}
+
 export const HL_PREFIX_PLUS_RE = new RegExp(`^\\+${HASH_CLASS}│`);
 export const HL_PREFIX_MINUS_RE = new RegExp(`^-(?:${HASH_CLASS}│| {${ANCHOR_LEN}}│)`);
 export const HL_BARE_PREFIX_RE = new RegExp(`^\\s*(${HASH_CLASS})│`);
@@ -131,7 +142,9 @@ export function lineHashesPure(content: string): string[] {
   for (let i = 0; i < lines.length; i++) {
     const c = getCanon(canonCache, lines[i]!);
     const baseIdx = (xxh32(c) >>> 14) % HASH_SPACE;
-    hashes[i] = assignHash(used, baseIdx, hint);
+    const h = assignHash(used, baseIdx, hint);
+    hashes[i] = h;
+    rememberHashCanon(h, c);
   }
   return hashes;
 }
@@ -218,6 +231,7 @@ export function mapStableHashes(oldContent: string, oldHashes: string[], newCont
     const newIdx = candidates.splice(pos, 1)[0]!;
     newHashes[newIdx] = entry.hash;
     markUsed(entry.hash);
+    rememberHashCanon(entry.hash, getCanon(canonCache, oldLines[entry.index]!));
   }
   const removedByContent = new Map<string, { hashes: string[]; pos: number }>();
   for (const entry of removedEntries) {
@@ -233,14 +247,18 @@ export function mapStableHashes(oldContent: string, oldHashes: string[], newCont
     if (newHashes[i]) continue;
     const queue = removedByContent.get(getCanon(canonCache, newLines[i]!));
     if (!queue || queue.pos >= queue.hashes.length) continue;
-    newHashes[i] = queue.hashes[queue.pos]!;
+    const h = queue.hashes[queue.pos]!;
+    newHashes[i] = h;
     queue.pos += 1;
+    rememberHashCanon(h, getCanon(canonCache, newLines[i]!));
   }
   for (let i = 0; i < newLines.length; i++) {
     if (newHashes[i]) continue;
     const c = getCanon(canonCache, newLines[i]!);
     const baseIdx = (xxh32(c) >>> 14) % HASH_SPACE;
-    newHashes[i] = assignHash(used, baseIdx, hint);
+    const h = assignHash(used, baseIdx, hint);
+    newHashes[i] = h;
+    rememberHashCanon(h, c);
   }
   return newHashes;
 }

--- a/src/hashline/index.ts
+++ b/src/hashline/index.ts
@@ -33,17 +33,19 @@ export { resEdit } from "./anchor-pipeline.js";
 export type { HEdit, HTEdit, NEdit, BDup, AutoFix } from "./anchor-pipeline.js";
 
 export {
- applyEdit,
- fmtRegion,
- changedRange,
- buildIdx,
- ServedRejectionError,
- AnchorMismatchError,
- isServedRejection,
- isAnchorMismatch,
- verifyServedRange,
- buildRangeEcho,
- fmtServedRows,
+	applyEdit,
+	fmtRegion,
+	changedRange,
+	buildIdx,
+	ServedRejectionError,
+	AnchorMismatchError,
+	EditHashEchoError,
+	findEditHashEcho,
+	isServedRejection,
+	isAnchorMismatch,
+	verifyServedRange,
+	buildRangeEcho,
+	fmtServedRows,
 } from "./anchor-pipeline.js";
 export type {
  ServedRow,

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -27,6 +27,7 @@ export const EDIT_GUIDANCE: ToolGuidance = {
     "`edit`: `\\n` is a line break, so a range ending on a blank line must end replacement_text with `\\n` and a non-blank last line must not; a blank-line run is one `\\n` per blank line.",
     "`edit`: the post-edit diff rows carry fresh anchors for follow-ups. A stale or never-served range is hard-rejected (`[E_RANGE_STALE]` / `[E_RANGE_UNSERVED]`); copy the echoed rows and retry — only tool-served rows count.",
     "`edit`: multiple edits to the same file in one call are atomic (all-or-nothing): if any tuple fails — stale, ambiguous, never-served — nothing is written and the failing tuple's current range is served back. Prefer one edit per call unless you have independent ranges.",
+    "edit: HASH vs HASH│content: served rows are HASH│content for you to copy the HASH from — never send HASH│content as an anchor or in replacement_text. Strip │ and everything after it for anchors; strip HASH│ prefix for replacement_text.",
   ],
 };
 

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -13,21 +13,23 @@ export interface ToolGuidance {
 }
 
 export const EDIT_DESCRIPTION =
-  "Edit a range of lines in a text file, targeted by the 3-char HASH anchors from read output. " +
-  'Use { "path": "file.ts", "edits": [[remove_from, remove_to, replacement_text], ...] } — path is the file to edit (or null to infer from anchors), edits is an array of [remove_from, remove_to, replacement_text] tuples. ' +
-  "remove_from and remove_to must each be a BARE 3-character hash: copy only the hash from the " +
-  'leftmost column of a read row (row `ve7│function hello() {` means `"remove_from": "ve7"`). ' +
-  "Never pass the line content, a code line, or a paragraph into these fields. The path is hoisted to the payload root so every edit in one call targets the same file; a length-1 edits array is a single edit.";
+  "Edit a range of lines in a text file with `{ \"path\": path, \"edits\": [[remove_from, remove_to, replacement_text], ...] }`. " +
+  "`path` is the file path or `null`. `read` returns `HASH\u2502content` (e.g. `wUp\u2502    \"site\": {`) \u2014 for `edit`, " +
+  "`remove_from`/`remove_to` are HASH anchors (bare 3-char value before `\u2502`, e.g. \"wUp\", \"AU6\"), never `HASH\u2502content` or line content. " +
+  "`replacement_text` is bare content without `HASH\u2502`, lines joined by \\n (e.g. \"    \\\"site\\\": {\\n        \\\"class\\\": SiteScraper,\"); use \"\" to delete. " +
+  "Example: read shows `wUp\u2502    \"site\": {` + `AU6\u2502        \"name\": \"old\",` \u2192 edit " +
+  "`{\"path\":\"scrape.py\",\"edits\":[[\"wUp\",\"AU6\",\"    \\\"site\\\": {\\n        \\\"class\\\": SiteScraper,\"]]}`. " +
+  "Edits in one call apply atomically; after success reuse `HASH\u2502content` from the returned diff for the next edit (no re-read needed). On failure follow the error hint.";
 
 export const EDIT_GUIDANCE: ToolGuidance = {
-  intro: "Edit a range of lines via a bare 3-char HASH anchor — payload is { path, edits: [[hash,hash,text]] } (single-file atomic, null path infers).",
+  intro: "Edit a range of lines via a bare 3-char HASH anchor \u2014 payload is { path, edits: [[hash,hash,text]] } (single-file atomic, null path infers).",
   lines: [
-    "`edit`: payload is { \"path\": \"file.ts\"|null, \"edits\": [[remove_from, remove_to, replacement_text], ...] } — path at root, each item is a 3-position tuple with bare hashes (`ve7`, not `ve7│function…`). A single line uses the same hash in both fields.",
-    "`edit`: replacement_text is byte-exact for the whole range — every line inside it you do not reproduce byte-exact is deleted, and leading whitespace is preserved exactly.",
-    "`edit`: `\\n` is a line break, so a range ending on a blank line must end replacement_text with `\\n` and a non-blank last line must not; a blank-line run is one `\\n` per blank line.",
-    "`edit`: the post-edit diff rows carry fresh anchors for follow-ups. A stale or never-served range is hard-rejected (`[E_RANGE_STALE]` / `[E_RANGE_UNSERVED]`); copy the echoed rows and retry — only tool-served rows count.",
-    "`edit`: multiple edits to the same file in one call are atomic (all-or-nothing): if any tuple fails — stale, ambiguous, never-served — nothing is written and the failing tuple's current range is served back. Prefer one edit per call unless you have independent ranges.",
-    "edit: HASH vs HASH│content: served rows are HASH│content for you to copy the HASH from — never send HASH│content as an anchor or in replacement_text. Strip │ and everything after it for anchors; strip HASH│ prefix for replacement_text.",
+    "`edit`: `HASH` vs `HASH\u2502content` \u2014 `HASH` is the bare 3-char (e.g. \"wUp\"), `HASH\u2502content` is the full line from `read`/`diff` (e.g. `wUp\u2502    \"site\": {`); never mix them.",
+    "`edit`: get `remove_from`/`remove_to` by copying only the 3 chars before `\u2502` from `read` output \u2014 never include `\u2502` or content after it.",
+    "`edit`: `replacement_text` is plain file content without `HASH\u2502` \u2014 e.g. \"    \\\"site\\\": {\\n        \\\"class\\\": SiteScraper,\" \u2014 never prefix lines with `HASH\u2502`.",
+    "`edit`: every `\\n` in `replacement_text` separates lines; mirror trailing blank lines explicitly (use \"\" to delete a range).",
+    "`edit`: after a successful edit the returned diff shows fresh anchors (`HASH\u2502content`) \u2014 copy new `HASH` values from there for the next edit; no need to re-read.",
+    "`edit`: `remove_from`/`remove_to` are inclusive; batch multiple edits to the same file only when independent \u2014 they apply atomically (fail \u2192 nothing written).",
   ],
 };
 

--- a/test/core/reject-and-serve-seam.test.ts
+++ b/test/core/reject-and-serve-seam.test.ts
@@ -78,7 +78,7 @@ describe("finalizeToolResult", () => {
 		expect(result.content).toEqual([
 			{
 				type: "text",
-				text: "+a\n-b\n\nW1\n\ndrift: 1 line(s) changed outside the range:",
+				text: "+a\n-b\n\nW1",
 			},
 		]);
 		expect(result.servedRows).toEqual([{ position: 0, hash: "abc" }]);

--- a/test/core/replace-response.test.ts
+++ b/test/core/replace-response.test.ts
@@ -194,7 +194,7 @@ describe("finalizeResult", () => {
 
   it("appends the drift notice after the diff", () => {
     const text = finalizeResult({ diff: "+a", driftNotice: "drift: ..." });
-    expect(text).toBe("+a\n\ndrift: ...");
+    expect(text).toBe("+a");
   });
 
   it("orders diff, warnings, then drift notice", () => {
@@ -203,7 +203,7 @@ describe("finalizeResult", () => {
       warnings: ["W1"],
       driftNotice: "drift: ...",
     });
-    expect(text).toBe("+a\n\nW1\n\ndrift: ...");
+    expect(text).toBe("+a\n\nW1");
   });
 
   it("ignores an empty warnings array", () => {


### PR DESCRIPTION
Absorbs pi-better-edit@7b91958..f5b58a5 **one-by-one** (fix/feat only, refactor skipped), each upstream → one downstream commit for cherry-pick/revert.

| Downstream | Upstream | Scope |
|---|---|---|
| 1b1a4e2 | f94fb88 (part of 08457eb) | heal multi-line staleness a b c→a 1 b c + stable anchoring hashToCanon |
| b3931bc | 671c66d | fs-write log stale-temp/sync |
| 356a41c | a837e9d | HASH vs HASH│content block error + info downgrade |
| 6d4a908 | b3665d8 | final HASH vs content prompt |
| c7a1b3a | 65b8eb1 | E_EDIT_HASH_ECHO guard + ADR-0005 |
| c4a7957 | 6ec52f2 | drift user-facing + ADR-0006 |
| 1f22fa8 | 6ec52f2 tests | align expectations |
| aaf0e5d | — | changelog + wt.toml |

7b91958 dense servedRows already in 0.3.1 (e4e0c70). 693/693 tests, typecheck green. Each commit is wt merge --stage tracked verified.

Closes #41