### PR TITLE
fix(hashline): prevent freed anchor reuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [Unreleased]
+
+### Fixed
+
+- **hashline:** prevent freed anchor reuse
+
 ## [0.6.0](https://github.com/Rianico/dsh-better-edit/compare/v0.5.1...v0.6.0) (2026-08-31)
 
 ### Features

--- a/src/file-view.ts
+++ b/src/file-view.ts
@@ -371,6 +371,8 @@ export interface ReadNormOptions {
   maxLines?: number;
   store?: HashStore;
   noPersist?: boolean;
+  reservedHashes?: ReadonlySet<string>;
+  retiredHashes?: ReadonlySet<string>;
 }
 
 export async function normFromText(input: {
@@ -381,6 +383,8 @@ export async function normFromText(input: {
   maxLines?: number;
   store?: HashStore;
   noPersist?: boolean;
+  reservedHashes?: ReadonlySet<string>;
+  retiredHashes?: ReadonlySet<string>;
   hadUtf8DecodeErrors?: boolean;
 }): Promise<NormFile> {
   const { absolutePath, displayPath, signal } = input;
@@ -402,6 +406,8 @@ export async function normFromText(input: {
     undefined,
     input.store,
     input.noPersist !== true,
+    input.reservedHashes,
+    input.retiredHashes,
   );
   return {
     absolutePath,
@@ -440,6 +446,8 @@ export async function readNormFile(
     maxLines: options?.maxLines,
     store: options?.store,
     noPersist: options?.noPersist,
+    reservedHashes: options?.reservedHashes,
+    retiredHashes: options?.retiredHashes,
     hadUtf8DecodeErrors: file.hadUtf8DecodeErrors,
   });
 }
@@ -634,6 +642,8 @@ export interface PreviewOpts {
 export interface ReadViewOpts extends PreviewOpts {
   encoding?: string;
   signal?: AbortSignal;
+  reservedHashes?: ReadonlySet<string>;
+  retiredHashes?: ReadonlySet<string>;
 }
 
 export async function preview(
@@ -666,6 +676,8 @@ export async function readView(
       displayPath: path,
       signal,
       maxLines: MAX_HASH_LINES,
+      reservedHashes: opts.reservedHashes,
+      retiredHashes: opts.retiredHashes,
     });
   const r = await fmtReadPreview(
     normalized,

--- a/src/hash-store.ts
+++ b/src/hash-store.ts
@@ -95,9 +95,12 @@ interface Prepared {
 	undoDelete: (...params: SqlParams) => void;
 	undoPruneOlderThan: (...params: SqlParams) => void;
 	servedGet: (...params: SqlParams) => Record<string, unknown> | undefined;
+	servedAllForPath: (...params: SqlParams) => Record<string, unknown>[];
 	servedUpsert: (...params: SqlParams) => void;
 	servedReportedUpsert: (...params: SqlParams) => void;
 	servedReportedClear: (...params: SqlParams) => void;
+	servedRetiredUpsert: (...params: SqlParams) => void;
+	servedRetiredClear: (...params: SqlParams) => void;
 	servedDelete: (...params: SqlParams) => void;
 	servedDeletePath: (...params: SqlParams) => void;
 	servedWipe: (...params: SqlParams) => void;
@@ -152,13 +155,22 @@ export interface HashStore {
 export interface ServedPersistence {
   getServed(sessionKey: string, path: string): (string | null)[];
   getServedReported(sessionKey: string, path: string): Set<string>;
+  getAnchorReservations(path: string): AnchorReservations;
+  getRetiredAnchors(sessionKey: string, path: string): Set<string>;
   upsertServed(sessionKey: string, path: string, hashesJson: string): void;
   upsertServedReported(sessionKey: string, path: string, reportedJson: string): void;
   clearServedReported(sessionKey: string, path: string): void;
+  upsertRetiredAnchors(sessionKey: string, path: string, hashesJson: string): void;
+  clearRetiredAnchors(sessionKey: string, path: string): void;
   deleteServed(sessionKey: string, path: string): void;
   deleteServedByPath(path: string): void;
   wipeServed(sessionKey: string): void;
   pruneServedOlderThan(ts: number): void;
+}
+
+export interface AnchorReservations {
+  reservedHashes: Set<string>;
+  retiredHashes: Set<string>;
 }
 
 export type InternalHashStore = HashStore & ServedPersistence;
@@ -300,10 +312,43 @@ function buildStore(db: DatabaseSync): { db: DatabaseSync; stmts: Prepared } {
 			"path TEXT NOT NULL, " +
 			"hashes TEXT NOT NULL, " +
 			"reported TEXT, " +
+			"retired TEXT, " +
 			"updated_at INTEGER NOT NULL, " +
 			"PRIMARY KEY (session_id, path)" +
 			")",
 	);
+	const currentServedColumns = db.prepare("PRAGMA table_info(served)").all() as {
+		name: string;
+	}[];
+	if (!currentServedColumns.some((column) => column.name === "retired")) {
+		let migrationOpen = false;
+		try {
+			db.exec("BEGIN IMMEDIATE");
+			migrationOpen = true;
+			const migrationColumns = db
+				.prepare("PRAGMA table_info(served)")
+				.all() as { name: string }[];
+			if (!migrationColumns.some((column) => column.name === "retired")) {
+				db.exec("ALTER TABLE served ADD COLUMN retired TEXT");
+				// Pre-fix snapshots and undo entries may already bind a remembered
+				// anchor to the wrong position. Preserve served rows, but rebuild
+				// every source that could restore the rebound anchor.
+				db.exec("DELETE FROM snapshots");
+				db.exec("DELETE FROM undo");
+			}
+			db.exec("COMMIT");
+			migrationOpen = false;
+		} catch (error) {
+			if (migrationOpen) {
+				try {
+					db.exec("ROLLBACK");
+				} catch (rollbackError) {
+					console.warn(rollbackError);
+				}
+			}
+			throw error;
+		}
+	}
 	db
 		.prepare(
 			"INSERT INTO meta (key, value) VALUES ('version', ?) " +
@@ -334,7 +379,10 @@ function buildStore(db: DatabaseSync): { db: DatabaseSync; stmts: Prepared } {
 		"DELETE FROM undo WHERE updated_at < ?",
 	);
 	const servedGetStmt = db.prepare(
-		"SELECT hashes, reported FROM served WHERE session_id = ? AND path = ?",
+		"SELECT hashes, reported, retired FROM served WHERE session_id = ? AND path = ?",
+	);
+	const servedAllForPathStmt = db.prepare(
+		"SELECT session_id, hashes, retired FROM served WHERE path = ?",
 	);
 	const servedUpsertStmt = db.prepare(
 		"INSERT INTO served (session_id, path, hashes, updated_at) VALUES (?, ?, ?, ?) " +
@@ -346,6 +394,13 @@ function buildStore(db: DatabaseSync): { db: DatabaseSync; stmts: Prepared } {
 	);
 	const servedReportedClearStmt = db.prepare(
 		"UPDATE served SET reported = NULL, updated_at = ? WHERE session_id = ? AND path = ?",
+	);
+	const servedRetiredUpsertStmt = db.prepare(
+		"INSERT INTO served (session_id, path, hashes, retired, updated_at) VALUES (?, ?, '[]', ?, ?) " +
+			"ON CONFLICT(session_id, path) DO UPDATE SET retired = excluded.retired, updated_at = excluded.updated_at",
+	);
+	const servedRetiredClearStmt = db.prepare(
+		"UPDATE served SET retired = NULL, updated_at = ? WHERE session_id = ? AND path = ?",
 	);
 	const servedDeleteStmt = db.prepare(
 		"DELETE FROM served WHERE session_id = ? AND path = ?",
@@ -390,6 +445,8 @@ function buildStore(db: DatabaseSync): { db: DatabaseSync; stmts: Prepared } {
 		},
 		servedGet: (...params) =>
 			servedGetStmt.get(...params) as Record<string, unknown> | undefined,
+		servedAllForPath: (...params) =>
+			servedAllForPathStmt.all(...params) as Record<string, unknown>[],
 		servedUpsert: (...params) => {
 			withBusyRetry(() => {
 				servedUpsertStmt.run(...params);
@@ -403,6 +460,16 @@ function buildStore(db: DatabaseSync): { db: DatabaseSync; stmts: Prepared } {
 		servedReportedClear: (...params) => {
 			withBusyRetry(() => {
 				servedReportedClearStmt.run(params[1], params[0], params[2]);
+			});
+		},
+		servedRetiredUpsert: (...params) => {
+			withBusyRetry(() => {
+				servedRetiredUpsertStmt.run(...params);
+			});
+		},
+		servedRetiredClear: (...params) => {
+			withBusyRetry(() => {
+				servedRetiredClearStmt.run(params[1], params[0], params[2]);
 			});
 		},
 		servedDelete: (...params) => {
@@ -548,6 +615,48 @@ function makeDomainStore(stmts: Prepared): InternalHashStore {
 				return new Set();
 			}
 		},
+		getAnchorReservations(path) {
+			const reservedHashes = new Set<string>();
+			const retiredHashes = new Set<string>();
+			for (const row of stmts.servedAllForPath(path)) {
+				try {
+					const served = JSON.parse(row.hashes as string) as unknown;
+					const retired =
+						row.retired === null || row.retired === undefined
+							? []
+							: (JSON.parse(row.retired as string) as unknown);
+					if (!isValidServedList(served) || !isValidHashList(retired)) {
+						throw new TypeError("invalid stored anchor reservations");
+					}
+					for (const hash of served) {
+						if (hash !== null) reservedHashes.add(hash);
+					}
+					for (const hash of retired) {
+						reservedHashes.add(hash);
+						retiredHashes.add(hash);
+					}
+				} catch (error) {
+					stmts.servedDelete(row.session_id as string, path);
+				}
+			}
+			return { reservedHashes, retiredHashes };
+		},
+		getRetiredAnchors(sessionKey, path) {
+			const row = stmts.servedGet(sessionKey, path);
+			if (!row || row.retired === null || row.retired === undefined) {
+				return new Set();
+			}
+			try {
+				const parsed = JSON.parse(row.retired as string) as unknown;
+				if (!isValidHashList(parsed)) {
+					throw new TypeError("invalid retired anchors");
+				}
+				return new Set(parsed);
+			} catch (error) {
+				stmts.servedDelete(sessionKey, path);
+				return new Set();
+			}
+		},
 		upsertServed(sessionKey, path, hashesJson) {
 			stmts.servedUpsert(sessionKey, path, hashesJson, Date.now());
 		},
@@ -556,6 +665,17 @@ function makeDomainStore(stmts: Prepared): InternalHashStore {
 		},
 		clearServedReported(sessionKey, path) {
 			stmts.servedReportedClear(sessionKey, Date.now(), path);
+		},
+		upsertRetiredAnchors(sessionKey, path, hashesJson) {
+			stmts.servedRetiredUpsert(
+				sessionKey,
+				path,
+				hashesJson,
+				Date.now(),
+			);
+		},
+		clearRetiredAnchors(sessionKey, path) {
+			stmts.servedRetiredClear(sessionKey, Date.now(), path);
 		},
 		deleteServed(sessionKey, path) {
 			stmts.servedDelete(sessionKey, path);

--- a/src/hashline/hash-assign.ts
+++ b/src/hashline/hash-assign.ts
@@ -133,10 +133,14 @@ function assignHash(used: Uint32Array, baseIdx: number, hint: { value: number })
   hint.value = nextIdx + HASH_PROBE_STRIDE;
   return hashAt(nextIdx);
 }
-export function lineHashesPure(content: string): string[] {
+export function lineHashesPure(
+  content: string,
+  reservedHashes: ReadonlySet<string> = new Set(),
+): string[] {
   const lines = splitLines(content);
   const hashes = new Array<string>(lines.length);
   const used = new Uint32Array(BITSET_WORDS);
+  for (const hash of reservedHashes) markHashUsed(used, hash);
   const hint = { value: 0 };
   const canonCache = new Map<string, string>();
   for (let i = 0; i < lines.length; i++) {
@@ -172,7 +176,13 @@ function nearestNew(candidates: number[], target: number): number {
   }
   return right < candidates.length ? right : -1;
 }
-export function mapStableHashes(oldContent: string, oldHashes: string[], newContent: string, removedHashes?: Set<string>): string[] {
+export function mapStableHashes(
+  oldContent: string,
+  oldHashes: string[],
+  newContent: string,
+  removedHashes?: Set<string>,
+  reservedHashes: ReadonlySet<string> = new Set(),
+): string[] {
   const oldLines = splitLines(oldContent);
   const newLines = splitLines(newContent);
   const newHashes = new Array<string>(newLines.length);
@@ -180,6 +190,8 @@ export function mapStableHashes(oldContent: string, oldHashes: string[], newCont
   const hint = { value: 0 };
   const canonCache = new Map<string, string>();
   const removed = removedHashes ?? new Set<string>();
+  const blocked = new Set(reservedHashes);
+  for (const hash of removed) blocked.add(hash);
   const oldHashIndex = new Map<string, number>();
   for (let i = 0; i < oldHashes.length; i++) {
     const hash = oldHashes[i]!;
@@ -192,6 +204,7 @@ export function mapStableHashes(oldContent: string, oldHashes: string[], newCont
     const idx = oldHashIndex.get(hash);
     if (idx !== undefined) removedIndexes.add(idx);
   }
+  for (const hash of blocked) markHashUsed(used, hash);
   let spanStart = oldLines.length;
   let spanEnd = -1;
   for (const idx of removedIndexes) {
@@ -202,11 +215,9 @@ export function mapStableHashes(oldContent: string, oldHashes: string[], newCont
   const replacementLen = newLines.length - oldLines.length + spanLen;
   const shiftAfterSpan = spanEnd >= spanStart ? replacementLen - spanLen : 0;
   const survivors: { index: number; hash: string }[] = [];
-  const removedEntries: { index: number; hash: string }[] = [];
   for (let i = 0; i < oldLines.length; i++) {
     const entry = { index: i, hash: oldHashes[i]! };
-    if (removedIndexes.has(i)) removedEntries.push(entry);
-    else survivors.push(entry);
+    if (!removedIndexes.has(i)) survivors.push(entry);
   }
   const newByContent = new Map<string, number[]>();
   for (let i = 0; i < newLines.length; i++) {
@@ -233,25 +244,6 @@ export function mapStableHashes(oldContent: string, oldHashes: string[], newCont
     markUsed(entry.hash);
     rememberHashCanon(entry.hash, getCanon(canonCache, oldLines[entry.index]!));
   }
-  const removedByContent = new Map<string, { hashes: string[]; pos: number }>();
-  for (const entry of removedEntries) {
-    const key = getCanon(canonCache, oldLines[entry.index]!);
-    let queue = removedByContent.get(key);
-    if (!queue) {
-      queue = { hashes: [], pos: 0 };
-      removedByContent.set(key, queue);
-    }
-    queue.hashes.push(entry.hash);
-  }
-  for (let i = 0; i < newLines.length; i++) {
-    if (newHashes[i]) continue;
-    const queue = removedByContent.get(getCanon(canonCache, newLines[i]!));
-    if (!queue || queue.pos >= queue.hashes.length) continue;
-    const h = queue.hashes[queue.pos]!;
-    newHashes[i] = h;
-    queue.pos += 1;
-    rememberHashCanon(h, getCanon(canonCache, newLines[i]!));
-  }
   for (let i = 0; i < newLines.length; i++) {
     if (newHashes[i]) continue;
     const c = getCanon(canonCache, newLines[i]!);
@@ -261,6 +253,11 @@ export function mapStableHashes(oldContent: string, oldHashes: string[], newCont
     rememberHashCanon(h, c);
   }
   return newHashes;
+}
+
+function markHashUsed(used: Uint32Array, hash: string): void {
+  const idx = hashToIndex(hash);
+  if (idx >= 0) setBit(used, idx);
 }
 
 // --- persistence wrapper (from hash.ts) ---

--- a/src/hashline/hash.ts
+++ b/src/hashline/hash.ts
@@ -59,9 +59,11 @@ export async function lineHashes(
   previous?: { content: string; hashes: string[]; removedHashes?: Set<string> },
   ioOrStore?: HashStore | HashSnapshotIO,
   persist?: boolean,
+  reservedHashes: ReadonlySet<string> = new Set(),
+  retiredHashes: ReadonlySet<string> = new Set(),
 ): Promise<string[]> {
   await initHasher();
-  if (!path) return lineHashesPure(content);
+  if (!path) return lineHashesPure(content, reservedHashes);
 
   // Back-compat: caller may pass HashStore as 4th arg; adapt to IO.
   const io: HashSnapshotIO | undefined =
@@ -70,7 +72,13 @@ export async function lineHashes(
       : (ioOrStore as HashSnapshotIO | undefined) ?? snapshotIOFor(undefined);
 
   if (previous) {
-    const newHashes = mapStableHashes(previous.content, previous.hashes, content, previous.removedHashes);
+    const newHashes = mapStableHashes(
+      previous.content,
+      previous.hashes,
+      content,
+      previous.removedHashes,
+      reservedHashes,
+    );
     if (persist !== false && io) {
       try {
         await io.upsert(path, contentChecksum(content), splitLines(content).length, newHashes);
@@ -88,8 +96,8 @@ export async function lineHashes(
       console.error("Failed to read hash store snapshot:", e);
     }
   }
-  if (cached) return cached;
-  const newHashes = lineHashesPure(content);
+  if (cached && !cached.some((hash) => retiredHashes.has(hash))) return cached;
+  const newHashes = lineHashesPure(content, reservedHashes);
   if (persist !== false && io) {
     try {
       await io.upsert(path, contentChecksum(content), splitLines(content).length, newHashes);

--- a/src/mutation.ts
+++ b/src/mutation.ts
@@ -45,7 +45,12 @@ import {
   type ServeRecordPolicy,
 } from "./hashline/anchor-pipeline.js";
 import { sessionKeyFor } from "./workspace-context.js"
-import { loadServed, scanDrift, recordServedTruncated } from "./session-view.js";
+import {
+	loadServed,
+	scanDrift,
+	recordServedTruncated,
+	loadAnchorReservations,
+} from "./session-view.js";
 import { abortIf, splitLines } from "./utils.js";
 import { applyOne } from "./mutation/engine.js";
 import {
@@ -113,6 +118,7 @@ export async function execPipeline(
 
 	abortIf(signal)
 	const absolutePath = await io.resolve(path, cwd, signal)
+	const reservations = await loadAnchorReservations(absolutePath)
 	const rawText = await io.readText(absolutePath, signal)
 	const {
 		normalized: originalNormalized,
@@ -128,6 +134,8 @@ export async function execPipeline(
 		maxLines: MAX_HASH_LINES,
 		store: hashStore,
 		noPersist: options?.noPersist,
+		reservedHashes: reservations.reservedHashes,
+		retiredHashes: reservations.retiredHashes,
 	})
 
 	const sessionKey = options?.sessionKey ?? sessionKeyFor(undefined)
@@ -149,6 +157,7 @@ export async function execPipeline(
 			warnings: editWarnings,
 			store: hashStore,
 			persist: options?.noPersist !== true,
+			reservedHashes: reservations.reservedHashes,
 			edit,
 		},
 		async (error) => {

--- a/src/mutation/engine.ts
+++ b/src/mutation/engine.ts
@@ -16,7 +16,12 @@ import type { FileIO } from "../fs-bridge.js";
 import type { HashStore } from "../hash-store.js";
 import type { LineEnding } from "../edit-diff.js";
 import { normFromText } from "../file-reader.js";
-import { scanDrift, loadServed } from "../session-view.js";
+import {
+	scanDrift,
+	loadServed,
+	loadAnchorReservations,
+	retireAnchors,
+} from "../session-view.js";
 import {
 	applyEdit,
 	resEdit,
@@ -183,6 +188,7 @@ export interface ApplyOneInput {
 	countHashes?: string[];
 	store?: HashStore;
 	persist: boolean;
+	reservedHashes?: ReadonlySet<string>;
 	/** Pre-resolved edit (single path keeps resEdit before IO for error order). */
 	edit?: HEdit;
 }
@@ -271,6 +277,7 @@ export async function applyOne(
 				},
 				input.store,
 				input.persist,
+				input.reservedHashes,
 			);
 	const { totalAddedLines, totalRemovedLines } = countLineChanges(
 		edit,
@@ -418,6 +425,8 @@ export async function runFileEdits(
 	const first = items[0]!;
 	abortIf(opts.signal);
 	const absolutePath = first.absolutePath;
+	const reservations = await loadAnchorReservations(absolutePath);
+	const reservedHashes = new Set(reservations.reservedHashes);
 	const rawText = await io.readText(absolutePath, opts.signal);
 	const {
 		normalized: originalNormalized,
@@ -431,6 +440,8 @@ export async function runFileEdits(
 		displayPath: first.path,
 		signal: opts.signal,
 		maxLines: MAX_HASH_LINES,
+		reservedHashes,
+		retiredHashes: reservations.retiredHashes,
 	});
 
 	const served = await loadServed(opts.sessionKey, absolutePath);
@@ -449,6 +460,7 @@ export async function runFileEdits(
 	let lastApplied:
 		| { content: string; hashes: string[]; removedHashes: Set<string> }
 		| undefined;
+	const newlyRetired = new Set<string>();
 
 	for (const item of items) {
 		abortIf(opts.signal);
@@ -466,6 +478,7 @@ export async function runFileEdits(
 				warnings,
 				countHashes: originalHashes,
 				persist: false,
+				reservedHashes,
 			},
 			async (error, edit) => {
 				if (
@@ -548,6 +561,10 @@ export async function runFileEdits(
 
 		appliedCount += 1;
 		const removedHashes = applied.removedHashes!;
+		for (const hash of removedHashes) {
+			reservedHashes.add(hash);
+			newlyRetired.add(hash);
+		}
 		totalAddedLines += applied.totalAddedLines;
 		totalRemovedLines += applied.totalRemovedLines;
 		lastApplied = {
@@ -575,7 +592,10 @@ export async function runFileEdits(
 			},
 			undefined,
 			true,
+			reservedHashes,
+			reservations.retiredHashes,
 		);
+		await retireAnchors(opts.sessionKey, absolutePath, newlyRetired);
 	}
 
 	if (hadUtf8DecodeErrors) {

--- a/src/read-and-serve.ts
+++ b/src/read-and-serve.ts
@@ -11,7 +11,11 @@
 import { abortIf } from "./utils.js";
 import { readView } from "./file-view.js";
 import { getAutoGuessFooter } from "./fs-bridge.js";
-import { recordServed, clearDriftReported } from "./session-view.js";
+import {
+	recordServed,
+	clearDriftReported,
+	loadAnchorReservations,
+} from "./session-view.js";
 import type { FileIO } from "./fs-bridge.js";
 import type { ServedRow } from "./hashline/anchor-pipeline.js";
 
@@ -58,11 +62,15 @@ export async function readAndServe(
 ): Promise<ReadAndServeResult> {
 	const { sessionKey, signal } = options;
 	abortIf(signal);
+	const absolutePath = await io.resolve(rawPath, cwd, signal);
+	const reservations = await loadAnchorReservations(absolutePath);
 	const view = await readView(io, rawPath, cwd, {
 		encoding: options.encoding,
 		offset: options.offset,
 		limit: options.limit,
 		signal,
+		reservedHashes: reservations.reservedHashes,
+		retiredHashes: reservations.retiredHashes,
 	});
 	if (view.served.length > 0) {
 		await recordServed(
@@ -70,6 +78,7 @@ export async function readAndServe(
 			view.absolutePath,
 			view.served,
 			view.hashes.length,
+			view.hashes,
 		);
 	}
 	await clearDriftReported(sessionKey, view.absolutePath);

--- a/src/session-view.ts
+++ b/src/session-view.ts
@@ -23,7 +23,13 @@
  */
 
 import { HASH_RE } from "./hashline/hash-assign.js";
-import { loadHashStore, loadServedStore, withStore } from "./hash-store.js";
+import {
+	loadHashStore,
+	loadServedStore,
+	withStore,
+	type AnchorReservations,
+	type ServedPersistence,
+} from "./hash-store.js";
 import { SERVED_ECHO_CAP } from "./constants.js";
 import type { ServedRow, ResolvedRange } from "./hashline/anchor-pipeline.js";
 import { fmtServedRows } from "./hashline/anchor-pipeline.js";
@@ -99,15 +105,91 @@ export async function loadServed(sessionKey: string, path: string): Promise<(str
 	return store.getServed(sessionKey, path);
 }
 
-export async function recordServed(sessionKey: string, path: string, rows: ServedEntry[], lineCount?: number): Promise<void> {
+/** Anchors that must not be allocated while any session can still remember them. */
+export async function loadAnchorReservations(
+	path: string,
+): Promise<AnchorReservations> {
+	const store = await loadServedStore();
+	return store.getAnchorReservations(path);
+}
+
+function addRetiredAnchors(
+	store: ServedPersistence,
+	sessionKey: string,
+	path: string,
+	hashes: Iterable<string>,
+): void {
+	const additions = [...hashes];
+	if (additions.length === 0) return;
+	const retired = store.getRetiredAnchors(sessionKey, path);
+	for (const hash of additions) {
+		if (!HASH_RE.test(hash)) {
+			throw new TypeError(`Invalid retired hash: ${hash}`);
+		}
+		retired.add(hash);
+	}
+	store.upsertRetiredAnchors(sessionKey, path, JSON.stringify([...retired]));
+}
+
+function displacedHashes(
+	current: readonly (string | null)[],
+	updated: readonly (string | null)[],
+): Set<string> {
+	const remaining = new Set(updated.filter((hash): hash is string => hash !== null));
+	return new Set(
+		current.filter(
+			(hash): hash is string => hash !== null && !remaining.has(hash),
+		),
+	);
+}
+
+/** Keep freed anchors dead for this session until it has seen the whole file again. */
+export async function retireAnchors(
+	sessionKey: string,
+	path: string,
+	hashes: Iterable<string>,
+): Promise<void> {
+	const additions = [...hashes];
+	if (additions.length === 0) return;
+	const store = await loadServedStore();
+	withStore(() => {
+		addRetiredAnchors(store, sessionKey, path, additions);
+	});
+}
+
+export async function recordServed(
+	sessionKey: string,
+	path: string,
+	rows: ServedEntry[],
+	lineCount?: number,
+	fullReadHashes?: readonly string[],
+): Promise<void> {
 	if (rows.length === 0) return;
 	try {
 		const store = await loadServedStore();
+		const isFullRead =
+			fullReadHashes !== undefined &&
+			rows.length === fullReadHashes.length &&
+			rows.every(
+				(row, index) =>
+					row.position === index && row.hash === fullReadHashes[index],
+			);
 		withStore(() => {
 			const current = store.getServed(sessionKey, path);
 			const updated = _mergeServedRows(current, rows, lineCount === undefined ? undefined : { truncateTo: lineCount });
-			if (current.length === updated.length && current.every((v, i) => v === updated[i])) return;
-			store.upsertServed(sessionKey, path, JSON.stringify(updated));
+			if (current.length !== updated.length || current.some((v, i) => v !== updated[i])) {
+				store.upsertServed(sessionKey, path, JSON.stringify(updated));
+			}
+			if (isFullRead) {
+				store.clearRetiredAnchors(sessionKey, path);
+			} else {
+				addRetiredAnchors(
+					store,
+					sessionKey,
+					path,
+					displacedHashes(current, updated),
+				);
+			}
 		});
 	} catch (error) {
 		console.error("Failed to record served rows:", error);
@@ -121,9 +203,15 @@ export async function recordServedTruncated(sessionKey: string, path: string, ro
 		withStore(() => {
 			const current = store.getServed(sessionKey, path);
 			const updated = _mergeServedRows(current, rows, { truncateTo: lineCount, clearFrom });
-			// Avoid no-op writes (perf: O(1) check, no extra I/O beyond current read)
-			if (current.length === updated.length && current.every((v, i) => v === updated[i])) return;
-			store.upsertServed(sessionKey, path, JSON.stringify(updated));
+			if (current.length !== updated.length || current.some((v, i) => v !== updated[i])) {
+				store.upsertServed(sessionKey, path, JSON.stringify(updated));
+			}
+			addRetiredAnchors(
+				store,
+				sessionKey,
+				path,
+				displacedHashes(current, updated),
+			);
 		});
 	} catch (error) {
 		console.error("Failed to record truncated served rows:", error);

--- a/src/tool-undo.ts
+++ b/src/tool-undo.ts
@@ -16,7 +16,11 @@ import { contentChecksum } from "./hashline/hash-assign.js";
 import { lineHashes } from "./hashline/hash.js";
 import { changedRange } from "./hashline/anchor-pipeline.js";
 import { getUndo, clearUndo } from "./undo-edit.js";
-import { recordServedTruncated } from "./session-view.js";
+import {
+	loadAnchorReservations,
+	recordServedTruncated,
+	retireAnchors,
+} from "./session-view.js";
 import { UNDO_DESCRIPTION } from "./prompts.js";
 import type { FileIO } from "./fs-bridge.js";
 import { execCwd, execSessionKey } from "./workspace-context.js";
@@ -89,7 +93,34 @@ export function buildUndoTool(io: FileIO, sandbox: FsSandboxController) {
 
 				const { text: currentStripped } = stripBOM(currentRaw);
 				const currentNormalized = toLF(currentStripped);
-				const currentHashes = await lineHashes(currentNormalized, absolutePath);
+				const reservations = await loadAnchorReservations(absolutePath);
+				const currentHashes = await lineHashes(
+					currentNormalized,
+					absolutePath,
+					undefined,
+					undefined,
+					false,
+					reservations.reservedHashes,
+					reservations.retiredHashes,
+				);
+				const retiredOriginalHashes = new Set(
+					undo.hashes.filter((hash) => reservations.retiredHashes.has(hash)),
+				);
+				const blockedRestoreHashes = new Set(reservations.reservedHashes);
+				for (const hash of currentHashes) blockedRestoreHashes.add(hash);
+				const restoredHashes = await lineHashes(
+					undo.content,
+					absolutePath,
+					{
+						content: undo.content,
+						hashes: undo.hashes,
+						removedHashes: retiredOriginalHashes,
+					},
+					undefined,
+					false,
+					blockedRestoreHashes,
+					reservations.retiredHashes,
+				);
 				const diffResult = genDiff(
 					undo.content,
 					currentNormalized,
@@ -103,15 +134,21 @@ export function buildUndoTool(io: FileIO, sandbox: FsSandboxController) {
 					currentNormalized,
 					undo.content,
 					1,
-					undo.hashes,
+					restoredHashes,
 					currentHashes,
 				);
 				const undoDiff = undoDiffResult.diff;
 				const undoDenseRows: typeof undoDiffResult.servedRows = [];
-				for (let i = 0; i < undo.hashes.length; i++) {
-					undoDenseRows.push({ position: i, hash: undo.hashes[i]! });
+				for (let i = 0; i < restoredHashes.length; i++) {
+					undoDenseRows.push({ position: i, hash: restoredHashes[i]! });
 				}
 				const restoredRange = changedRange(currentNormalized, undo.content);
+				const restoredSet = new Set(restoredHashes);
+				await retireAnchors(
+					sessionKey,
+					absolutePath,
+					currentHashes.filter((hash) => !restoredSet.has(hash)),
+				);
 
 				try {
 					await io.writeText(
@@ -130,7 +167,7 @@ export function buildUndoTool(io: FileIO, sandbox: FsSandboxController) {
 						absolutePath,
 						contentChecksum(undo.content),
 						splitLines(undo.content).length,
-						undo.hashes,
+						restoredHashes,
 					);
 				} catch (error) {
 					console.error("Failed to restore hash store snapshot after undo:", error);

--- a/test/core/hashline-stable-mapping.test.ts
+++ b/test/core/hashline-stable-mapping.test.ts
@@ -304,7 +304,7 @@ describe("mapStableHashes — removedHashes edge cases", () => {
     expect(result[1]).toBe(secondBHash);
   });
 
-  it("removedHashes with all candidates removed reuses the first removed hash for identical re-insertion", async () => {
+  it("allocates a fresh hash when identical text replaces removed candidates", async () => {
     const oldContent = "a\nb\nb\nc";
     const oldHashes = await lineHashes(oldContent, home.testPath);
     const firstBHash = oldHashes[1]!;
@@ -318,10 +318,11 @@ describe("mapStableHashes — removedHashes edge cases", () => {
       removedHashes: new Set([firstBHash, secondBHash]),
     });
 
-    expect(result[1]).toBe(firstBHash);
+    expect(result[1]).not.toBe(firstBHash);
+    expect(result[1]).not.toBe(secondBHash);
   });
 
-  it("re-inserting identical text reuses the removed line's hash", async () => {
+  it("does not reuse a removed hash when identical text remains", async () => {
     const oldContent = "a\nb\nc";
     const oldHashes = await lineHashes(oldContent, home.testPath);
     const newContent = "a\nX\nc";
@@ -332,7 +333,7 @@ describe("mapStableHashes — removedHashes edge cases", () => {
       removedHashes: new Set([oldHashes[0]!]),
     });
 
-    expect(result[0]).toBe(oldHashes[0]);
+    expect(result[0]).not.toBe(oldHashes[0]);
     expect(result[1]).toMatch(/^[A-Za-z0-9_\\-]{3}$/);
     expect(result[1]).not.toBe(oldHashes[0]);
     expect(result[1]).not.toBe(oldHashes[1]);
@@ -360,7 +361,7 @@ describe("mapStableHashes — removedHashes edge cases", () => {
     expect(result[3]).toBe(oldHashes[3]);
   });
 
-  it("re-inserting identical text at the same position keeps its hash", async () => {
+  it("does not resurrect removed hashes at the same positions", async () => {
     const oldContent = "a\nb\nc";
     const oldHashes = await lineHashes(oldContent, home.testPath);
     const newContent = "a\nX\nc";
@@ -371,7 +372,8 @@ describe("mapStableHashes — removedHashes edge cases", () => {
       removedHashes: new Set(oldHashes.slice(0, 2)),
     });
 
-    expect(result[0]).toBe(oldHashes[0]);
+    expect(result[0]).not.toBe(oldHashes[0]);
+    expect(result[0]).not.toBe(oldHashes[1]);
     expect(result[1]).toMatch(/^[A-Za-z0-9]{3}$/);
     expect(result[1]).not.toBe(oldHashes[0]);
     expect(result[1]).not.toBe(oldHashes[1]);
@@ -390,9 +392,10 @@ describe("mapStableHashes — removedHashes edge cases", () => {
       removedHashes: new Set(oldHashes.slice(1, 4)),
     });
 
-    expect(result[1]).toBe(oldHashes[1]);
-    expect(result[2]).toBe(oldHashes[2]);
-    expect(result[4]).toBe(oldHashes[3]);
+    const removedHashes = new Set(oldHashes.slice(1, 4));
+    expect(removedHashes.has(result[1]!)).toBe(false);
+    expect(removedHashes.has(result[2]!)).toBe(false);
+    expect(removedHashes.has(result[4]!)).toBe(false);
     expect(result[6]).toBe(oldHashes[5]);
     expect(result[7]).toBe(oldHashes[6]);
     expect(result[8]).toBe(oldHashes[7]);
@@ -509,7 +512,7 @@ describe("mapStableHashes — nearest-candidate selection", () => {
     expect(result[0]).toBe(oldHashes[0]);
   });
 
-  it("reuses the first removed hash when every candidate is removed", async () => {
+  it("allocates outside the removed set when every candidate is removed", async () => {
     const oldContent = "same\nsame";
     const oldHashes = await lineHashes(oldContent, home.testPath);
     const removedHashes = new Set(oldHashes);
@@ -521,7 +524,7 @@ describe("mapStableHashes — nearest-candidate selection", () => {
     });
 
     expect(result).toHaveLength(1);
-    expect(result[0]).toBe(oldHashes[0]);
+    expect(removedHashes.has(result[0]!)).toBe(false);
   });
 
   it("keeps uniqueness when interleaving duplicates and removed candidates", async () => {
@@ -544,10 +547,7 @@ describe("mapStableHashes — nearest-candidate selection", () => {
 
     expect(result).toHaveLength(1_500);
     expect(new Set(result).size).toBe(1_500);
-    const reinserted = result.filter((hash) => removedHashes.has(hash));
-    expect(reinserted).toHaveLength(250);
-    const survivors = result.filter((hash) => !removedHashes.has(hash));
-    expect(survivors).toHaveLength(1_250);
+    expect(result.some((hash) => removedHashes.has(hash))).toBe(false);
   }, 120_000);
 
   it("keeps an untouched line's hash when the replacement contains identical content nearer to its old position", async () => {

--- a/test/core/hashline-stale-rebind.test.ts
+++ b/test/core/hashline-stale-rebind.test.ts
@@ -1,0 +1,312 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+
+import { loadHashStore, loadServedStore } from "../../src/hash-store.js";
+import { withWorkspace } from "../../src/workspace-context.js";
+import {
+	extractHash,
+	getText,
+	setupIntegrationTest,
+	withTempFile,
+} from "../support/fixtures.js";
+
+describe("retired hash anchors", () => {
+	it("rejects a stale anchor instead of rebinding it to later identical text", async () => {
+		const initial = "  show: true,\n  items: [],\n";
+
+		await withTempFile("config.ts", initial, async ({ cwd, path }) => {
+			const { readTool, editTool } = setupIntegrationTest(cwd);
+			const read = await readTool.execute("read", { path: "config.ts" });
+			const rows = getText(read).split("\n");
+			const staleAnchor = extractHash(
+				rows.find((line) => line.endsWith("│  show: true,"))!,
+			);
+			const itemsAnchor = extractHash(
+				rows.find((line) => line.endsWith("│  items: [],"))!,
+			);
+
+			await editTool.execute("free-anchor", {
+				path: "config.ts",
+				remove_from: staleAnchor,
+				remove_to: staleAnchor,
+				replacement_text: "  enabled: true,",
+			});
+			await editTool.execute("insert-identical", {
+				path: "config.ts",
+				remove_from: itemsAnchor,
+				remove_to: itemsAnchor,
+				replacement_text: "  items: [],\n  show: true,",
+			});
+
+			const expected = "  enabled: true,\n  items: [],\n  show: true,\n";
+			expect(await readFile(path, "utf-8")).toBe(expected);
+			await withWorkspace(cwd, async () => {
+				const store = await loadServedStore();
+				expect(store.getRetiredAnchors("test-session", path)).toContain(
+					staleAnchor,
+				);
+			});
+
+			await expect(
+				editTool.execute("reuse-stale", {
+					path: "config.ts",
+					remove_from: staleAnchor,
+					remove_to: staleAnchor,
+					replacement_text: "  show: false,",
+				}),
+			).rejects.toThrow(/E_STALE_ANCHOR|E_RANGE_STALE/);
+			expect(await readFile(path, "utf-8")).toBe(expected);
+		});
+	});
+
+	it("keeps tombstones through a partial read and clears them after a full read", async () => {
+		const initial = "one\ntwo\nthree\nfour\n";
+
+		await withTempFile("pages.txt", initial, async ({ cwd, path }) => {
+			const { readTool, editTool } = setupIntegrationTest(cwd);
+			const read = await readTool.execute("read", { path: "pages.txt" });
+			const staleAnchor = extractHash(
+				getText(read)
+					.split("\n")
+					.find((line) => line.endsWith("│one"))!,
+			);
+
+			await editTool.execute("edit", {
+				path: "pages.txt",
+				remove_from: staleAnchor,
+				remove_to: staleAnchor,
+				replacement_text: "ONE",
+			});
+			await readTool.execute("partial", {
+				path: "pages.txt",
+				offset: 2,
+				limit: 1,
+			});
+			await withWorkspace(cwd, async () => {
+				const store = await loadServedStore();
+				expect(store.getRetiredAnchors("test-session", path)).toContain(
+					staleAnchor,
+				);
+			});
+
+			await readTool.execute("full", { path: "pages.txt" });
+			await withWorkspace(cwd, async () => {
+				const store = await loadServedStore();
+				expect(store.getRetiredAnchors("test-session", path)).not.toContain(
+					staleAnchor,
+				);
+			});
+		});
+	});
+
+	it("retires a remembered anchor displaced by a partial read", async () => {
+		const initial = "show\nitems\n";
+
+		await withTempFile("external.txt", initial, async ({ cwd, path }) => {
+			const { readTool, editTool } = setupIntegrationTest(cwd);
+			const read = await readTool.execute("read", { path: "external.txt" });
+			const staleAnchor = extractHash(
+				getText(read)
+					.split("\n")
+					.find((line) => line.endsWith("│show"))!,
+			);
+
+			await writeFile(path, "enabled\nitems\n", "utf-8");
+			const partial = await readTool.execute("partial", {
+				path: "external.txt",
+				offset: 1,
+				limit: 1,
+			});
+			const enabledAnchor = extractHash(
+				getText(partial)
+					.split("\n")
+					.find((line) => line.endsWith("│enabled"))!,
+			);
+			await withWorkspace(cwd, async () => {
+				const store = await loadServedStore();
+				expect(store.getRetiredAnchors("test-session", path)).toContain(
+					staleAnchor,
+				);
+			});
+
+			await editTool.execute("insert", {
+				path: "external.txt",
+				remove_from: enabledAnchor,
+				remove_to: enabledAnchor,
+				replacement_text: "enabled\nshow",
+			});
+			const expected = "enabled\nshow\nitems\n";
+			expect(await readFile(path, "utf-8")).toBe(expected);
+			await withWorkspace(cwd, async () => {
+				const store = await loadHashStore();
+				expect(store.getSnapshot(path, expected)).not.toContain(staleAnchor);
+			});
+			await expect(
+				editTool.execute("stale-after-partial", {
+					path: "external.txt",
+					remove_from: staleAnchor,
+					remove_to: staleAnchor,
+					replacement_text: "wrong",
+				}),
+			).rejects.toThrow(/E_STALE_ANCHOR|E_RANGE_STALE/);
+		});
+	});
+
+	it("undo restores removed content with a fresh anchor", async () => {
+		const initial = "  show: true,\n  items: [],\n";
+
+		await withTempFile("undo.ts", initial, async ({ cwd, path }) => {
+			const harness = setupIntegrationTest(cwd);
+			const read = await harness.readTool.execute("read", { path: "undo.ts" });
+			const staleAnchor = extractHash(
+				getText(read)
+					.split("\n")
+					.find((line) => line.endsWith("│  show: true,"))!,
+			);
+
+			await harness.editTool.execute("edit", {
+				path: "undo.ts",
+				remove_from: staleAnchor,
+				remove_to: staleAnchor,
+				replacement_text: "  enabled: true,",
+			});
+			const undo = harness.getTool("undo_last_edit") as {
+				execute: (name: string, args: { path: string }) => Promise<{
+					content: Array<{ text?: string }>;
+				}>;
+			};
+			const undoResult = await undo.execute("undo", { path: "undo.ts" });
+			const restoredLine = getText(undoResult)
+				.split("\n")
+				.find((line) => line.endsWith("│  show: true,"))!;
+			const restoredAnchor = restoredLine.slice(1).split("│")[0]!;
+
+			expect(restoredAnchor).not.toBe(staleAnchor);
+			expect(await readFile(path, "utf-8")).toBe(initial);
+			await expect(
+				harness.editTool.execute("stale-after-undo", {
+					path: "undo.ts",
+					remove_from: staleAnchor,
+					remove_to: staleAnchor,
+					replacement_text: "  show: false,",
+				}),
+			).rejects.toThrow(/E_STALE_ANCHOR|E_RANGE_STALE/);
+			await harness.editTool.execute("fresh-after-undo", {
+				path: "undo.ts",
+				remove_from: restoredAnchor,
+				remove_to: restoredAnchor,
+				replacement_text: "  show: false,",
+			});
+			expect(await readFile(path, "utf-8")).toBe(
+				"  show: false,\n  items: [],\n",
+			);
+		});
+	});
+
+	it("undo does not move an introduced duplicate's hash onto a surviving line", async () => {
+		const initial = "y\nx\n";
+
+		await withTempFile("duplicates.txt", initial, async ({ cwd }) => {
+			const harness = setupIntegrationTest(cwd);
+			const read = await harness.readTool.execute("read", {
+				path: "duplicates.txt",
+			});
+			const rows = getText(read).split("\n");
+			const yAnchor = extractHash(
+				rows.find((line) => line.endsWith("│y"))!,
+			);
+			const survivingXAnchor = extractHash(
+				rows.find((line) => line.endsWith("│x"))!,
+			);
+
+			await harness.editTool.execute("duplicate", {
+				path: "duplicates.txt",
+				remove_from: yAnchor,
+				remove_to: yAnchor,
+				replacement_text: "x",
+			});
+
+			const undo = harness.getTool("undo_last_edit") as {
+				execute: (name: string, args: { path: string }) => Promise<{
+					content: Array<{ text?: string }>;
+				}>;
+			};
+			const undoResult = await undo.execute("undo", {
+				path: "duplicates.txt",
+			});
+			const undoRows = getText(undoResult).split("\n");
+			const restoredYAnchor = undoRows
+				.find((line) => line.startsWith("+") && line.endsWith("│y"))!
+				.slice(1)
+				.split("│")[0]!;
+			const currentXAnchor = undoRows
+				.find((line) => line.startsWith(" ") && line.endsWith("│x"))!
+				.slice(1)
+				.split("│")[0]!;
+
+			expect(restoredYAnchor).not.toBe(yAnchor);
+			expect(currentXAnchor).toBe(survivingXAnchor);
+		});
+	});
+
+	it("undo does not recycle a hash owned only by the current file", async () => {
+		const initial = "old\nsurvivor\n";
+		const edited = "new30258\nsurvivor\n";
+
+		await withTempFile("undo-collision.txt", initial, async ({ cwd, path }) => {
+			const harness = setupIntegrationTest(cwd);
+			const read = await harness.readTool.execute("read", {
+				path: "undo-collision.txt",
+			});
+			const oldAnchor = extractHash(
+				getText(read)
+					.split("\n")
+					.find((line) => line.endsWith("│old"))!,
+			);
+			expect(oldAnchor).toBe("tYt");
+
+			await harness.editTool.execute("collide", {
+				path: "undo-collision.txt",
+				remove_from: oldAnchor,
+				remove_to: oldAnchor,
+				replacement_text: "new30258",
+			});
+			let currentOnlyAnchor = "";
+			await withWorkspace(cwd, async () => {
+				const hashStore = await loadHashStore();
+				const currentHashes = hashStore.getSnapshot(path, edited)!;
+				currentOnlyAnchor = currentHashes[0]!;
+				expect(currentOnlyAnchor).toBe("quC");
+
+				const servedStore = await loadServedStore();
+				servedStore.upsertRetiredAnchors(
+					"other-session",
+					path,
+					JSON.stringify([oldAnchor]),
+				);
+				servedStore.deleteServed("test-session", path);
+			});
+
+			const undo = harness.getTool("undo_last_edit") as {
+				execute: (name: string, args: { path: string }) => Promise<{
+					content: Array<{ text?: string }>;
+				}>;
+			};
+			const undoResult = await undo.execute("undo", {
+				path: "undo-collision.txt",
+			});
+			const restoredAnchor = getText(undoResult)
+				.split("\n")
+				.find((line) => line.startsWith("+") && line.endsWith("│old"))!
+				.slice(1)
+				.split("│")[0]!;
+
+			expect(restoredAnchor).not.toBe(oldAnchor);
+			expect(restoredAnchor).not.toBe(currentOnlyAnchor);
+			await withWorkspace(cwd, async () => {
+				const store = await loadHashStore();
+				expect(store.getSnapshot(path, initial)).not.toContain(currentOnlyAnchor);
+			});
+		});
+	});
+});

--- a/test/core/hashline-stress.test.ts
+++ b/test/core/hashline-stress.test.ts
@@ -233,8 +233,8 @@ describe("mapStableHashes — large file stress", () => {
     expect(result).toHaveLength(3_000);
     const survivors = result.filter((hash) => !removedHashes.has(hash));
     const reinserted = result.filter((hash) => removedHashes.has(hash));
-    expect(survivors).toHaveLength(2_500);
-    expect(reinserted).toHaveLength(500);
+    expect(survivors).toHaveLength(3_000);
+    expect(reinserted).toHaveLength(0);
     expect(new Set(result).size).toBe(3_000);
   }, 120_000);
 
@@ -250,7 +250,9 @@ describe("mapStableHashes — large file stress", () => {
       removedHashes,
     });
     const elapsed = performance.now() - start;
-    expect(result).toEqual(oldHashes);
+    expect(result).toHaveLength(oldHashes.length);
+    expect(new Set(result).size).toBe(result.length);
+    expect(result.some((hash) => removedHashes.has(hash))).toBe(false);
     expect(elapsed).toBeLessThan(60_000);
   }, 120_000);
 });

--- a/test/core/served-store.test.ts
+++ b/test/core/served-store.test.ts
@@ -3,7 +3,11 @@ import { mkdtemp, mkdir, rm, writeFile } from "fs/promises";
 import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 
-import { loadHashStore, shutdownHashStore } from "../../src/hash-store.js";
+import {
+	loadHashStore,
+	loadServedStore,
+	shutdownHashStore,
+} from "../../src/hash-store.js";
 import {
 	_mergeServedRows,
 	loadServed,
@@ -79,6 +83,9 @@ describe("served state — record semantics", () => {
 			await recordServed("sessionA", "/p.ts", [{ position: 0, hash: "abc" }]);
 			await recordServed("sessionA", "/p.ts", [{ position: 0, hash: "def" }]);
 			expect(await loadServed("sessionA", "/p.ts")).toEqual(["def"]);
+			expect(
+				(await loadServedStore()).getRetiredAnchors("sessionA", "/p.ts"),
+			).toEqual(new Set(["abc"]));
 		});
 	});
 
@@ -91,6 +98,9 @@ describe("served state — record semantics", () => {
 			]);
 			await recordServed("sessionA", "/p.ts", [{ position: 1, hash: null }]);
 			expect(await loadServed("sessionA", "/p.ts")).toEqual(["abc", null, "ghi"]);
+			expect(
+				(await loadServedStore()).getRetiredAnchors("sessionA", "/p.ts"),
+			).toEqual(new Set(["def"]));
 		});
 	});
 
@@ -139,6 +149,9 @@ describe("served state — merge helper (stale-tail invariant)", () => {
 			// (E_RANGE_UNVERIFIED, "served at N positions").
 			await recordServed("sessionA", "/p.ts", [{ position: 0, hash: "abc" }], 1);
 			expect(await loadServed("sessionA", "/p.ts")).toEqual(["abc"]);
+			expect(
+				(await loadServedStore()).getRetiredAnchors("sessionA", "/p.ts"),
+			).toEqual(new Set(["def", "ghi"]));
 		});
 	});
 
@@ -153,6 +166,9 @@ describe("served state — merge helper (stale-tail invariant)", () => {
 			const served = await loadServed("sessionA", "/p.ts");
 			expect(served).toEqual(["abc"]);
 			expect(servedPositionsOf(served, "abc")).toEqual([0]);
+			expect(
+				(await loadServedStore()).getRetiredAnchors("sessionA", "/p.ts"),
+			).toEqual(new Set(["def"]));
 		});
 	});
 
@@ -168,6 +184,9 @@ describe("served state — merge helper (stale-tail invariant)", () => {
 			// view of everything at/after it no longer holds.
 			await recordServedTruncated("sessionA", "/p.ts", [{ position: 2, hash: "xxx" }], 4, 1);
 			expect(await loadServed("sessionA", "/p.ts")).toEqual(["aaa", null, "xxx"]);
+			expect(
+				(await loadServedStore()).getRetiredAnchors("sessionA", "/p.ts"),
+			).toEqual(new Set(["bbb", "ccc", "ddd"]));
 		});
 	});
 
@@ -381,6 +400,51 @@ describe("served state — schema versioning", () => {
 			expect(await driftReported("sessionA", "/p.ts")).toEqual(new Set(["abc"]));
 		});
 	});
+
+	it("preserves served rows but invalidates rebound sources when adding retired anchors", async () => {
+		await withTempHome(async (home) => {
+			const path = join(home, "rebound.txt");
+			const content = "new\nold\n";
+			await writeFile(path, content, "utf-8");
+			const initialStore = await loadHashStore();
+			await recordServed("sessionA", path, [
+				{ position: 0, hash: "AAA" },
+			]);
+			initialStore.upsertSnapshot(path, contentChecksum(content), 2, [
+				"BBB",
+				"AAA",
+			]);
+			initialStore.upsertUndo(path, {
+				content: "old\nnew\n",
+				bom: "",
+				ending: "\n",
+				hashes: ["BBB", "AAA"],
+				resultContent: content,
+			});
+			shutdownHashStore();
+
+			const db = new DatabaseSync(sqlitePath(home), {
+				defensive: false,
+			} as any);
+			db.exec("ALTER TABLE served DROP COLUMN retired");
+			db.close();
+
+			const store = await loadServedStore();
+			expect(store.getAnchorReservations(path).reservedHashes).toEqual(
+				new Set(["AAA"]),
+			);
+			expect((await loadHashStore()).getSnapshot(path, content)).toBeUndefined();
+			expect((await loadHashStore()).getUndo(path)).toBeUndefined();
+			store.upsertRetiredAnchors(
+				"sessionA",
+				path,
+				JSON.stringify(["BBB"]),
+			);
+			expect(store.getRetiredAnchors("sessionA", path)).toEqual(
+				new Set(["BBB"]),
+			);
+		});
+	});
 });
 
 describe("served state — pruneMissing", () => {
@@ -581,6 +645,7 @@ async function withTempHome(
 		join(await getWritableTempRoot(), "pi-hashline-served-test-"),
 	);
 	vi.stubEnv("HOME", tmpHome);
+	vi.stubEnv("DSH_HOME", join(tmpHome, ".dsh"));
 	vi.stubEnv("XDG_CONFIG_HOME", "");
 	try {
 		await run(tmpHome);


### PR DESCRIPTION
## Summary

- keep freed anchors tombstoned for a session until that session completes an exact full-file read
- reserve served and retired anchors during fresh and stable hash allocation, including edit, batch, partial/dense re-serve, and undo paths
- restore tombstoned undo lines with fresh anchors and prevent restored allocation from stealing a current-file anchor
- migrate existing served state atomically: preserve served rows, add retired-anchor storage, and invalidate pre-fix snapshots and undo entries that may already contain a rebound anchor
- replace the removed-content reuse expectation with end-to-end regressions for stale rebind, partial/full-read lifetime, migration, and duplicate-safe undo

## Why

A freed three-character anchor could be allocated to identical text elsewhere, letting a stale one-line edit silently target the wrong line. This carries the maintainer-requested freed-anchor tombstones across the complete single-agent lifecycle instead of only blocking reuse within one edit.

Closes #31.

## Verification

- Biome lint: 170 files clean
- source and test TypeScript checks passed
- focused Vitest: 5 files, 106 tests passed
- clean WSL full suite: 108 files, 1,222 tests passed
- commitlint and diff checks passed

## Scope

This patch closes the maintainer-verified single-agent lifecycle gap. Cross-process allocation/file-write coordination remains out of scope, and this change does not claim race-free behavior across concurrent processes.