### PR TITLE
feat(edit): render diff card after tool calling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Features
+
+- **edit:** render diff card after tool calling
+
 ### Fixed
 
 - **ci:** add neural version check to Verify and Release

--- a/src/edit-response.ts
+++ b/src/edit-response.ts
@@ -1,5 +1,6 @@
 import type { ServedRow } from "./hashline/served.js";
 import { genDiff } from "./edit-diff.js";
+import { truncateHead, formatSize } from "./file-view.js";
 import { visLines, clipLine } from "./utils.js";
 
 export type EditDetails = {
@@ -125,6 +126,24 @@ function warnBlock(warnings: string[] | undefined): string {
 	return warnings?.length ? `\n\n${warnings.join("\n")}` : "";
 }
 
+const DIFF_CARD_MAX_LINES = 400;
+const DIFF_CARD_MAX_BYTES = 80 * 1024;
+
+function formatDiffCard(diff: string): string {
+	if (!diff || diff.trim().length === 0) return "";
+	const truncation = truncateHead(diff, {
+		maxLines: DIFF_CARD_MAX_LINES,
+		maxBytes: DIFF_CARD_MAX_BYTES,
+	});
+	const fenced = `\n\n\`\`\`diff\n${truncation.content}\n\`\`\``;
+	if (!truncation.truncated) return fenced;
+	const hint =
+		truncation.firstLineExceedsLimit
+			? `[Diff truncated: first line exceeds ${formatSize(truncation.maxBytes)} — use read to inspect file]`
+			: `[Diff truncated: showing ${truncation.outputLines}/${truncation.totalLines} lines (${formatSize(truncation.outputBytes)}/${formatSize(truncation.totalBytes)}) — re-read file to see full content]`;
+	return `${fenced}\n\n${hint}`;
+}
+
 function driftBlock(driftNotice: string | undefined): string {
 	return driftNotice ? `\n\n${driftNotice}` : "";
 }
@@ -192,12 +211,14 @@ export function buildChanged(input: SuccessInput): TResult {
 		addedLines > 0 || removedLines > 0
 			? ` Added ${addedLines} line(s), removed ${removedLines} line(s).`
 			: "";
-	const text =
+	const baseText =
 		resultLines.length === 0
 			? "File is empty. Use edit to insert content."
 			: warningsBlock
 				? `${successPrefix}${lineSummary}${warningsBlock}`
 				: `${successPrefix}${lineSummary}`;
+	const diffSection = resultLines.length === 0 ? "" : formatDiffCard(diffResult.diff);
+	const text = `${baseText}${diffSection}`;
 
 	const metrics = buildMetrics({
 		classification: "applied",
@@ -312,7 +333,9 @@ export function buildBatchResult(sections: BatchSection[]): TResult {
 	const modelWarnings = warnings.filter(
 		(w) => !w.startsWith("Batch drift note:"),
 	);
-	const text = `${summary}${warnBlock(modelWarnings)}`;
+	const baseText = `${summary}${warnBlock(modelWarnings)}`;
+	const diffSection = formatDiffCard(diff);
+	const text = `${baseText}${diffSection}`;
 
 	return {
 		content: [{ type: "text", text }],

--- a/test/core/diff-card.test.ts
+++ b/test/core/diff-card.test.ts
@@ -1,0 +1,231 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { buildBatchResult, buildChanged } from "../../src/edit-response.js";
+import { lineHashes } from "../../src/hashline/index.js";
+import { initHasher } from "../../src/hashline/hasher.js";
+import { useTestHome } from "../support/fixtures.js";
+
+const home = useTestHome();
+
+beforeAll(async () => {
+	await initHasher();
+});
+
+describe("diff card — buildChanged", () => {
+	it("renders fenced diff block after success summary", async () => {
+		const original = "aaa\nbbb\nccc\n";
+		const result = "aaa\nBBB\nccc\n";
+		const originalHashes = await lineHashes(original, home.testPath);
+		const resultHashes = await lineHashes(result, home.testPath);
+
+		const out = buildChanged({
+			path: "test.txt",
+			originalNormalized: original,
+			originalHashes,
+			result,
+			resultHashes,
+			warnings: undefined,
+			snapshotId: "snap1",
+			editMeta: {
+				editsAttempted: 1,
+				noopEditsCount: 0,
+				firstChangedLine: 2,
+				lastChangedLine: 2,
+				addedLines: 1,
+				removedLines: 1,
+			},
+		});
+
+		const text = out.content[0]!.text;
+		expect(text).toContain("Successfully edited in test.txt");
+		// diff card: fenced block with language hint
+		expect(text).toContain("```diff");
+		expect(text).toContain("```");
+		// closing fence after diff
+		expect(text.indexOf("```diff")).toBeLessThan(text.lastIndexOf("```"));
+		// diff content still mirrors details.diff hash-anchored rows
+		expect(text).toContain("│bbb");
+		expect(text).toContain("│BBB");
+		expect(out.details.diff).toContain("│bbb");
+	});
+
+	it("keeps warnings before the diff fence in model content", async () => {
+		const original = "aaa\nbbb\nccc\n";
+		const result = "aaa\nBBB\nccc\n";
+		const originalHashes = await lineHashes(original, home.testPath);
+		const resultHashes = await lineHashes(result, home.testPath);
+
+		const out = buildChanged({
+			path: "test.txt",
+			originalNormalized: original,
+			originalHashes,
+			result,
+			resultHashes,
+			warnings: ["Boundary duplication (leading)"],
+			snapshotId: "snap1",
+			editMeta: {
+				editsAttempted: 1,
+				noopEditsCount: 0,
+				firstChangedLine: 2,
+				lastChangedLine: 2,
+				addedLines: 1,
+				removedLines: 1,
+			},
+		});
+
+		const text = out.content[0]!.text;
+		const warnIdx = text.indexOf("Boundary duplication");
+		const fenceIdx = text.indexOf("```diff");
+		expect(warnIdx).toBeGreaterThan(-1);
+		expect(fenceIdx).toBeGreaterThan(-1);
+		expect(warnIdx).toBeLessThan(fenceIdx);
+	});
+
+	it("does not render diff fence when file becomes empty", async () => {
+		const original = "aaa\nbbb\n";
+		const result = "";
+		const originalHashes = await lineHashes(original, home.testPath);
+		const resultHashes = await lineHashes(result, home.testPath);
+
+		const out = buildChanged({
+			path: "test.txt",
+			originalNormalized: original,
+			originalHashes,
+			result,
+			resultHashes,
+			warnings: undefined,
+			snapshotId: "snap1",
+			editMeta: {
+				editsAttempted: 1,
+				noopEditsCount: 0,
+				firstChangedLine: 1,
+				lastChangedLine: 2,
+				addedLines: 0,
+				removedLines: 2,
+			},
+		});
+
+		expect(out.content[0]!.text).toBe("File is empty. Use edit to insert content.");
+		expect(out.content[0]!.text).not.toContain("```diff");
+	});
+
+	it("truncates large diffs and appends hint", async () => {
+		// 500-line file where every even line changes — diff > 400 lines, triggers truncateHead
+		const manyOriginal = Array.from({ length: 500 }, (_, i) => `line ${i} original`).join("\n") + "\n";
+		const manyResult = Array.from({ length: 500 }, (_, i) =>
+			i % 2 === 0 ? `line ${i} CHANGED` : `line ${i} original`,
+		).join("\n") + "\n";
+		const originalHashes = await lineHashes(manyOriginal, home.testPath);
+		const resultHashes = await lineHashes(manyResult, home.testPath);
+
+		const out = buildChanged({
+			path: "big.txt",
+			originalNormalized: manyOriginal,
+			originalHashes,
+			result: manyResult,
+			resultHashes,
+			warnings: undefined,
+			snapshotId: "snap1",
+			editMeta: {
+				editsAttempted: 1,
+				noopEditsCount: 0,
+				firstChangedLine: 1,
+				lastChangedLine: 500,
+				addedLines: 250,
+				removedLines: 250,
+			},
+		});
+
+		const text = out.content[0]!.text;
+		expect(text).toContain("```diff");
+		expect(text).toContain("[Diff truncated:");
+		expect(text).toContain("showing");
+		// truncated block is shorter than full details.diff
+		const fenced = text.slice(text.indexOf("```diff"), text.lastIndexOf("```") + 3);
+		expect(fenced.split("\n").length).toBeLessThan(out.details.diff.split("\n").length);
+	});
+});
+
+describe("diff card — buildBatchResult", () => {
+	it("renders per-file headers inside fenced diff for batch edits", async () => {
+		const original = "aaa\nbbb\nccc\n";
+		const result = "aaa\nBBB\nccc\n";
+		const originalHashes = await lineHashes(original, home.testPath);
+		const resultHashes = await lineHashes(result, home.testPath);
+
+		const out = buildBatchResult([
+			{
+				path: "a.txt",
+				originalNormalized: original,
+				result,
+				originalHashes,
+				resultHashes,
+				warnings: undefined,
+				driftNotice: undefined,
+				appliedCount: 1,
+				noopCount: 0,
+				totalAddedLines: 1,
+				totalRemovedLines: 1,
+			},
+			{
+				path: "b.txt",
+				originalNormalized: original,
+				result,
+				originalHashes,
+				resultHashes,
+				warnings: undefined,
+				driftNotice: undefined,
+				appliedCount: 1,
+				noopCount: 0,
+				totalAddedLines: 1,
+				totalRemovedLines: 1,
+			},
+		]);
+
+		const text = out.content[0]!.text;
+		expect(text).toContain("Successfully edited 2 file(s)");
+		expect(text).toContain("```diff");
+		expect(text).toContain("--- a.txt ---");
+		expect(text).toContain("--- b.txt ---");
+		expect(out.details.diff).toContain("--- a.txt ---");
+	});
+
+	it("still truncates batch diffs when combined size exceeds limits", async () => {
+		const orig = Array.from({ length: 300 }, (_, i) => `orig ${i}`).join("\n") + "\n";
+		const res = Array.from({ length: 300 }, (_, i) => `changed ${i}`).join("\n") + "\n";
+		const oh = await lineHashes(orig, home.testPath);
+		const rh = await lineHashes(res, home.testPath);
+
+		const out = buildBatchResult([
+			{
+				path: "x.txt",
+				originalNormalized: orig,
+				result: res,
+				originalHashes: oh,
+				resultHashes: rh,
+				warnings: undefined,
+				driftNotice: undefined,
+				appliedCount: 1,
+				noopCount: 0,
+				totalAddedLines: 300,
+				totalRemovedLines: 300,
+			},
+			{
+				path: "y.txt",
+				originalNormalized: orig,
+				result: res,
+				originalHashes: oh,
+				resultHashes: rh,
+				warnings: undefined,
+				driftNotice: undefined,
+				appliedCount: 1,
+				noopCount: 0,
+				totalAddedLines: 300,
+				totalRemovedLines: 300,
+			},
+		]);
+
+		expect(out.content[0]!.text).toContain("```diff");
+		// combined 600 changed lines → should hit 400-line cap
+		expect(out.content[0]!.text).toContain("[Diff truncated:");
+	});
+});


### PR DESCRIPTION
Option 1 — fenced ```diff card in edit result text.

Implements hash-anchored unified diff (genDiff, 1 context line, stable hashes) as fenced block appended to success summary. Truncates via truncateHead at 400 lines / 80KB with [Diff truncated: showing X/Y] hint. Covers buildChanged (single-file) and buildBatchResult (multi-file --- path --- headers); empty-file and noop paths unchanged. details.diff remains raw for programmatic use.

Tests: test/core/diff-card.test.ts (6 cases) — fenced block, warning ordering, empty-file no fence, large-diff truncation, batch headers and batch truncation. Gate: pnpm run typecheck pass, 775 tests pass, biome check clean. DSH install verified via dsh plugin --profile web add link: and --dump-config shows # == dsh-better-edit layer; lib/edit-response.js contains DIFF_CARD_MAX_*.

This pushes diff card text manually to model via content[0].text (model-facing), not a separate UI channel.

Resolves diff-card Option 1 investigation.