### PR TITLE
fix(hashline)!: remove boundaryDups auto-fix (Closes #38)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@
 
 ### Fixed
 
+- **hashline:** remove boundaryDups auto-fix (BREAKING CHANGE)
 - **ci:** add neural version check to Verify and Release
+
+### Documentation
+
+- **adr:** add ADR-0007 removing boundaryDups auto-fix
 
 ## [0.5.1](https://github.com/Rianico/dsh-better-edit/compare/v0.5.0...v0.5.1) (2026-08-30)
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -145,6 +145,10 @@ _Avoid_: E_HASH_ECHO (ambiguous between write/edit)
 Refusal of an `edit` whose `replacement_text` contains a served hash echo at the range-relative position — `[E_EDIT_HASH_ECHO] Refused edit to ${path}: replacement line ${k} begins with the exact ${hash}│ anchor served for this session, path, and range-relative line. Remove the copied anchors and retry. Nothing was written.` Deny, not strip — fail-loud, compensable (AA: A).
 _Avoid_: E_WRITE_HASH_ECHO (write-only), generic strip
 
+**boundary duplicate (historical, removed by ADR-0007):**
+Auto-spliced `replacement_text` edge when it equaled an adjacent file line — `trailingDups`/`leadingDups` (byte `===`, 1-line) and `firstNewAfterDups`/`lastNewBeforeDups` (`canon()` + `sectionIsUnique`). Removed — tool is now pure `range = [remove_from, remove_to]` by hash, `replacement = exact replacement_text`; a duplicate stays as a loud duplicate the model fixes next turn (see ADR-0007).
+_Avoid_: boundaryDups
+
 ### Guidance
 
 **Prompt section**:

--- a/docs/adr/0007-remove-boundarydups-autofix.md
+++ b/docs/adr/0007-remove-boundarydups-autofix.md
@@ -1,0 +1,40 @@
+# Remove boundaryDups auto-fix — tool is pure range+replacement
+
+Date: 2026-08-31
+
+## Status
+
+accepted
+
+## Context
+
+`AnchorPipeline` (`src/hashline/anchor-pipeline.ts`) auto-spliced `replacement_text` when its edge equaled an adjacent file line. Four helpers formed the seam: `trailingDups`/`leadingDups` (byte `===` vs `fileLines[endLine+k]` / `fileLines[startLine-2-k]`, 1-line threshold) and `firstNewAfterDups`/`lastNewBeforeDups` (`canon()` + `sectionIsUnique` gate on the first genuinely new line). Origin `ec472e1`/`1d71c29` was copy-paste slip of a diff block; the invariant was `swapReversed → stripBare → stripDiff → valEdit → boundaryDups splice → valEdit → verifyServed → resToSpan`.
+
+Downstream `dsh-better-edit#38` proved the 1-line byte trap breaks the `model–tool boundary` (`CONTEXT.md`): `a\nb` over `a` (`Wot..Wot "a\nb"`) → `2` not `3` lines (`a\nb\nb\n`); `case A` C++ switch (`lA0..AU6`) → `9` not `10` lines, outermost `}` lost, every later line mis-nested. `firstNewAfter`/`lastNewBefore` share the same surprise — `canon` equality still rewrites intent. Models now reliably pass correct `remove_from`/`remove_to` hashes; a loud duplicate is reversible (next edit deletes it), silent loss is not.
+
+## Decision
+
+Delete all four `boundaryDups` helpers and their seam: `trailingDups`, `leadingDups`, `firstNewAfterDups`, `lastNewBeforeDups`, plus `sectionIsUnique`, `canonCounts`, `findNewEdge` (kept only as stub if re-exported), `BDup`/`AutoFix` types, `boundaryDups` field in `valEdit`, and the `splice → second valEdit` block in `applyEdit`. `AnchorPipeline` invariant becomes:
+
+```
+swapReversed → stripBare → stripDiff → valEdit → verifyServed → resToSpan
+```
+
+`replacement_text` is taken literally; `range = [remove_from, remove_to]` by hash, `replacement` is exact. No auto-splice, no new error code.
+
+## Considered Options
+
+- **Keep all four (status quo):** preserves diff-block paste ergonomic, but keeps 1-line `}` loss and violates `anchor philosophy: rejected, never fuzzy-matched`. Rejected.
+- **Raise threshold to ≥2 consecutive lines:** fixes `#38` single-`}` case but `}\n}` (2-line run per `1d71c29`) still silently loses, still guesses intent. Rejected — still violates `model owns intent`.
+- **Fail-closed `E_BOUNDARY_DUP` on three-in-a-row (`last == remove_to == endLine+1`):** converts silent loss to loud reject-and-serve, consistent with `E_RANGE_*`. Viable but punishes legitimate intentional duplicate (`a\nb` where model *did* want `b` twice) and adds a new code models have never seen. Deferred.
+- **Symmetric extend (also delete `fileLines[endLine+k]`):** keeps file length consistent (`1b4d7e6` gap) but changes `hash_bounds` meaning behind model's back (`remove 1` deletes `2`). Rejected — same surprise, worse contract.
+- **Delete all four (chosen):** removes surprise, keeps `model–tool boundary` pure, makes file result predictable (`a\nb` over `a` → `3` lines, `case` → `10`). Loud duplicate is visible in post-edit diff (`details` per ADR-0006) and fixable next turn. Hard to reverse silently (fork must re-add seam), but that's the point — surprising without context.
+
+## Consequences
+
+- `src/hashline/anchor-pipeline.ts` — invariant trimmed, imports `firstNonEmptyIndex`/`lastNonEmptyIndex` removed, `HashAssign.canon` import kept for `verifyServed` only.
+- `CONTEXT.md` — `boundary duplicate` marked `historical, removed by ADR-0007`; `model–tool boundary` sharpened (tool never rewrites `replacement_text`).
+- Tests — `hashline-apply-internals`, `hashline-fuzz-autofix` drop run-semantics; expectations become `no dedup` (`a\nb` → `3`). No new `E_BOUNDARY_DUP` code.
+- Prompt stays `replacement_text is bare content without HASH│`; no guidance change.
+- Breaking: one major bump (`feat(hashline)!`); downstream forks re-adding the seam must own the surprise.
+

--- a/src/hashline/anchor-pipeline.ts
+++ b/src/hashline/anchor-pipeline.ts
@@ -2,16 +2,14 @@
  * AnchorPipeline — deep module owning the anchor autofix chain.
  *
  * Single ordering invariant (private):
- *   swapReversed → stripBare → stripDiff → valEdit → boundaryDups splice → valEdit → verifyServed → resToSpan
+ *   swapReversed → stripBare → stripDiff → valEdit → verifyServed → resToSpan
  *
- * Detection (valEdit → boundaryDups[]) and correction (splice + second valEdit)
- * were split across resolve.ts / apply.ts with an implicit coupling.
- * This seam co-locates that invariant. Public surface is two functions:
+ * This seam co-locates the ordering invariant. Public surface is two functions:
  *   resEdit  — pre-validation (tool-layer, no file state)
  *   applyEdit — full pipeline (file + hashes + served verification)
  *
  * Private to this seam (not re-exported): stripBarePrefixes, stripDiffPrefixes,
- * swapReversedRanges, valEdit, boundaryDups helpers, warnUnicodeEsc, findNewEdge,
+ * swapReversedRanges, valEdit, warnUnicodeEsc,
  * resAnchorFromMap, assertAligned, etc. They remain exported from resolve.ts
  * for backwards compat but are marked @internal and should be imported via this
  * module only.
@@ -19,7 +17,7 @@
  * @module dsh-better-edit/hashline/anchor-pipeline
  */
 
-import { abortIf, splitLines, rejectUnknownFields, firstNonEmptyIndex, lastNonEmptyIndex, clipLine } from "../utils.js";
+import { abortIf, splitLines, rejectUnknownFields, clipLine } from "../utils.js";
 import { HASH_CLASS, HL_BARE_PREFIX_RE, HL_PREFIX_PLUS_RE, HL_PREFIX_MINUS_RE, HASH_SEP, ANCHOR_LEN, ALPH_RE, canon, lineHashesPure, getCanonForHash, rememberHashCanon } from "./hash-assign.js";
 import { recordServed, servedPositionsOf } from "../session-view.js";
 import { SERVED_ECHO_CAP } from "../constants.js";
@@ -100,17 +98,6 @@ interface HMismatch {
 	kind: "not_found" | "ambiguous";
 	candidates?: number[];
 	context?: RAnchor;
-}
-
-export interface BDup {
-	kind: "trailing" | "leading" | "first-new-after" | "last-new-before";
-	replacementLineIndex: number;
-}
-
-export interface AutoFix {
-	kind: "trailing" | "leading" | "first-new-after" | "last-new-before";
-	removedLine: string;
-	removedLineIndex: number;
 }
 
 export interface NEdit {
@@ -401,148 +388,7 @@ function swapReversedRanges(
 	return { ...edit, hash_bounds: [endRef, startRef] as [Anchor, Anchor] };
 }
 
-function trailingDups(
-	contentLines: string[],
-	fileLines: string[],
-	endLine: number,
-): BDup[] {
-	const start = lastNonEmptyIndex(contentLines);
-	if (start < 0) return [];
-	const dups: BDup[] = [];
-	const maxK = Math.min(start + 1, fileLines.length - endLine);
-	for (let k = 0; k < maxK; k++) {
-		if (contentLines[start - k] !== fileLines[endLine + k]) break;
-		dups.push({ kind: "trailing", replacementLineIndex: start - k });
-	}
-	return dups;
-}
-
-function leadingDups(
-	contentLines: string[],
-	fileLines: string[],
-	startLine: number,
-): BDup[] {
-	const start = firstNonEmptyIndex(contentLines);
-	if (start < 0) return [];
-	const dups: BDup[] = [];
-	const maxK = Math.min(contentLines.length - start, startLine - 1);
-	for (let k = 0; k < maxK; k++) {
-		if (contentLines[start + k] !== fileLines[startLine - 2 - k]) break;
-		dups.push({ kind: "leading", replacementLineIndex: start + k });
-	}
-	return dups;
-}
-
-function sectionIsUnique(
-	canonLines: string[],
-	start: number,
-	length: number,
-): boolean {
-	let count = 0;
-	for (let i = 0; i + length <= canonLines.length; i++) {
-		let k = 0;
-		while (k < length && canonLines[i + k] === canonLines[start + k]) k++;
-		if (k < length) continue;
-		count++;
-		if (count > 1) return false;
-	}
-	return true;
-}
-
-function firstNewAfterDups(
-	contentLines: string[],
-	rangeLines: string[],
-	canonLines: string[],
-	endLine: number,
-): BDup[] {
-	const firstNew = findNewEdge(contentLines, rangeLines, false);
-	if (!firstNew) return [];
-	const maxK = Math.min(
-		contentLines.length - firstNew.index,
-		canonLines.length - endLine,
-	);
-	let runLen = 0;
-	while (
-		runLen < maxK &&
-		canon(contentLines[firstNew.index + runLen]!) ===
-			canonLines[endLine + runLen]!
-	) {
-		runLen++;
-	}
-	if (runLen === 0 || !sectionIsUnique(canonLines, endLine, runLen)) return [];
-	const dups: BDup[] = [];
-	for (let k = 0; k < runLen; k++) {
-		dups.push({
-			kind: "first-new-after",
-			replacementLineIndex: firstNew.index + k,
-		});
-	}
-	return dups;
-}
-
-function lastNewBeforeDups(
-	contentLines: string[],
-	rangeLines: string[],
-	canonLines: string[],
-	startLine: number,
-): BDup[] {
-	const lastNew = findNewEdge(contentLines, rangeLines, true);
-	if (!lastNew) return [];
-	const maxK = Math.min(lastNew.index + 1, startLine - 1);
-	let runLen = 0;
-	while (
-		runLen < maxK &&
-		canon(contentLines[lastNew.index - runLen]!) ===
-			canonLines[startLine - 2 - runLen]!
-	) {
-		runLen++;
-	}
-	if (runLen === 0) return [];
-	const sectionStart = startLine - 1 - runLen;
-	if (!sectionIsUnique(canonLines, sectionStart, runLen)) return [];
-	const dups: BDup[] = [];
-	for (let k = 0; k < runLen; k++) {
-		dups.push({
-			kind: "last-new-before",
-			replacementLineIndex: lastNew.index - k,
-		});
-	}
-	return dups;
-}
-
-function canonCounts(lines: string[]): Map<string, number> {
-	const counts = new Map<string, number>();
-	for (const line of lines) {
-		const key = canon(line);
-		counts.set(key, (counts.get(key) ?? 0) + 1);
-	}
-	return counts;
-}
-
 /** @internal — private to anchor-pipeline seam */
-export function findNewEdge(
-	contentLines: string[],
-	rangeLines: string[],
-	fromEnd: boolean,
-): { index: number; line: string } | undefined {
-	const multiset = canonCounts(rangeLines);
-	const step = fromEnd ? -1 : 1;
-	const start = fromEnd ? contentLines.length - 1 : 0;
-	for (let i = start; i >= 0 && i < contentLines.length; i += step) {
-		const line = contentLines[i]!;
-		if (line.length === 0) continue;
-		const key = canon(line);
-		const count = multiset.get(key) ?? 0;
-		if (count > 0) {
-			multiset.set(key, count - 1);
-		} else {
-			return { index: i, line };
-		}
-	}
-	return undefined;
-}
-
-/** @internal — private to anchor-pipeline seam: detection + boundaryDups belongs to AnchorPipeline ordering */
 function valEdit(
 	edit: HEdit,
 	fileLines: string[],
@@ -552,11 +398,9 @@ function valEdit(
 ): {
 	resolved: RHEdit | undefined;
 	mismatches: HMismatch[];
-	boundaryDups: BDup[];
 } {
 	assertAligned(fileLines, fileHashes, "valEdit");
 	const mismatches: HMismatch[] = [];
-	const boundaryDups: BDup[] = [];
 
 	const hashIndex = new Map<string, number[]>();
 	for (let i = 0; i < fileHashes.length; i++) {
@@ -592,7 +436,7 @@ function valEdit(
 			if (endMismatch && endMismatch.kind === "not_found")
 				endMismatch.context = startResolved;
 		}
-		return { resolved: undefined, mismatches, boundaryDups };
+		return { resolved: undefined, mismatches };
 	}
 	if (startResolved.line > endResolved.line) {
 		throw new Error(
@@ -600,29 +444,16 @@ function valEdit(
 		);
 	}
 	const endLine = endResolved.line;
-	const rangeLines = fileLines.slice(startResolved.line - 1, endLine);
-	const canonLines = fileLines.map((line) => canon(line));
-	boundaryDups.push(
-		...trailingDups(edit.content_lines, fileLines, endLine),
-		...leadingDups(edit.content_lines, fileLines, startResolved.line),
-		...firstNewAfterDups(edit.content_lines, rangeLines, canonLines, endLine),
-		...lastNewBeforeDups(
-			edit.content_lines,
-			rangeLines,
-			canonLines,
-			startResolved.line,
-		),
-	);
-
 	return {
 		resolved: {
 			content_lines: edit.content_lines,
 			hash_bounds: [startResolved, endResolved],
 		},
 		mismatches,
-		boundaryDups,
 	};
 }
+
+export function findNewEdge(): undefined { return undefined; }
 
 export { warnUnicodeEsc };
 
@@ -1169,7 +1000,6 @@ export function applyEdit(
 	range: ResolvedRange;
 	warnings?: string[];
 	noopEdit?: NEdit;
-	autoFixes?: AutoFix[];
 } {
 	abortIf(signal);
 
@@ -1186,7 +1016,6 @@ export function applyEdit(
 	const {
 		resolved: initialResolved,
 		mismatches,
-		boundaryDups,
 	} = valEdit(prefixFixed, lineIndex.fileLines, fileHashes, warnings, signal);
 	if (mismatches.length || !initialResolved) {
 		const { message, servedRows } = fmtMismatchWithServes(
@@ -1200,52 +1029,7 @@ export function applyEdit(
 
 	warnUnicodeEsc(prefixFixed, warnings);
 
-	let resolved = initialResolved;
-	let autoFixes: AutoFix[] | undefined;
-	if (boundaryDups.length > 0) {
-		autoFixes = [];
-		const correctedEdit: HEdit = {
-			...prefixFixed,
-			content_lines: [...prefixFixed.content_lines],
-		};
-		const seen = new Set<number>();
-		const uniqueDups: BDup[] = [];
-		for (const dup of boundaryDups) {
-			if (seen.has(dup.replacementLineIndex)) continue;
-			seen.add(dup.replacementLineIndex);
-			uniqueDups.push(dup);
-		}
-		const dupsByIndex = uniqueDups.sort(
-			(a, b) => b.replacementLineIndex - a.replacementLineIndex,
-		);
-		for (const dup of dupsByIndex) {
-			const idx = dup.replacementLineIndex;
-			if (idx < 0 || idx >= correctedEdit.content_lines.length) continue;
-			const removed = correctedEdit.content_lines.splice(idx, 1)[0];
-			autoFixes.push({
-				kind: dup.kind,
-				removedLine: removed,
-				removedLineIndex: idx,
-			});
-		}
-		const correctedResult = valEdit(
-			correctedEdit,
-			lineIndex.fileLines,
-			fileHashes,
-			warnings,
-			signal,
-		);
-		if (correctedResult.mismatches.length || !correctedResult.resolved) {
-			const { message, servedRows } = fmtMismatchWithServes(
-				correctedResult.mismatches,
-				lineIndex.fileLines,
-				fileHashes,
-				filePath,
-			);
-			throw new AnchorMismatchError(message, servedRows);
-		}
-		resolved = correctedResult.resolved;
-	}
+	const resolved = initialResolved;
 
 if (served) {
 		const startLineEcho = resolved.hash_bounds[0].line;
@@ -1296,7 +1080,6 @@ if (served) {
 		lastChangedLine: changed?.lastChangedLine,
 		range: resolvedRange(resolved),
 		...(warnings.length ? { warnings } : {}),
-		...(autoFixes ? { autoFixes } : {}),
 	};
 }
 

--- a/src/hashline/index.ts
+++ b/src/hashline/index.ts
@@ -30,7 +30,7 @@ export { parseHashRef, parseText } from "./parse.js";
 export type { Anchor } from "./parse.js";
 
 export { resEdit } from "./anchor-pipeline.js";
-export type { HEdit, HTEdit, NEdit, BDup, AutoFix } from "./anchor-pipeline.js";
+export type { HEdit, HTEdit, NEdit } from "./anchor-pipeline.js";
 
 export {
 	applyEdit,

--- a/src/mutation/engine.ts
+++ b/src/mutation/engine.ts
@@ -276,7 +276,7 @@ export async function applyOne(
 		edit,
 		input.countHashes ?? input.hashes,
 		noop,
-		anchorResult.autoFixes?.length ?? 0,
+		0,
 	);
 
 	return {

--- a/test/core/coverage-agent-c-anchor-pipeline.test.ts
+++ b/test/core/coverage-agent-c-anchor-pipeline.test.ts
@@ -106,17 +106,19 @@ describe("coverage: anchor-pipeline applyEdit", () => {
     expect(result.content).toContain("X");
   });
 
-  it("detects boundary dups trailing/leading and auto-fixes", () => {
+  it("keeps boundary dups (no auto-fix) trailing/leading", () => {
     const content = "a\nb\nc\nd\ne";
     const hashes = lineHashesPure(content);
-    // edit replacing lines 2-3 (b,c) but include trailing dup d which equals file line after range
+    // edit replacing lines 2-3 (b,c) but include trailing dup d which equals file line after range — now kept
     const edit: any = { hash_bounds: [{ hash: hashes[1]! }, { hash: hashes[2]! }], content_lines: ["B", "C", "d"] };
     const result = applyEdit(content, edit, undefined, hashes);
-    expect(result.autoFixes?.length).toBeGreaterThan(0);
+    expect(result.autoFixes ?? []).toHaveLength(0);
+    expect(result.content).toBe("a\nB\nC\nd\nd\ne");
     // also test leading dup
     const edit2: any = { hash_bounds: [{ hash: hashes[1]! }, { hash: hashes[2]! }], content_lines: ["a", "B", "C"] };
     const result2 = applyEdit(content, edit2, undefined, hashes);
-    expect(result2.autoFixes?.length).toBeGreaterThan(0);
+    expect(result2.autoFixes ?? []).toHaveLength(0);
+    expect(result2.content).toBe("a\na\nB\nC\nd\ne");
   });
 
   it("throws on stale anchors", () => {
@@ -161,11 +163,11 @@ describe("coverage: anchor-pipeline applyEdit", () => {
     const edit: any = { hash_bounds: [{ hash: hashes[0]! }, { hash: hashes[0]! }], content_lines: [] };
     expect(() => applyEdit(content, edit, undefined, hashes)).toThrow(/E_WOULD_EMPTY/);
   });
-  it("findNewEdge works for leading/trailing new content", () => {
-    expect(findNewEdge(["new", "b", "c"], ["b", "c"], false)).toBeDefined();
-    expect(findNewEdge(["a", "b", "new"], ["a", "b"], true)).toBeDefined();
+  it("findNewEdge stub returns undefined (boundaryDups removed)", () => {
+    expect(findNewEdge(["new", "b", "c"], ["b", "c"], false)).toBeUndefined();
+    expect(findNewEdge(["a", "b", "new"], ["a", "b"], true)).toBeUndefined();
     expect(findNewEdge(["a", "b"], ["a", "b"], false)).toBeUndefined();
-    expect(findNewEdge(["", "new"], ["a"], false)).toBeDefined();
+    expect(findNewEdge(["", "new"], ["a"], false)).toBeUndefined();
   });
 
   it("warnUnicodeEsc adds warning", () => {

--- a/test/core/coverage-agent-f-anchor-pipeline.test.ts
+++ b/test/core/coverage-agent-f-anchor-pipeline.test.ts
@@ -103,22 +103,22 @@ describe("coverage-f: anchor-pipeline fmtMismatch", () => {
   });
 });
 
-describe("coverage-f: anchor-pipeline boundary dups & warnings", () => {
-  it("covers trailing/leading dup autoFix via applyEdit", () => {
+describe("coverage-f: anchor-pipeline no boundary dups (removed)", () => {
+  it("keeps trailing/leading dup (no autoFix)", () => {
     const content = "a\nb\nc\nd\ne";
     const hashes = lineHashesPure(content);
-    // trailing dup: replacement includes next line's content
+    // trailing dup: replacement includes next line's content — now kept
     const edit1: any = { hash_bounds: [{ hash: hashes[1]! }, { hash: hashes[2]! }], content_lines: ["B", "C", "d"] };
     const r1 = applyEdit(content, edit1, undefined, hashes);
-    expect(r1.autoFixes !== undefined).toBe(true);
+    expect((r1 as any).autoFixes ?? (r1 as any).nes).toBeUndefined();
     // leading dup
     const edit2: any = { hash_bounds: [{ hash: hashes[1]! }, { hash: hashes[2]! }], content_lines: ["a", "B", "C"] };
     const r2 = applyEdit(content, edit2, undefined, hashes);
-    expect(r2.autoFixes !== undefined).toBe(true);
+    expect((r2 as any).autoFixes ?? (r2 as any).nes).toBeUndefined();
   });
-  it("covers findNewEdge and buildRangeEcho", () => {
-    expect(findNewEdge(["new", "b"], ["b"], false)).toBeDefined();
-    expect(findNewEdge(["a", "new"], ["a"], true)).toBeDefined();
+  it("covers findNewEdge stub and buildRangeEcho", () => {
+    expect(findNewEdge(["new", "b"], ["b"], false)).toBeUndefined();
+    expect(findNewEdge(["a", "new"], ["a"], true)).toBeUndefined();
     expect(findNewEdge(["a"], ["a"], false)).toBeUndefined();
     const hashes = lineHashesPure("a\nb\nc\nd");
     const rows = buildRangeEcho(1, 4, hashes);

--- a/test/core/hashline-apply-internals.test.ts
+++ b/test/core/hashline-apply-internals.test.ts
@@ -42,30 +42,27 @@ resEdit(
   });
 });
 
-describe("checkBoundaryDup (via applyEdit) — auto-fix", () => {
-  it("auto-fixes trailing duplication", async () => {
+describe("checkBoundaryDup (via applyEdit) — no auto-fix (removed)", () => {
+  it("keeps trailing duplication (no auto-fix)", async () => {
     const content = "a\nb\nc\nd";
     const hashes = await lineHashes(content, home.testPath);
     const result = applyEdit(content, 
 resEdit(
       { remove_from: hashes[1]!, remove_to: hashes[2]!, replacement_text: "X\nd" },
     ));
-    expect(result.content).toBe("a\nX\nd");
-    expect(result.autoFixes).toBeDefined();
-    expect(result.autoFixes).toHaveLength(1);
-    expect(result.autoFixes![0]!.kind).toBe("trailing");
+    expect(result.content).toBe("a\nX\nd\nd");
+    expect(result.autoFixes ?? []).toHaveLength(0);
   });
 
-  it("auto-fixes leading duplication", async () => {
+  it("keeps leading duplication (no auto-fix)", async () => {
     const content = "a\nb\nc\nd";
     const hashes = await lineHashes(content, home.testPath);
     const result = applyEdit(content, 
 resEdit(
       { remove_from: hashes[1]!, remove_to: hashes[2]!, replacement_text: "a\nX" },
     ));
-    expect(result.content).toBe("a\nX\nd");
-    expect(result.autoFixes).toHaveLength(1);
-    expect(result.autoFixes![0]!.kind).toBe("leading");
+    expect(result.content).toBe("a\na\nX\nd");
+    expect(result.autoFixes ?? []).toHaveLength(0);
   });
 
   it("does not auto-fix when replacement does not duplicate adjacent lines", async () => {
@@ -88,41 +85,37 @@ resEdit(
     expect(result.autoFixes ?? []).toHaveLength(0);
   });
 
-  it("auto-fixes trailing duplication when content_lines has trailing empty lines", async () => {
+  it("keeps trailing duplication when content_lines has trailing empty lines (no auto-fix)", async () => {
     const content = "a\nb\nc\nd";
     const hashes = await lineHashes(content, home.testPath);
     const result = applyEdit(content, 
 resEdit(
       { remove_from: hashes[1]!, remove_to: hashes[2]!, replacement_text: `X\nd\n` },
     ));
-    expect(result.content).toBe("a\nX\n\nd");
-    expect(result.autoFixes).toHaveLength(1);
-    expect(result.autoFixes![0]!.kind).toBe("trailing");
-    expect(result.autoFixes![0]!.removedLine).toBe("d");
+    expect(result.content).toBe("a\nX\nd\n\nd");
+    expect(result.autoFixes ?? []).toHaveLength(0);
   });
 
-  it("auto-fixes leading duplication when content_lines has leading empty lines", async () => {
+  it("keeps leading duplication when content_lines has leading empty lines (no auto-fix)", async () => {
     const content = "a\nb\nc\nd";
     const hashes = await lineHashes(content, home.testPath);
     const result = applyEdit(content, 
 resEdit(
       { remove_from: hashes[1]!, remove_to: hashes[2]!, replacement_text: `\na\nX` },
     ));
-    expect(result.content).toBe("a\n\nX\nd");
-    expect(result.autoFixes).toHaveLength(1);
-    expect(result.autoFixes![0]!.kind).toBe("leading");
-    expect(result.autoFixes![0]!.removedLine).toBe("a");
+    expect(result.content).toBe("a\n\na\nX\nd");
+    expect(result.autoFixes ?? []).toHaveLength(0);
   });
 
-  it("auto-fixes both trailing and leading in one edit", async () => {
+  it("keeps both trailing and leading duplication in one edit (no auto-fix)", async () => {
     const content = "a\nb\nc\nd";
     const hashes = await lineHashes(content, home.testPath);
     const result = applyEdit(content, 
 resEdit(
       { remove_from: hashes[1]!, remove_to: hashes[2]!, replacement_text: "a\nd" },
     ));
-    expect(result.content).toBe("a\nd");
-    expect(result.autoFixes).toHaveLength(2);
+    expect(result.content).toBe("a\na\nd\nd");
+    expect(result.autoFixes ?? []).toHaveLength(0);
   });
 });
 
@@ -231,96 +224,89 @@ resEdit(
   });
 });
 
-describe("auto-fix via applyEdit", () => {
-  it("auto-fixes trailing duplication", async () => {
+describe("no auto-fix via applyEdit (removed)", () => {
+  it("keeps trailing duplication (no auto-fix)", async () => {
     const content = "before\nold one\nold two\nafter";
     const hashes = await lineHashes(content, home.testPath);
     const result = applyEdit(content, 
 resEdit(
       { remove_from: hashes[1]!, remove_to: hashes[2]!, replacement_text: `new one\nnew two\nafter` },
     ));
-    expect(result.autoFixes).toHaveLength(1);
-    expect(result.autoFixes![0]!.kind).toBe("trailing");
-    expect(result.autoFixes![0]!.removedLine).toBe("after");
-    expect(result.content).toBe("before\nnew one\nnew two\nafter");
+    expect(result.autoFixes ?? []).toHaveLength(0);
+    expect(result.content).toBe("before\nnew one\nnew two\nafter\nafter");
   });
 
-  it("auto-fixes leading duplication", async () => {
+  it("keeps leading duplication (no auto-fix)", async () => {
     const content = "before\nold one\nold two\nafter";
     const hashes = await lineHashes(content, home.testPath);
     const result = applyEdit(content, 
 resEdit(
       { remove_from: hashes[1]!, remove_to: hashes[2]!, replacement_text: `before\nnew one\nnew two` },
     ));
-    expect(result.autoFixes).toHaveLength(1);
-    expect(result.autoFixes![0]!.kind).toBe("leading");
-    expect(result.autoFixes![0]!.removedLine).toBe("before");
-    expect(result.content).toBe("before\nnew one\nnew two\nafter");
+    expect(result.autoFixes ?? []).toHaveLength(0);
+    expect(result.content).toBe("before\nbefore\nnew one\nnew two\nafter");
   });
 
-  it("auto-fixes both leading and trailing in one edit", async () => {
+  it("keeps both leading and trailing duplication (no auto-fix)", async () => {
     const content = "ctx1\nctx2\nold1\nold2\nctx3\nctx4";
     const hashes = await lineHashes(content, home.testPath);
     const result = applyEdit(content, 
 resEdit(
       { remove_from: hashes[2]!, remove_to: hashes[3]!, replacement_text: `ctx2\ndup\ndup\nctx3` },
     ));
-    expect(result.autoFixes).toBeDefined();
-    expect(result.autoFixes).toHaveLength(2);
-    expect(result.content).toBe("ctx1\nctx2\ndup\ndup\nctx3\nctx4");
+    expect(result.autoFixes ?? []).toHaveLength(0);
+    expect(result.content).toBe("ctx1\nctx2\nctx2\ndup\ndup\nctx3\nctx3\nctx4");
   });
 });
 
-describe("boundary-dup autocorrection (via applyEdit)", () => {
-  it("strips a trailing duplicate without a warning", async () => {
+describe("boundary-dup no autocorrection (removed)", () => {
+  it("keeps a trailing duplicate (no auto-fix)", async () => {
     const content = "a\nb\nc\nd";
     const hashes = await lineHashes(content, home.testPath);
     const result = applyEdit(content, 
 resEdit(
       { remove_from: hashes[1]!, remove_to: hashes[2]!, replacement_text: "X\nd" },
     ));
-    expect(result.content).toBe("a\nX\nd");
+    expect(result.content).toBe("a\nX\nd\nd");
     expect(result.warnings).toBeUndefined();
-    expect(result.autoFixes).toHaveLength(1);
-    expect(result.autoFixes![0]!.kind).toBe("trailing");
-    expect(result.autoFixes![0]!.removedLineIndex).toBe(1);
+    expect(result.autoFixes ?? []).toHaveLength(0);
   });
 
-  it("strips a new line duplicating a unique line after the range (noop)", async () => {
+  it("keeps duplicate after range (no auto-fix, not noop)", async () => {
     const content = "class A {\n  x = 1;\n\n  constructor() {}\n}\n";
     const hashes = await lineHashes(content, home.testPath);
     const result = applyEdit(content, 
 resEdit(
       { remove_from: hashes[0]!, remove_to: hashes[2]!, replacement_text: "class A {\n  x = 1;\n\n  constructor() {}\n}" },
     ));
-    expect(result.content).toBe(content);
-    expect(result.noopEdit).toBeDefined();
+    // With no dedup, replacement duplicates the following line, so not noop
+    expect(result.content).toBe("class A {\n  x = 1;\n\n  constructor() {}\n}\n  constructor() {}\n}\n");
+    expect(result.noopEdit).toBeUndefined();
     expect(result.warnings).toBeUndefined();
-    expect(result.autoFixes).toBeUndefined();
+    expect(result.autoFixes ?? []).toHaveLength(0);
   });
 
-  it("strips a new line duplicating a unique line before the range (noop)", async () => {
+  it("keeps duplicate even when unique line before range (no auto-fix, not noop)", async () => {
     const content = "foo();\nbar();\nbaz();\n";
     const hashes = await lineHashes(content, home.testPath);
     const result = applyEdit(content, 
 resEdit(
       { remove_from: hashes[1]!, remove_to: hashes[2]!, replacement_text: "bar();\nbaz();\nfoo();" },
     ));
-    expect(result.content).toBe(content);
-    expect(result.noopEdit).toBeDefined();
-    expect(result.autoFixes).toBeUndefined();
+    expect(result.content).toBe("foo();\nbar();\nbaz();\nfoo();\n");
+    expect(result.noopEdit).toBeUndefined();
+    expect(result.autoFixes ?? []).toHaveLength(0);
   });
 
-  it("does not strip new-line duplicates when the adjacent line is not unique in the file", async () => {
+  it("keeps new-line duplicates even when adjacent line is not unique (no auto-fix)", async () => {
     const content = "if (a) {\n  x();\n}\nif (b) {\n  y();\n}\n";
     const hashes = await lineHashes(content, home.testPath);
     const result = applyEdit(content, 
 resEdit(
       { remove_from: hashes[3]!, remove_to: hashes[4]!, replacement_text: "if (b) {\n  yNew();\n}" },
     ));
-    expect(result.content).toBe("if (a) {\n  x();\n}\nif (b) {\n  yNew();\n}\n");
+    expect(result.content).toBe("if (a) {\n  x();\n}\nif (b) {\n  yNew();\n}\n}\n");
     expect(result.warnings).toBeUndefined();
-    expect(result.autoFixes).toHaveLength(1);
-    expect(result.autoFixes![0]!.kind).toBe("trailing");
+    expect(result.autoFixes ?? []).toHaveLength(0);
   });
 });

--- a/test/core/hashline-fuzz-autofix.test.ts
+++ b/test/core/hashline-fuzz-autofix.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
 import { applyEdit, lineHashes, resEdit, canon } from "../../src/hashline/index.js";
-import { findNewEdge } from "../../src/hashline/anchor-pipeline.js";
 import {
   firstNonEmptyIndex,
   lastNonEmptyIndex,
@@ -98,73 +97,8 @@ function applyAutoFix(
   s: number,
   e: number,
 ): { fixed: string[]; fixes: { kind: string; removedLine: string; removedLineIndex: number }[] } {
-  const dups: { kind: string; index: number }[] = [];
-  const lastIdx = lastNonEmptyIndex(repl);
-  if (lastIdx >= 0) {
-    for (let k = 0; lastIdx - k >= 0 && e + k < fileLines.length; k++) {
-      if (repl[lastIdx - k] !== fileLines[e + k]) break;
-      dups.push({ kind: "trailing", index: lastIdx - k });
-    }
-  }
-  const firstIdx = firstNonEmptyIndex(repl);
-  if (firstIdx >= 0) {
-    for (let k = 0; firstIdx + k < repl.length && s - 2 - k >= 0; k++) {
-      if (repl[firstIdx + k] !== fileLines[s - 2 - k]) break;
-      dups.push({ kind: "leading", index: firstIdx + k });
-    }
-  }
-  const rangeLines = fileLines.slice(s - 1, e);
-  const firstNew = findNewEdge(repl, rangeLines, false);
-  if (firstNew) {
-    let runLen = 0;
-    while (
-      firstNew.index + runLen < repl.length &&
-      e + runLen < fileLines.length &&
-      canon(repl[firstNew.index + runLen]!) === canon(fileLines[e + runLen]!)
-    ) {
-      runLen++;
-    }
-    if (runLen > 0 && sectionCount(fileLines, e, runLen) === 1) {
-      for (let k = 0; k < runLen; k++) {
-        dups.push({ kind: "first-new-after", index: firstNew.index + k });
-      }
-    }
-  }
-  const lastNew = findNewEdge(repl, rangeLines, true);
-  if (lastNew) {
-    let runLen = 0;
-    while (
-      lastNew.index - runLen >= 0 &&
-      s - 2 - runLen >= 0 &&
-      canon(repl[lastNew.index - runLen]!) === canon(fileLines[s - 2 - runLen]!)
-    ) {
-      runLen++;
-    }
-    if (runLen > 0) {
-      const sectionStart = s - 1 - runLen;
-      if (sectionCount(fileLines, sectionStart, runLen) === 1) {
-        for (let k = 0; k < runLen; k++) {
-          dups.push({ kind: "last-new-before", index: lastNew.index - k });
-        }
-      }
-    }
-  }
-  const seen = new Set<number>();
-  const unique: { kind: string; index: number }[] = [];
-  for (const dup of dups) {
-    if (seen.has(dup.index)) continue;
-    seen.add(dup.index);
-    unique.push(dup);
-  }
-  unique.sort((a, b) => b.index - a.index);
-  const fixed = [...repl];
-  const fixes: { kind: string; removedLine: string; removedLineIndex: number }[] = [];
-  for (const dup of unique) {
-    if (dup.index < 0 || dup.index >= fixed.length) continue;
-    fixes.push({ kind: dup.kind, removedLine: fixed[dup.index]!, removedLineIndex: dup.index });
-    fixed.splice(dup.index, 1);
-  }
-  return { fixed, fixes };
+  // boundaryDups removed — no auto-fix, pure replacement
+  return { fixed: [...repl], fixes: [] };
 }
 
 type StepResult = {
@@ -245,7 +179,7 @@ describe("fuzz: boundary-dup autocorrection with hash stability", () => {
       if (state.autofixed) autofixed++;
       if (state.noop) noop++;
     }
-    expect(autofixed).toBeGreaterThan(100);
+    expect(autofixed).toBe(0);
     expect(noop).toBeGreaterThan(20);
   }, 120_000);
 
@@ -270,6 +204,6 @@ describe("fuzz: boundary-dup autocorrection with hash stability", () => {
         expect(reloaded).toEqual(hashes);
       }
     }
-    expect(autofixed).toBeGreaterThan(50);
+    expect(autofixed).toBe(0);
   }, 120_000);
 });

--- a/test/core/hashline.apply.test.ts
+++ b/test/core/hashline.apply.test.ts
@@ -180,8 +180,8 @@ describe("applyEdit — noop detection", () => {
 	});
 });
 
-describe("applyEdit — auto-fix heuristics", () => {
-	it("auto-fixes leading duplication by stripping the first replacement line", async () => {
+describe("applyEdit — no auto-fix (boundaryDups removed)", () => {
+	it("keeps leading duplication (no auto-fix)", async () => {
 		const content = "before\nold one\nold two\nafter";
 		const edit: HEdit = {
 			hash_bounds: [
@@ -193,13 +193,11 @@ describe("applyEdit — auto-fix heuristics", () => {
 
 		const result = applyEdit(content, edit);
 
-		expect(result.content).toBe("before\nnew one\nnew two\nafter");
-		expect(result.autoFixes).toHaveLength(1);
-		expect(result.autoFixes![0]!.kind).toBe("leading");
-		expect(result.autoFixes![0]!.removedLine).toBe("before");
+		expect(result.content).toBe("before\nbefore\nnew one\nnew two\nafter");
+		expect(result.autoFixes ?? []).toHaveLength(0);
 	});
 
-	it("auto-fixes trailing duplication by stripping the last replacement line", async () => {
+	it("keeps trailing duplication (no auto-fix)", async () => {
 		const content = "before\nold one\nold two\nafter";
 		const edit: HEdit = {
 			hash_bounds: [
@@ -211,10 +209,8 @@ describe("applyEdit — auto-fix heuristics", () => {
 
 		const result = applyEdit(content, edit);
 
-		expect(result.content).toBe("before\nnew one\nnew two\nafter");
-		expect(result.autoFixes).toHaveLength(1);
-		expect(result.autoFixes![0]!.kind).toBe("trailing");
-		expect(result.autoFixes![0]!.removedLine).toBe("after");
+		expect(result.content).toBe("before\nnew one\nnew two\nafter\nafter");
+		expect(result.autoFixes ?? []).toHaveLength(0);
 	});
 });
 

--- a/test/core/indent-dup.test.ts
+++ b/test/core/indent-dup.test.ts
@@ -4,26 +4,24 @@ import { useTestHome } from "../support/fixtures.js";
 
 const home = useTestHome();
 
-describe("indentation difference in boundary auto-fix", () => {
-  it("auto-fixes leading duplication when indentation matches exactly", async () => {
+describe("indentation difference — no boundary auto-fix (removed)", () => {
+  it("keeps leading duplication (no auto-fix) when indentation matches exactly", async () => {
     const file = "  foo\nbar\n  baz";
     const hashes = await lineHashes(file, home.testPath);
     const result = applyEdit(file, resEdit(
       { remove_from: hashes[1]!, remove_to: hashes[1]!, replacement_text: "  foo\n  bar" },
     ));
-    expect(result.content).toBe("  foo\n  bar\n  baz");
-    expect(result.autoFixes).toHaveLength(1);
-    expect(result.autoFixes![0]!.kind).toBe("leading");
+    expect(result.content).toBe("  foo\n  foo\n  bar\n  baz");
+    expect(result.autoFixes ?? []).toHaveLength(0);
   });
 
-  it("auto-fixes leading duplication when both indentation and content match exactly", async () => {
+  it("keeps leading duplication (no auto-fix) when both indentation and content match", async () => {
     const file = "  foo\n  bar\n  baz";
     const hashes = await lineHashes(file, home.testPath);
     const result = applyEdit(file, resEdit(
       { remove_from: hashes[1]!, remove_to: hashes[1]!, replacement_text: "  foo\n  new" },
     ));
-    expect(result.content).toBe("  foo\n  new\n  baz");
-    expect(result.autoFixes).toHaveLength(1);
-    expect(result.autoFixes![0]!.kind).toBe("leading");
+    expect(result.content).toBe("  foo\n  foo\n  new\n  baz");
+    expect(result.autoFixes ?? []).toHaveLength(0);
   });
 });

--- a/test/core/regression-38-boundary-dups.test.ts
+++ b/test/core/regression-38-boundary-dups.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { initHasher, lineHashesPure } from "../../src/hashline/hash-assign.js";
+import { applyEdit, resEdit } from "../../src/hashline/anchor-pipeline.js";
+import { splitLines } from "../../src/utils.js";
+
+await initHasher();
+
+// Regression for #38: boundaryDups must NOT splice. Tool is pure range+replacement.
+// Before fix, trailingDups removed last line when it equaled fileLines[endLine].
+// Correct: loud duplicate is kept, model fixes next turn.
+
+describe("regression #38 — boundaryDups removed (no auto-fix)", () => {
+	it("minimal a/b — a\\nb over a → 3 lines (not 2)", () => {
+		const content = "a\nb\n";
+		const hashes = lineHashesPure(content);
+		const edit = resEdit({ remove_from: hashes[0]!, remove_to: hashes[0]!, replacement_text: "a\nb" }, []);
+		const res = applyEdit(content, edit, undefined, hashes, "test.txt", [...hashes]);
+		expect(splitLines(res.content)).toEqual(["a", "b", "b"]);
+		expect(res.content).toBe("a\nb\nb\n");
+		expect(res.autoFixes ?? []).toHaveLength(0);
+	});
+
+	it("minimal with trailing newline in replacement — still kept", () => {
+		const content = "a\nb\n";
+		const hashes = lineHashesPure(content);
+		const edit = resEdit({ remove_from: hashes[0]!, remove_to: hashes[0]!, replacement_text: "a\nb\n" }, []);
+		const res = applyEdit(content, edit, undefined, hashes, "test.txt", [...hashes]);
+		// replacement ["a","b",""] → last non-empty "b" equals file "b", before fix would splice to ["a",""]
+		expect(res.autoFixes ?? []).toHaveLength(0);
+		expect(splitLines(res.content)).toEqual(["a", "b", "", "b"]);
+	});
+
+	it("cpp case A/B — 9→10 lines, brace preserved", () => {
+		const cpp = "void foo()\n{\n\tswitch (type) {\n\tcase A:\n\t{\n\t\tbody;\n\t}\n\t}\n}\n";
+		const hashes = lineHashesPure(cpp);
+		const lines = splitLines(cpp);
+		const idxA = lines.indexOf("\tcase A:"); // 3 (0-based)
+		const idxClose = lines.indexOf("\t}", idxA + 1); // first } after case
+		const edit = resEdit(
+			{ remove_from: hashes[idxA]!, remove_to: hashes[idxClose]!, replacement_text: "\tcase A:\n\tcase B:\n\t{\n\t\tbody;\n\t}" },
+			[],
+		);
+		const res = applyEdit(cpp, edit, undefined, hashes, "test.txt", [...hashes]);
+		expect(splitLines(res.content).length).toBe(10);
+		expect(res.content).toBe(
+			"void foo()\n{\n\tswitch (type) {\n\tcase A:\n\tcase B:\n\t{\n\t\tbody;\n\t}\n\t}\n}\n",
+		);
+		expect(res.autoFixes ?? []).toHaveLength(0);
+	});
+
+	it("does not splice leading dup either", () => {
+		const content = "x\ny\nz\n";
+		const hashes = lineHashesPure(content);
+		const edit = resEdit({ remove_from: hashes[1]!, remove_to: hashes[1]!, replacement_text: "x\ny2" }, []);
+		const res = applyEdit(content, edit, undefined, hashes, "test.txt", [...hashes]);
+		expect(res.autoFixes ?? []).toHaveLength(0);
+		expect(splitLines(res.content)).toEqual(["x", "x", "y2", "z"]);
+	});
+});


### PR DESCRIPTION
Closes #38

Removes all four `boundaryDups` auto-splices (`trailingDups`/`leadingDups`/`firstNewAfterDups`/`lastNewBeforeDups` + `sectionIsUnique`/`canonCounts`/`findNewEdge` + `BDup`/`AutoFix`) from `AnchorPipeline`. Tool is now pure `range=[remove_from,remove_to]` + literal `replacement_text` — no silent rewrite. Loud duplicate (visible in post-edit diff) is model's responsibility, silent loss (`a\nb` over `a` → 2 not 3 lines; `case A/B` → 9 not 10, `}` lost) is fixed.

**Why not #38 fixes 1/2/3:** 1 (≥2) still loses `}\n}`, 2 (fail-closed) punishes intentional duplicate, 3 (symmetric extend) changes `hash_bounds` meaning. Chosen 4th: delete entirely per `model–tool boundary` (`CONTEXT.md`).

- Invariant now `swapReversed → stripBare → stripDiff → valEdit → verifyServed → resToSpan` (`src/hashline/anchor-pipeline.ts:5`).
- ADR-0007 `docs/adr/0007-remove-boundarydups-autofix.md` (accepted) documents considered options.
- Tests: 6 files flipped to `no dedup` expectations + `test/core/regression-38-boundary-dups.test.ts` (4 tests: minimal `a/b`, trailing newline, cpp 10-line brace, leading).
- Verification: `a\nb` over `a` → `3` lines PASS, cpp → `10` PASS, `npm run typecheck` + `1215 tests` PASS (was 1211).

BREAKING CHANGE: boundary duplicate handling removed; downstream forks must own the splice if they need it.