### PR TITLE
fix(hashline): prevent freed anchor reuse (#31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Documentation
 
+- **adr:** clarify single vs multi-session pos-free trade-off
 - **adr:** refine ADR-0013 to automatic fallback (no config)
 - **adr:** add ADR-0013 pos-free roundtrip with concurrency fallback (#31)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Fixed
 
+- **hashline:** add per-session canons, epoch and strict pos for ADR-0013
 - **hashline:** prevent freed anchor reuse (#31)
 
 ### Documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Fixed
 
+- **hashline:** make read path per-session reserved for ADR-0013
 - **hashline:** polish P2s for ADR-0013 automatic fallback
 - **hashline:** implement per-session tombstone and epoch-aware strict pos
 - **hashline:** add per-session canons, epoch and strict pos for ADR-0013

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Fixed
 
+- **hashline:** eliminate remaining P2s for zero-issue review
 - **hashline:** make read path per-session reserved for ADR-0013
 - **hashline:** polish P2s for ADR-0013 automatic fallback
 - **hashline:** implement per-session tombstone and epoch-aware strict pos

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Documentation
 
+- **adr:** refine ADR-0013 to automatic fallback (no config)
 - **adr:** add ADR-0013 pos-free roundtrip with concurrency fallback (#31)
 
 ## [0.6.0](https://github.com/Rianico/dsh-better-edit/compare/v0.5.1...v0.6.0) (2026-08-31)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Fixed
 
+- **hashline:** polish P2s for ADR-0013 automatic fallback
 - **hashline:** implement per-session tombstone and epoch-aware strict pos
 - **hashline:** add per-session canons, epoch and strict pos for ADR-0013
 - **hashline:** prevent freed anchor reuse (#31)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [Unreleased]
+
+### Fixed
+
+- **hashline:** prevent freed anchor reuse (#31)
+
+### Documentation
+
+- **adr:** add ADR-0013 pos-free roundtrip with concurrency fallback (#31)
+
 ## [0.6.0](https://github.com/Rianico/dsh-better-edit/compare/v0.5.1...v0.6.0) (2026-08-31)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Fixed
 
+- **hashline:** implement per-session tombstone and epoch-aware strict pos
 - **hashline:** add per-session canons, epoch and strict pos for ADR-0013
 - **hashline:** prevent freed anchor reuse (#31)
 

--- a/docs/adr/0013-pos-free-roundtrip-optimization.md
+++ b/docs/adr/0013-pos-free-roundtrip-optimization.md
@@ -61,7 +61,16 @@ Makes `shift==rebind` loud only when `changed` overlaps target, not when exterio
 ### 4. Non-overlapping forever is pos-free
 
 `A:10..12 +1 line` shifts `B:20..30->21..31`. `B`'s `served 20..30 == file 21..31` still `candidates==1` -> pass. Non-overlapping spans never abort in `resist`.
+## Single vs Multi-session
 
+|  | Single-session (serial `read->edit*` per `sessionKey`) | Multi-session (concurrent `A`+`B`) |
+|---|---|---|
+| Read-set | `epoch==curId` → no concurrent writer | `epoch!=curId` → concurrent `changed` detected |
+| Non-overlapping `A:10..12+1` shifts `B:20..30→21..31` | `pass` — candidates `hash==` still `1`, `tombstone∉` | `changed ∩ [L,R]==∅` → `resist` → `pass` (drift notice, not abort) |
+| Overlapping `S@3 reborn @3` whole-span | `tombstone` blocks allocation → `E_STALE_ANCHOR` | `changed ∩ [L,R]!=∅` → `strict from==pos` → `E_RANGE_STALE` |
+| Cost | `pos-free` — zero extra round trips | May incur one `edit` retry via `reject-and-serve` (`E.servedRows` already re-serves, no `read` needed) |
+
+We keep `pos-free` by default because line non-overlap ≈ semantic non-overlap for hash-anchored edits; strict would make every exterior `insert @0` abort `B`'s unrelated range, violating `CONTEXT.md:anchor philosophy` and `ADR-0004` healing. Concurrency fallback is automatic, no `supportConcurrency` flag — exterior drift stays `resist`, only overlapping concurrent goes `strict`.
 ## Considered Options
 
 - **Strict pos always** — would make every exterior insert abort `edit 10..12` after `insert @0`, forcing re-read tax, violating `position-independent` and ADR-0004.

--- a/docs/adr/0013-pos-free-roundtrip-optimization.md
+++ b/docs/adr/0013-pos-free-roundtrip-optimization.md
@@ -39,11 +39,24 @@ At `edit` (`mutation/engine.ts:applyOne` -> `hashline/anchor-pipeline.ts:verifyS
 
 Prevents `S@3` reborn `@3` whole-span case where `pos`+`canon` both pass.
 
-### 3. Concurrency fallback (opt-in)
+### 3. Concurrency fallback (automatic, no config)
 
-`config support_concurrency:true` (default `false`=`resist`):
+No `supportConcurrency` flag — fallback is automatic via `epoch`:
 
-- `strict: from==startLine-1 && to==endLine-1` added to `verifyServedRange` after candidates. Makes `shift==rebind` loud for `AgentTeams` shared `sessionKey` (isolated `tombstone` would otherwise allow `S@2->7` shift as valid). Cost is one extra `edit` retry via `reject-and-serve` (`E.servedRows` already serves fresh anchors, no `read` needed), rare (`~1/238k` collision or reuse).
+```
+curId = fileSnap(path) // ino|mtime|size|checksum at edit
+if curId == epoch.snapshotId
+  -> single-thread, no concurrent write: resist (pos-free)
+     candidates hash== && tombstone∉ && canon==
+else
+  changed = diff(epochHashes, curHashes) // indices where hash!= 
+  if changed ∩ [L,R] == ∅ && changed ∩ servedRanges == ∅
+    -> resist (exterior drift, e.g. insert @0 before served 1..5) -> pass
+  else
+    -> strict: from==startLine-1 && to==endLine-1 && tombstone∉ && canon== else E_RANGE_STALE
+```
+
+Makes `shift==rebind` loud only when `changed` overlaps target, not when exterior. Cost is one `edit` retry via `reject-and-serve` (no `read`), rare (`~1/238k`).
 
 ### 4. Non-overlapping forever is pos-free
 
@@ -59,6 +72,7 @@ Prevents `S@3` reborn `@3` whole-span case where `pos`+`canon` both pass.
 
 - `hash-store.ts:served` adds `canons TEXT` parallel to `hashes` and `tombstones TEXT`; `session-view.ts` adds `loadTombstones/putTombstones` (`withStore` atomic with `hashes+canons`).
 - `hash-assign.ts` removes `removedByContent`, adds `tombstone` param to `mapStableHashes`/`lineHashes`.
-- `anchor-pipeline.ts:verifyServedRange` keeps candidate enumeration, adds `tombstone` filter and `servedCanons` check, `strict` pos behind config.
+- `anchor-pipeline.ts:verifyServedRange` keeps candidate enumeration, adds `tombstone` filter and `servedCanons` check, `strict` pos via automatic `changed ∩ [L,R]` (no config).
 - Tests: `hashline-stable-mapping.test.ts` "reuses first removed hash" flips to `fresh hash`; new property `identical canon after removal gets ≠ removed hash`.
+
 - Round trips: single-thread exterior drift no longer aborts; concurrency strict aborts only on `read-set stale`, retry uses `E.servedRows` without `read`.

--- a/docs/adr/0013-pos-free-roundtrip-optimization.md
+++ b/docs/adr/0013-pos-free-roundtrip-optimization.md
@@ -1,0 +1,64 @@
+# ADR-0013 — Pos-free round-trip optimization with concurrency fallback
+
+Date: 2026-09-01
+
+## Status
+
+accepted
+
+## Context
+
+Issue [#31](https://github.com/Rianico/dsh-better-edit/issues/31) — freed `3-char` anchors re-bind to identical-content lines and pass `verifyServedRange` silently. Root cause is two-layer: `mapStableHashes` re-allocates a freed hash via `removedByContent` queue + `baseIdx=xxh32(canon)%SPACE` free-bit, and `verifyServedRange` is position-blind (`served[candFrom+k]==fileHashes[startLine-1+k]` only).
+
+Production evidence: 1050 edits / 145 sessions, 901 `Successfully edited` hide rebind-successes; `old_string` fails loud+lossless in same situation. The whole-span variant (`S@3 reborn @3` after `other|cards` swap) shows strict `from==pos` also fails when `same pos+same canon` but different span.
+
+Project contract (`CONTEXT.md:anchor philosophy`) is `position-independent` — exterior `insert @0` before `served 1..5` must not abort `edit 10..12`. Strict `pos` breaks it. Whitespace-insensitive (`ADR-0002`), orphan healing (`ADR-0004`) already rely on content-matching candidates, not pos.
+
+See `CONTEXT.md` glossary (`serve`, `served state`, `position-independent`, `reject-and-serve`, `orphaned serve`) for terminology.
+
+## Decision
+
+Keep **`position-free` for single-thread** (serial `read->edit*` per `sessionKey`), fallback to **`pos-restricted + tombstone + canon`** for concurrency. Model is `OCC` with read-set=`served range`, not file — exterior drift is `drift notice` (ADR-0006), not abort.
+
+### 1. Epoch not pos
+
+At `read full` (`file-view.ts:readView` without `offset/limit` and not truncated): store `epoch={snapshotId:ino|mtime|size|checksum, servedHashes, servedCanons}` per `(session,path)` in `hash-store.ts:served`. `partial read` merges via `_mergeServedRows` without clearing epoch.
+
+At `edit` (`mutation/engine.ts:applyOne` -> `hashline/anchor-pipeline.ts:verifyServedRange`):
+
+- `curId=fileSnap(path)` vs `epoch.snapshotId`: if `==` skip pos.
+- else candidates `{ [cFrom,cTo] | len==currentLen && ∀k servedHashes[cFrom+k]==fileHashes[startLine-1+k] }` (existing lazy disambiguation, ADR-0004), filtered by `tombstone`, then `∀k servedCanons[from+k]==canon(fileLines[startLine-1+k])` else `E_RANGE_STALE`. No `from==pos`.
+
+### 2. Tombstone (allocation invariant)
+
+`hash-assign.ts:mapStableHashes` drops `removedByContent` queue. `used=bitset(oldHashes)∪bitset(tombstone)` where `tombstone:Set<string>` per `(session,path)` since last full `read`, persisted in `served.tombstones TEXT` (`JSON string[]`). New lines probe over it. Lifecycle:
+
+- `edit success: tombstone∪=removedHashes` (`mutation/engine.ts:collectRemovedHashes`)
+- `undo: tombstone=(tombstone-restored)∪(cur-restored)`
+- `read full: tombstone=∅` ; `partial: keep` ; `pruneServedOlderThan` clears with `served`.
+
+Prevents `S@3` reborn `@3` whole-span case where `pos`+`canon` both pass.
+
+### 3. Concurrency fallback (opt-in)
+
+`config support_concurrency:true` (default `false`=`resist`):
+
+- `strict: from==startLine-1 && to==endLine-1` added to `verifyServedRange` after candidates. Makes `shift==rebind` loud for `AgentTeams` shared `sessionKey` (isolated `tombstone` would otherwise allow `S@2->7` shift as valid). Cost is one extra `edit` retry via `reject-and-serve` (`E.servedRows` already serves fresh anchors, no `read` needed), rare (`~1/238k` collision or reuse).
+
+### 4. Non-overlapping forever is pos-free
+
+`A:10..12 +1 line` shifts `B:20..30->21..31`. `B`'s `served 20..30 == file 21..31` still `candidates==1` -> pass. Non-overlapping spans never abort in `resist`.
+
+## Considered Options
+
+- **Strict pos always** — would make every exterior insert abort `edit 10..12` after `insert @0`, forcing re-read tax, violating `position-independent` and ADR-0004.
+- **Tombstone+canon without pos** — fixes `#31` same-session dense whole-span, but cross-session isolated `S@2->7` shift stays silent (desired for single thread, undesired for strict concurrency).
+- **Global file tombstone** — would block reuse for all sessions until any `read`, prematurely cleared by another agent's `read`. Per-session epoch is correct; file `snapshots` stays global last-writer-wins.
+
+## Consequences
+
+- `hash-store.ts:served` adds `canons TEXT` parallel to `hashes` and `tombstones TEXT`; `session-view.ts` adds `loadTombstones/putTombstones` (`withStore` atomic with `hashes+canons`).
+- `hash-assign.ts` removes `removedByContent`, adds `tombstone` param to `mapStableHashes`/`lineHashes`.
+- `anchor-pipeline.ts:verifyServedRange` keeps candidate enumeration, adds `tombstone` filter and `servedCanons` check, `strict` pos behind config.
+- Tests: `hashline-stable-mapping.test.ts` "reuses first removed hash" flips to `fresh hash`; new property `identical canon after removal gets ≠ removed hash`.
+- Round trips: single-thread exterior drift no longer aborts; concurrency strict aborts only on `read-set stale`, retry uses `E.servedRows` without `read`.

--- a/docs/specs/architecture-adr0013.md
+++ b/docs/specs/architecture-adr0013.md
@@ -1,0 +1,164 @@
+# Architecture — ADR-0013 Pos-free Round-trip Optimization
+
+> ADR: `docs/adr/0013-pos-free-roundtrip-optimization.md` · Issue: [#31](https://github.com/Rianico/dsh-better-edit/issues/31) · PR: [#41](https://github.com/Rianico/dsh-better-edit/pull/41) · Branch: `fix/issue-31-freed-anchor-tombstones`
+
+## 1. Goal
+
+Keep the extension **position-free for single-thread** (serial `read → edit*` per `sessionKey`) to reduce round trips, while guaranteeing correctness under concurrency by **fallback to `pos + tombstone + canon`**. The whole-span variant `S@3 reborn @3` after `other|cards` swap shows `pos` alone is insufficient; `tombstone` per epoch is load-bearing.
+
+Project contracts from `CONTEXT.md` preserved: `anchor philosophy` (position-independent, ASCII-whitespace strip `ADR-0002`), `model–tool boundary`, `reject-and-serve`, `served state` mirror, `orphaned serve` healing (`ADR-0004`).
+
+## 2. Clean Architecture — Layers & Dependency Rule
+
+**Dependency Rule:** dependencies point **inward**. Inner layers know nothing of outer. Outer layers depend on inner via **interfaces/ports**.
+
+```text
+Frameworks/Drivers → Interface Adapters → Use Cases → Entities
+```
+
+### 2.1 Entities (enterprise business rules, no I/O)
+
+| Entity | Invariant | File |
+| --- | --- | --- |
+| `HashSpace` | `HASH_SPACE=62^3`, `HASH_LEN=3`, `probe stride = 63^2+63+1`, unique per file, `canon=line.replace(/[ \t\r\n]+/g,"")` (`ADR-0002`) | `src/hashline/hash-assign.ts` (pure part) |
+| `Anchor` | `HASH_SEP=│`, `HASH_RE`, content-derived, never fuzzy-matched | `src/hashline/hash-assign.ts` |
+| `ServedMirror` | `served: (hash \| null)[]` per `(session,path)` is model's knowledge; `orphan` = hash at wrong slot | `src/session-view.ts` (`_mergeServedRows`) |
+| `TombstoneEpoch` | `tombstone:Set<hash>` per `(session,path)` since last **full** `read`; `used=bitset(oldHashes)∪bitset(tombstone)` | `src/hash-store.ts:served.retired`, `src/session-view.ts` |
+| `Snapshot` | `path+checksum+lineCount -> hashes[]` global last-writer-wins cache | `src/hash-store.ts:snapshots` |
+| `Canons` | `hash->canon` map for `S@3==S@3` whole-span detection; `canon==` alone not enough, need `tombstone` | `src/hashline/hash-assign.ts` (`hashToCanon`) + `served.canons` (proposed) |
+
+### 2.2 Use Cases (application business rules)
+
+| Use Case | Interactor | Input/Output Port |
+| --- | --- | --- |
+| `ReadAndServe` | `readView` + `readAndServe` | In: `path, offset/limit, encoding, sessionKey` → Out: `hashes+servedRows` |
+| `VerifyServedRange` | `verifyServedRange` | In: `served, fileHashes, fileLines, start/endHash, tombstone, canons, strictPos?` → Out: `void` or `E_RANGE_*` + `servedRows` |
+| `AllocateHashes` | `lineHashesPure` / `mapStableHashes` | In: `content, previous{hashes,removed}, reserved/tombstone` → Out: `hashes[]` |
+| `ExecuteEdit` (single/batch) | `applyOne` / `runFileEdits` | In: `HEdit, hashes, served, reservations` → Out: `result+range+removedHashes` |
+| `HealOrphan` | `_mergeServedRows` (eager) + candidate enumeration (lazy) | `ADR-0004` |
+| `ComputeDrift` | `scanDrift` | `drift notice` (user-facing per `ADR-0006`) |
+
+### 2.3 Interface Adapters
+
+| Adapter | Role | File |
+| --- | --- | --- |
+| `FileView` | normalize → hash → render → truncate → `served` selection | `src/file-view.ts` |
+| `HashPersistence` | `HashSnapshotIO` (`get/upsert`) — port for Entities | `src/hashline/hash.ts` |
+| `ServedPersistence` | `ServedPersistence` (`getServed`, `getAnchorReservations`, `getRetiredAnchors`, `upsertRetiredAnchors`, `clearRetiredAnchors`) | `src/hash-store.ts`, `src/session-view.ts` |
+| `MutationEngine` | `applyOne`, `runFileEdits`, `persistUndoAndWrite` | `src/mutation/engine.ts`, `src/mutation.ts` |
+| `AnchorPipeline` | `resEdit → swapReversed → stripBare → stripDiff → valEdit → verifyServed → resToSpan` (sealed seam) | `src/hashline/anchor-pipeline.ts` |
+
+### 2.4 Frameworks/Drivers (outermost)
+
+`@deepseek-ai/cordis` `defineTool` (`src/tool-read.ts`, `src/tool-edit.ts`, `src/tool-undo.ts`), `DatabaseSync` (`node:sqlite`), `fs-bridge.ts` (`FileIO`), `workspace-context.ts` (`execSessionKey`, `withWorkspace`), `xxhash-wasm`.
+
+> `hash.ts` stays **pure** with injected `HashSnapshotIO`; `hash-assign.ts` stays **pure** with `reservedHashes` param — no `loadHashStore()` inside Entities/Use Cases. This satisfies `ADR-0004` "hash-layer detection rejected".
+
+## 3. Mermaid — Dependencies Point Inward
+
+```mermaid
+graph TD
+  subgraph OUTER["Frameworks / Drivers"]
+    DSH["DSH defineTool<br/>tool-read / tool-edit"]
+    SQLite["DatabaseSync<br/>hash-store.ts"]
+    FS["fs-bridge / workspace-context<br/>xxhash-wasm"]
+  end
+
+  subgraph ADAPTERS["Interface Adapters"]
+    FV["FileView<br/>file-view.ts"]
+    SV["SessionView<br/>session-view.ts"]
+    ME["MutationEngine<br/>mutation/engine.ts"]
+    AP["AnchorPipeline<br/>anchor-pipeline.ts"]
+    HP["HashPersistence<br/>hash.ts"]
+  end
+
+  subgraph USECASES["Use Cases"]
+    RNS["ReadAndServe"]
+    VSR["VerifyServedRange"]
+    ALLOC["AllocateHashes<br/>mapStableHashes"]
+    EXEC["ExecuteEdit<br/>applyOne/runFileEdits"]
+  end
+
+  subgraph ENTITIES["Entities"]
+    HS["HashSpace / Canon"]
+    SM["ServedMirror / TombstoneEpoch"]
+    SN["Snapshot / Canons"]
+  end
+
+  DSH --> FV
+  DSH --> ME
+  FV --> HP
+  FV --> SV
+  ME --> VSR
+  ME --> ALLOC
+  AP --> VSR
+  SV --> HS
+  HP --> HS
+  VSR --> SM
+  ALLOC --> HS
+  EXEC --> SM
+  SV -.->|port| SQLite
+  HP -.->|port| SQLite
+  FS --> FV
+  FS --> ME
+
+  %% Dependency Rule: outer -> inner only
+```
+
+## 4. PR #41 — What Got Right vs Outdated (pre-discussion)
+
+PR #41 is built on the first single-agent tombstone understanding before the pos-free design.
+
+**Got right (reusable):**
+
+* Drops `removedByContent` queue in `mapStableHashes` — correct single-agent lifecycle gap.
+* Blocks freed hashes via `used=bitset(oldHashes)∪bitset(blocked)` where `blocked=reserved∪removed` (`src/hashline/hash-assign.ts`).
+* Migrates `served` schema `ALTER TABLE served ADD COLUMN retired TEXT` preserving `hashes`, invalidates pre-fix `snapshots`+`undo` that may contain rebound anchors (`src/hash-store.ts:buildStore`).
+* Fixes `lineHashes` to reject cached `hashes` containing `retiredHashes` and to reserve during `lineHashesPure`/`mapStableHashes`.
+* Retires anchors on `edit`/`batch`/`partial read displacement` and clears on `full read` (`src/session-view.ts:retireAnchors`, `recordServed` `isFullRead` check, `recordServedTruncated`).
+
+**Outdated vs ADR-0013 (needs update):**
+
+* **No epoch `snapshotId`** (`ino|mtime|size|checksum` via `file-view.ts:fileSnap`). PR #41 uses `isFullRead = rows.length==fullReadHashes.length && rows.every(pos==index)` — no file-version comparison, so `insert @0` before `served 1..5` still moves `served` and is healed as `displacedHashes` retirement, not recognized as exterior drift that should stay pos-free.
+* **No `canons TEXT` column.** Stores only `hashes+retired`, no `canon_at_serve` parallel array. Whole-span `S@3==S@3` with same `canon` passes `hash==` check; `canon` check is missing.
+* **Global `reserved=served∪retired` across *all* sessions per path** (`getAnchorReservations(path)` scans `SELECT ... WHERE path=?`). ADR-0013 requires **per-`(session,path)` tombstone epoch** since last full `read`; global reservation blocks reuse for *all* sessions until any session does a full read — prematurely cleared and violates per-session isolation. `file snapshots` stays global last-writer-wins, but `tombstone` must be per-session.
+* **No `pos` fallback.** No `from==startLine-1` strict check, no `support_concurrency` config. Cross-session `S@2->7` shift with isolated `tombstone` stays silent (desired for single-thread, needs `strict` for concurrency).
+* **No `pos-free` guarantee for non-overlapping** — PR #41 still retires `displacedHashes(Current,Updated)` on every `recordServed`/`recordServedTruncated`, so `A:10..12 +1` forever retires `B:20..30` hashes as `displaced`, even though exterior `insert` should be allowed.
+* **Whole-span `S@3 reborn @3`** not covered without `canons`+`tombstone` per epoch (PR #41's `reserved` would block it only if same `path` and any session still holds `S`, but same-pos rebind with `reserved` across all sessions may over-block).
+* **Undo restores with `restoredHashes` via `blockedRestoreHashes = reserved∪currentHashes`** — close to ADR-0013's `(tombstone-restored)∪(cur-restored)` but without `canons` and with global `reserved`.
+
+## 5. Curated Architecture (ADR-0013)
+
+Keep `pos-free` for `resist` (default), fallback to `strict` for `concurrency:true`.
+
+* **Read full:** store `epoch={snapshotId, servedHashes, servedCanons}` per `(session,path)` in `hash-store.ts:served` (`hashes TEXT, canons TEXT, tombstones TEXT, reported TEXT`). Partial read merges via `_mergeServedRows` without clearing epoch, but `displacedHashes` only retires when `hash` actually displaced, not on exterior shift.
+* **Edit `verifyServedRange`:** `curId=fileSnap(path)` vs `epoch.snapshotId` → if `==` skip `pos`; else `candidates { hash== && len== }` filtered by `tombstone`, then `servedCanons[from+k]==canon(fileLines[startLine-1+k])` else `E_RANGE_STALE`. No `from==pos` in `resist`. `strict` adds `from==startLine-1 && to==endLine-1` behind config.
+* **Allocate:** `hash-assign.ts:mapStableHashes(..., tombstone)` with `used=bitset(oldHashes)∪bitset(tombstone)`; drop `removedByContent`; `lineHashesPure(..., reserved)` also respects per-session `tombstone`. `hash.ts:lineHashes` threads `reservedHashes, retiredHashes` from `loadAnchorReservations` per session, not global.
+* **Non-overlapping forever pos-free:** `A:10..12 +1` shifts `B:20..30->21..31`; `B`'s `served 20..30 == file 21..31` still `candidates==1` → pass, `tombstone` not touched (no `removed` in that range).
+
+## 6. Reuse Verdict per File (vs PR #41)
+
+| File | Verdict | Reason | Severity |
+| --- | --- | --- | --- |
+| `src/hashline/hash-assign.ts` | **reusable** — needs update | Drop `removedByContent`, add `tombstone` param is correct; needs `markHashUsed(tombstone)` already in PR #41, keep. Needs `canon` storage not here — allocation layer stays hash-only. | — |
+| `src/hashline/hash.ts` | **reusable** — needs update | `reservedHashes`/`retiredHashes` params correct; needs to switch from `getAnchorReservations(path)` global to `getTombstone(session,path)+getServedCanons(session,path)` per-session epoch. | medium |
+| `src/hash-store.ts` | **needs update** | `retired TEXT` migration preserving `hashes` correct; must add `canons TEXT` + `tombstones TEXT` per `(session,path)` epoch, change `servedAllForPath(path)` global scan to per-session `getServedCanons(session,path)` + `getTombstone(session,path)`. Remove global `reserved = served∪retired` scan. Invalidate `snapshots` on `canon` upgrade already done. | high |
+| `src/session-view.ts` | **needs update** | `retireAnchors`, `displacedHashes`, `isFullRead` logic correct single-agent; must make `displaced` not retire exterior shift (only when `hash` displaced within served range), and persist `canons` atomically with `hashes` in `recordServed`. | high |
+| `src/file-view.ts` | **reusable** | `reservedHashes`/`retiredHashes` threading via `ReadNormOptions`/`ReadViewOpts` is correct adapter pattern; keep but wire per-session `tombstone` instead of global `reserved`. | low |
+| `src/mutation/engine.ts` | **reusable** — needs update | `reservedHashes` into `applyOne`/`runFileEdits` and `newlyRetired` accumulation correct; needs per-session `loadAnchorReservations(session,path)` not global, and `lineHashes` call must pass `canons` epoch. | medium |
+| `src/hashline/anchor-pipeline.ts` | **needs update** | `verifyServedRange` already has `isHealed`/`canon` healing and `E_RANGE_*` taxonomy; must add `servedCanons` parallel array param, `tombstone` filter on candidates, `epoch snapshotId` early-exit, and `support_concurrency` strict `pos` gate. | high |
+| `src/read-and-serve.ts` | **reusable** | `loadAnchorReservations` before `readView` + `recordServed(..., view.hashes)` full-read detection correct; needs to pass `canons` too. | low |
+| `src/tool-undo.ts` | **needs update** | Fresh `restoredHashes` via `blockedRestoreHashes` correct; needs per-session `tombstone` update `(tombstone-restored)∪(cur-restored)` already, but with global `reserved` it over-blocks `currentOnlyAnchor`. Switch to per-session. | medium |
+| `test/core/hashline-stable-mapping.test.ts` | **reusable** | Flipped expectations (`fresh hash not removed`) already match ADR-0013. | — |
+
+## 7. Residual Risks
+
+* `served.canons` migration without invalidating `served.hashes` — old rows lack `canons`, `verifyServedRange` `getCanonForHash` fallback (`hashToCanon` in-memory) may miss. Mitigate by `ALTER TABLE served ADD COLUMN canons TEXT` with `null` healing via `canon(fileLines[pos])` lazy fill on first `recordServed`.
+* Per-session `tombstone` grows without bound if session never does full `read` (`SERVED_TTL_MS` sweep via `pruneServedOlderThan` covers it, but tune).
+
+## 8. Next Steps (no code edit in this task)
+
+1. Implement `hash-store.ts:served (hashes, canons, tombstones)` per-session epoch + `fileSnap` epoch.
+2. Update `hash-assign.ts`/`hash.ts` to thread per-session `tombstone`.
+3. Update `anchor-pipeline.ts:verifyServedRange` to `epoch` + `candidates hash==` + `tombstone` filter + `canon==` + `strict` flag.
+4. Add `config.support_concurrency` and flip property tests.

--- a/src/file-view.ts
+++ b/src/file-view.ts
@@ -371,6 +371,8 @@ export interface ReadNormOptions {
   maxLines?: number;
   store?: HashStore;
   noPersist?: boolean;
+  reservedHashes?: ReadonlySet<string>;
+  retiredHashes?: ReadonlySet<string>;
 }
 
 export async function normFromText(input: {
@@ -381,6 +383,8 @@ export async function normFromText(input: {
   maxLines?: number;
   store?: HashStore;
   noPersist?: boolean;
+  reservedHashes?: ReadonlySet<string>;
+  retiredHashes?: ReadonlySet<string>;
   hadUtf8DecodeErrors?: boolean;
 }): Promise<NormFile> {
   const { absolutePath, displayPath, signal } = input;
@@ -402,6 +406,8 @@ export async function normFromText(input: {
     undefined,
     input.store,
     input.noPersist !== true,
+    input.reservedHashes,
+    input.retiredHashes,
   );
   return {
     absolutePath,
@@ -440,6 +446,8 @@ export async function readNormFile(
     maxLines: options?.maxLines,
     store: options?.store,
     noPersist: options?.noPersist,
+    reservedHashes: options?.reservedHashes,
+    retiredHashes: options?.retiredHashes,
     hadUtf8DecodeErrors: file.hadUtf8DecodeErrors,
   });
 }
@@ -634,6 +642,8 @@ export interface PreviewOpts {
 export interface ReadViewOpts extends PreviewOpts {
   encoding?: string;
   signal?: AbortSignal;
+  reservedHashes?: ReadonlySet<string>;
+  retiredHashes?: ReadonlySet<string>;
 }
 
 export async function preview(
@@ -666,6 +676,8 @@ export async function readView(
       displayPath: path,
       signal,
       maxLines: MAX_HASH_LINES,
+      reservedHashes: opts.reservedHashes,
+      retiredHashes: opts.retiredHashes,
     });
   const r = await fmtReadPreview(
     normalized,

--- a/src/hash-store.ts
+++ b/src/hash-store.ts
@@ -95,9 +95,12 @@ interface Prepared {
 	undoDelete: (...params: SqlParams) => void;
 	undoPruneOlderThan: (...params: SqlParams) => void;
 	servedGet: (...params: SqlParams) => Record<string, unknown> | undefined;
+	servedAllForPath: (...params: SqlParams) => Record<string, unknown>[];
 	servedUpsert: (...params: SqlParams) => void;
 	servedReportedUpsert: (...params: SqlParams) => void;
 	servedReportedClear: (...params: SqlParams) => void;
+	servedRetiredUpsert: (...params: SqlParams) => void;
+	servedRetiredClear: (...params: SqlParams) => void;
 	servedDelete: (...params: SqlParams) => void;
 	servedDeletePath: (...params: SqlParams) => void;
 	servedWipe: (...params: SqlParams) => void;
@@ -152,13 +155,22 @@ export interface HashStore {
 export interface ServedPersistence {
   getServed(sessionKey: string, path: string): (string | null)[];
   getServedReported(sessionKey: string, path: string): Set<string>;
+  getAnchorReservations(path: string): AnchorReservations;
+  getRetiredAnchors(sessionKey: string, path: string): Set<string>;
   upsertServed(sessionKey: string, path: string, hashesJson: string): void;
   upsertServedReported(sessionKey: string, path: string, reportedJson: string): void;
   clearServedReported(sessionKey: string, path: string): void;
+  upsertRetiredAnchors(sessionKey: string, path: string, hashesJson: string): void;
+  clearRetiredAnchors(sessionKey: string, path: string): void;
   deleteServed(sessionKey: string, path: string): void;
   deleteServedByPath(path: string): void;
   wipeServed(sessionKey: string): void;
   pruneServedOlderThan(ts: number): void;
+}
+
+export interface AnchorReservations {
+  reservedHashes: Set<string>;
+  retiredHashes: Set<string>;
 }
 
 export type InternalHashStore = HashStore & ServedPersistence;
@@ -300,10 +312,43 @@ function buildStore(db: DatabaseSync): { db: DatabaseSync; stmts: Prepared } {
 			"path TEXT NOT NULL, " +
 			"hashes TEXT NOT NULL, " +
 			"reported TEXT, " +
+			"retired TEXT, " +
 			"updated_at INTEGER NOT NULL, " +
 			"PRIMARY KEY (session_id, path)" +
 			")",
 	);
+	const currentServedColumns = db.prepare("PRAGMA table_info(served)").all() as {
+		name: string;
+	}[];
+	if (!currentServedColumns.some((column) => column.name === "retired")) {
+		let migrationOpen = false;
+		try {
+			db.exec("BEGIN IMMEDIATE");
+			migrationOpen = true;
+			const migrationColumns = db
+				.prepare("PRAGMA table_info(served)")
+				.all() as { name: string }[];
+			if (!migrationColumns.some((column) => column.name === "retired")) {
+				db.exec("ALTER TABLE served ADD COLUMN retired TEXT");
+				// Pre-fix snapshots and undo entries may already bind a remembered
+				// anchor to the wrong position. Preserve served rows, but rebuild
+				// every source that could restore the rebound anchor.
+				db.exec("DELETE FROM snapshots");
+				db.exec("DELETE FROM undo");
+			}
+			db.exec("COMMIT");
+			migrationOpen = false;
+		} catch (error) {
+			if (migrationOpen) {
+				try {
+					db.exec("ROLLBACK");
+				} catch (rollbackError) {
+					console.warn(rollbackError);
+				}
+			}
+			throw error;
+		}
+	}
 	db
 		.prepare(
 			"INSERT INTO meta (key, value) VALUES ('version', ?) " +
@@ -334,7 +379,10 @@ function buildStore(db: DatabaseSync): { db: DatabaseSync; stmts: Prepared } {
 		"DELETE FROM undo WHERE updated_at < ?",
 	);
 	const servedGetStmt = db.prepare(
-		"SELECT hashes, reported FROM served WHERE session_id = ? AND path = ?",
+		"SELECT hashes, reported, retired FROM served WHERE session_id = ? AND path = ?",
+	);
+	const servedAllForPathStmt = db.prepare(
+		"SELECT session_id, hashes, retired FROM served WHERE path = ?",
 	);
 	const servedUpsertStmt = db.prepare(
 		"INSERT INTO served (session_id, path, hashes, updated_at) VALUES (?, ?, ?, ?) " +
@@ -346,6 +394,13 @@ function buildStore(db: DatabaseSync): { db: DatabaseSync; stmts: Prepared } {
 	);
 	const servedReportedClearStmt = db.prepare(
 		"UPDATE served SET reported = NULL, updated_at = ? WHERE session_id = ? AND path = ?",
+	);
+	const servedRetiredUpsertStmt = db.prepare(
+		"INSERT INTO served (session_id, path, hashes, retired, updated_at) VALUES (?, ?, '[]', ?, ?) " +
+			"ON CONFLICT(session_id, path) DO UPDATE SET retired = excluded.retired, updated_at = excluded.updated_at",
+	);
+	const servedRetiredClearStmt = db.prepare(
+		"UPDATE served SET retired = NULL, updated_at = ? WHERE session_id = ? AND path = ?",
 	);
 	const servedDeleteStmt = db.prepare(
 		"DELETE FROM served WHERE session_id = ? AND path = ?",
@@ -390,6 +445,8 @@ function buildStore(db: DatabaseSync): { db: DatabaseSync; stmts: Prepared } {
 		},
 		servedGet: (...params) =>
 			servedGetStmt.get(...params) as Record<string, unknown> | undefined,
+		servedAllForPath: (...params) =>
+			servedAllForPathStmt.all(...params) as Record<string, unknown>[],
 		servedUpsert: (...params) => {
 			withBusyRetry(() => {
 				servedUpsertStmt.run(...params);
@@ -403,6 +460,16 @@ function buildStore(db: DatabaseSync): { db: DatabaseSync; stmts: Prepared } {
 		servedReportedClear: (...params) => {
 			withBusyRetry(() => {
 				servedReportedClearStmt.run(params[1], params[0], params[2]);
+			});
+		},
+		servedRetiredUpsert: (...params) => {
+			withBusyRetry(() => {
+				servedRetiredUpsertStmt.run(...params);
+			});
+		},
+		servedRetiredClear: (...params) => {
+			withBusyRetry(() => {
+				servedRetiredClearStmt.run(params[1], params[0], params[2]);
 			});
 		},
 		servedDelete: (...params) => {
@@ -548,6 +615,48 @@ function makeDomainStore(stmts: Prepared): InternalHashStore {
 				return new Set();
 			}
 		},
+		getAnchorReservations(path) {
+			const reservedHashes = new Set<string>();
+			const retiredHashes = new Set<string>();
+			for (const row of stmts.servedAllForPath(path)) {
+				try {
+					const served = JSON.parse(row.hashes as string) as unknown;
+					const retired =
+						row.retired === null || row.retired === undefined
+							? []
+							: (JSON.parse(row.retired as string) as unknown);
+					if (!isValidServedList(served) || !isValidHashList(retired)) {
+						throw new TypeError("invalid stored anchor reservations");
+					}
+					for (const hash of served) {
+						if (hash !== null) reservedHashes.add(hash);
+					}
+					for (const hash of retired) {
+						reservedHashes.add(hash);
+						retiredHashes.add(hash);
+					}
+				} catch (error) {
+					stmts.servedDelete(row.session_id as string, path);
+				}
+			}
+			return { reservedHashes, retiredHashes };
+		},
+		getRetiredAnchors(sessionKey, path) {
+			const row = stmts.servedGet(sessionKey, path);
+			if (!row || row.retired === null || row.retired === undefined) {
+				return new Set();
+			}
+			try {
+				const parsed = JSON.parse(row.retired as string) as unknown;
+				if (!isValidHashList(parsed)) {
+					throw new TypeError("invalid retired anchors");
+				}
+				return new Set(parsed);
+			} catch (error) {
+				stmts.servedDelete(sessionKey, path);
+				return new Set();
+			}
+		},
 		upsertServed(sessionKey, path, hashesJson) {
 			stmts.servedUpsert(sessionKey, path, hashesJson, Date.now());
 		},
@@ -556,6 +665,17 @@ function makeDomainStore(stmts: Prepared): InternalHashStore {
 		},
 		clearServedReported(sessionKey, path) {
 			stmts.servedReportedClear(sessionKey, Date.now(), path);
+		},
+		upsertRetiredAnchors(sessionKey, path, hashesJson) {
+			stmts.servedRetiredUpsert(
+				sessionKey,
+				path,
+				hashesJson,
+				Date.now(),
+			);
+		},
+		clearRetiredAnchors(sessionKey, path) {
+			stmts.servedRetiredClear(sessionKey, Date.now(), path);
 		},
 		deleteServed(sessionKey, path) {
 			stmts.servedDelete(sessionKey, path);

--- a/src/hash-store.ts
+++ b/src/hash-store.ts
@@ -58,6 +58,15 @@ export function isValidSnapshot(value: unknown): value is LegacySnapshot {
 }
 
 /** A served-row array: per-position hash, or null for never-served slots. */
+export function isValidCanonsList(value: unknown): value is (string | null)[] {
+	if (!Array.isArray(value)) return false;
+	for (const entry of value) {
+		if (entry === null) continue;
+		if (typeof entry !== "string") return false;
+	}
+	return true;
+}
+
 export function isValidServedList(value: unknown): value is (string | null)[] {
 	if (!Array.isArray(value)) return false;
 	for (const entry of value) {
@@ -101,6 +110,10 @@ interface Prepared {
 	servedReportedClear: (...params: SqlParams) => void;
 	servedRetiredUpsert: (...params: SqlParams) => void;
 	servedRetiredClear: (...params: SqlParams) => void;
+	servedCanonsUpsert: (...params: SqlParams) => void;
+	servedCanonsClear: (...params: SqlParams) => void;
+	servedSnapshotUpsert: (...params: SqlParams) => void;
+	servedSnapshotClear: (...params: SqlParams) => void;
 	servedDelete: (...params: SqlParams) => void;
 	servedDeletePath: (...params: SqlParams) => void;
 	servedWipe: (...params: SqlParams) => void;
@@ -157,11 +170,17 @@ export interface ServedPersistence {
   getServedReported(sessionKey: string, path: string): Set<string>;
   getAnchorReservations(path: string): AnchorReservations;
   getRetiredAnchors(sessionKey: string, path: string): Set<string>;
+  getServedCanons(sessionKey: string, path: string): (string | null)[];
+  getEpochSnapshotId(sessionKey: string, path: string): string | undefined;
   upsertServed(sessionKey: string, path: string, hashesJson: string): void;
   upsertServedReported(sessionKey: string, path: string, reportedJson: string): void;
   clearServedReported(sessionKey: string, path: string): void;
   upsertRetiredAnchors(sessionKey: string, path: string, hashesJson: string): void;
   clearRetiredAnchors(sessionKey: string, path: string): void;
+  upsertServedCanons(sessionKey: string, path: string, canonsJson: string): void;
+  clearServedCanons(sessionKey: string, path: string): void;
+  upsertEpochSnapshotId(sessionKey: string, path: string, snapshotId: string): void;
+  clearEpochSnapshotId(sessionKey: string, path: string): void;
   deleteServed(sessionKey: string, path: string): void;
   deleteServedByPath(path: string): void;
   wipeServed(sessionKey: string): void;
@@ -313,6 +332,8 @@ function buildStore(db: DatabaseSync): { db: DatabaseSync; stmts: Prepared } {
 			"hashes TEXT NOT NULL, " +
 			"reported TEXT, " +
 			"retired TEXT, " +
+			"canons TEXT, " +
+			"snapshotId TEXT, " +
 			"updated_at INTEGER NOT NULL, " +
 			"PRIMARY KEY (session_id, path)" +
 			")",
@@ -349,6 +370,18 @@ function buildStore(db: DatabaseSync): { db: DatabaseSync; stmts: Prepared } {
 			throw error;
 		}
 	}
+	const canonsColumns = db.prepare("PRAGMA table_info(served)").all() as {
+		name: string;
+	}[];
+	if (!canonsColumns.some((column) => column.name === "canons")) {
+		db.exec("ALTER TABLE served ADD COLUMN canons TEXT");
+	}
+	const snapshotColumns = db.prepare("PRAGMA table_info(served)").all() as {
+		name: string;
+	}[];
+	if (!snapshotColumns.some((column) => column.name === "snapshotId")) {
+		db.exec("ALTER TABLE served ADD COLUMN snapshotId TEXT");
+	}
 	db
 		.prepare(
 			"INSERT INTO meta (key, value) VALUES ('version', ?) " +
@@ -379,7 +412,7 @@ function buildStore(db: DatabaseSync): { db: DatabaseSync; stmts: Prepared } {
 		"DELETE FROM undo WHERE updated_at < ?",
 	);
 	const servedGetStmt = db.prepare(
-		"SELECT hashes, reported, retired FROM served WHERE session_id = ? AND path = ?",
+		"SELECT hashes, reported, retired, canons, snapshotId FROM served WHERE session_id = ? AND path = ?",
 	);
 	const servedAllForPathStmt = db.prepare(
 		"SELECT session_id, hashes, retired FROM served WHERE path = ?",
@@ -401,6 +434,20 @@ function buildStore(db: DatabaseSync): { db: DatabaseSync; stmts: Prepared } {
 	);
 	const servedRetiredClearStmt = db.prepare(
 		"UPDATE served SET retired = NULL, updated_at = ? WHERE session_id = ? AND path = ?",
+	);
+	const servedCanonsUpsertStmt = db.prepare(
+		"INSERT INTO served (session_id, path, hashes, canons, updated_at) VALUES (?, ?, '[]', ?, ?) " +
+			"ON CONFLICT(session_id, path) DO UPDATE SET canons = excluded.canons, updated_at = excluded.updated_at",
+	);
+	const servedCanonsClearStmt = db.prepare(
+		"UPDATE served SET canons = NULL, updated_at = ? WHERE session_id = ? AND path = ?",
+	);
+	const servedSnapshotUpsertStmt = db.prepare(
+		"INSERT INTO served (session_id, path, hashes, snapshotId, updated_at) VALUES (?, ?, '[]', ?, ?) " +
+			"ON CONFLICT(session_id, path) DO UPDATE SET snapshotId = excluded.snapshotId, updated_at = excluded.updated_at",
+	);
+	const servedSnapshotClearStmt = db.prepare(
+		"UPDATE served SET snapshotId = NULL, updated_at = ? WHERE session_id = ? AND path = ?",
 	);
 	const servedDeleteStmt = db.prepare(
 		"DELETE FROM served WHERE session_id = ? AND path = ?",
@@ -470,6 +517,26 @@ function buildStore(db: DatabaseSync): { db: DatabaseSync; stmts: Prepared } {
 		servedRetiredClear: (...params) => {
 			withBusyRetry(() => {
 				servedRetiredClearStmt.run(params[1], params[0], params[2]);
+			});
+		},
+		servedCanonsUpsert: (...params) => {
+			withBusyRetry(() => {
+				servedCanonsUpsertStmt.run(...params);
+			});
+		},
+		servedCanonsClear: (...params) => {
+			withBusyRetry(() => {
+				servedCanonsClearStmt.run(params[1], params[0], params[2]);
+			});
+		},
+		servedSnapshotUpsert: (...params) => {
+			withBusyRetry(() => {
+				servedSnapshotUpsertStmt.run(...params);
+			});
+		},
+		servedSnapshotClear: (...params) => {
+			withBusyRetry(() => {
+				servedSnapshotClearStmt.run(params[1], params[0], params[2]);
 			});
 		},
 		servedDelete: (...params) => {
@@ -676,6 +743,35 @@ function makeDomainStore(stmts: Prepared): InternalHashStore {
 		},
 		clearRetiredAnchors(sessionKey, path) {
 			stmts.servedRetiredClear(sessionKey, Date.now(), path);
+		},
+		getServedCanons(sessionKey, path) {
+			const row = stmts.servedGet(sessionKey, path);
+			if (!row || row.canons === null || row.canons === undefined) return [];
+			try {
+				const parsed = JSON.parse(row.canons as string) as unknown;
+				if (!isValidCanonsList(parsed)) throw new TypeError("invalid canons");
+				return parsed;
+			} catch {
+				stmts.servedDelete(sessionKey, path);
+				return [];
+			}
+		},
+		getEpochSnapshotId(sessionKey, path) {
+			const row = stmts.servedGet(sessionKey, path);
+			if (!row || row.snapshotId === null || row.snapshotId === undefined) return undefined;
+			return row.snapshotId as string;
+		},
+		upsertServedCanons(sessionKey, path, canonsJson) {
+			stmts.servedCanonsUpsert(sessionKey, path, canonsJson, Date.now());
+		},
+		clearServedCanons(sessionKey, path) {
+			stmts.servedCanonsClear(sessionKey, Date.now(), path);
+		},
+		upsertEpochSnapshotId(sessionKey, path, snapshotId) {
+			stmts.servedSnapshotUpsert(sessionKey, path, snapshotId, Date.now());
+		},
+		clearEpochSnapshotId(sessionKey, path) {
+			stmts.servedSnapshotClear(sessionKey, Date.now(), path);
 		},
 		deleteServed(sessionKey, path) {
 			stmts.servedDelete(sessionKey, path);

--- a/src/hashline/anchor-pipeline.ts
+++ b/src/hashline/anchor-pipeline.ts
@@ -609,12 +609,26 @@ export function verifyServedRange(args: {
 	const echo = fmtServedRows(echoRows, fileLines) + tail;
 
 	// Tombstone check for boundaries (whole-span S@3==S@3)
+	// If hash was freed in this epoch, any reuse is stale even at same pos+same canon.
+	// Early reject checks canon change to avoid false positive on same line re-read.
 	if (tombstone.has(startHash) || tombstone.has(endHash)) {
-		// If hash was freed in this epoch, stale reuse must be loud even at same pos
-		// Only reject if hash is still in file at a different logical position? But tombstone means it was freed, so any reuse is stale
-		// Check if hash is in file but servedCanons mismatch or pos strict
-		// For now, if tombstone contains the hash and file still has it, treat as stale if servedCanons check fails or strict pos fails
-		// We will handle more precisely below after from/to resolved
+		const tombstonedHash = tombstone.has(startHash) ? startHash : endHash;
+		if (servedCanons) {
+			const pos = fileHashes.indexOf(tombstonedHash);
+			if (pos >= 0) {
+				const servedIdx = served.indexOf(tombstonedHash);
+				const expected = servedIdx >= 0 ? servedCanons[servedIdx] : undefined;
+				const actual = canon(fileLines[pos] ?? "");
+				if (expected !== undefined && expected !== null && expected !== actual) {
+					throw new ServedRejectionError({
+						code: "E_RANGE_STALE",
+						message: `[E_RANGE_STALE] anchor "${tombstonedHash}" was freed since last full read (tombstoned, canon changed from "${expected}" to "${actual}"). Re-read.\nCurrent range:\n${echo}`,
+						firstOffendingLine: pos + 1,
+						servedRows: echoRows,
+					});
+				}
+			}
+		}
 	}
 
 	const startPositions = servedPositionsOf(served, startHash);

--- a/src/hashline/anchor-pipeline.ts
+++ b/src/hashline/anchor-pipeline.ts
@@ -565,6 +565,11 @@ export function verifyServedRange(args: {
 	fileHashes: string[];
 	fileLines: string[];
 	filePath?: string;
+	servedCanons?: (string | null)[];
+	tombstone?: ReadonlySet<string>;
+	epochSnapshotId?: string;
+	curSnapshotId?: string;
+	strictPos?: boolean;
 }): void {
 	const {
 		served,
@@ -577,6 +582,11 @@ export function verifyServedRange(args: {
 		filePath,
 	} = args;
 	const where = filePath ? ` in ${filePath}` : "";
+	const tombstone = args.tombstone ?? new Set<string>();
+	const servedCanons = args.servedCanons;
+	const strictPos = args.strictPos ?? false;
+	const epochSnapshotId = args.epochSnapshotId;
+	const curSnapshotId = args.curSnapshotId;
 	let isHealed = false;
 	for (let i = 0; i < fileHashes.length; i++) {
 		const h = fileHashes[i]!;
@@ -597,6 +607,15 @@ export function verifyServedRange(args: {
 			? `\n${paginationHint(startLine + echoRows.length, totalLen - echoRows.length)}`
 			: "";
 	const echo = fmtServedRows(echoRows, fileLines) + tail;
+
+	// Tombstone check for boundaries (whole-span S@3==S@3)
+	if (tombstone.has(startHash) || tombstone.has(endHash)) {
+		// If hash was freed in this epoch, stale reuse must be loud even at same pos
+		// Only reject if hash is still in file at a different logical position? But tombstone means it was freed, so any reuse is stale
+		// Check if hash is in file but servedCanons mismatch or pos strict
+		// For now, if tombstone contains the hash and file still has it, treat as stale if servedCanons check fails or strict pos fails
+		// We will handle more precisely below after from/to resolved
+	}
 
 	const startPositions = servedPositionsOf(served, startHash);
 	const endPositions = servedPositionsOf(served, endHash);
@@ -824,6 +843,47 @@ export function verifyServedRange(args: {
 				});
 			}
 		}
+		// Strict pos check for concurrency (pos-free vs strict)
+		if (strictPos && from !== startLine - 1) {
+			throw new ServedRejectionError({
+				code: "E_RANGE_STALE",
+				message: `[E_RANGE_STALE] anchor was served at line ${from + 1} but now resolves to line ${startLine} (pos-restricted concurrency). Re-read.\nCurrent range:\n${echo}`,
+				firstOffendingLine: startLine,
+				servedRows: echoRows,
+			});
+		}
+		// Canon check for same-pos different content (collision)
+		if (servedCanons) {
+			for (let k = 0; k < servedLen; k++) {
+				const expected = servedCanons[from + k];
+				if (expected !== null && expected !== undefined) {
+					const actual = canon(fileLines[startLine - 1 + k] ?? "");
+					if (expected !== actual) {
+						throw new ServedRejectionError({
+							code: "E_RANGE_STALE",
+							message: `[E_RANGE_STALE] line ${startLine + k}${where} canon differs from served (expected "${expected}" vs actual "${actual}").\nCurrent range:\n${echo}`,
+							firstOffendingLine: startLine + k,
+							servedRows: echoRows,
+						});
+					}
+				}
+			}
+		}
+		// Tombstone interior check (whole-span)
+		for (let k = 0; k < servedLen; k++) {
+			const h = fileHashes[startLine - 1 + k];
+			if (h && tombstone.has(h)) {
+				// If hash is tombstoned but still in file at same pos with same canon, it's a reborn
+				// Only reject if this hash was previously served at a different position? For now, reject any tombstoned hash in range
+				// This catches S@3 reborn @3 after swap
+				throw new ServedRejectionError({
+					code: "E_RANGE_STALE",
+					message: `[E_RANGE_STALE] line ${startLine + k}${where} uses tombstoned anchor "${h}" (freed since last full read). Re-read.\nCurrent range:\n${echo}`,
+					firstOffendingLine: startLine + k,
+					servedRows: echoRows,
+				});
+			}
+		}
 		for (let k = 0; k < servedLen; k++) {
 			if (served[from + k] !== fileHashes[startLine - 1 + k]) {
 				const offendingLine = startLine + k;
@@ -993,6 +1053,11 @@ export function applyEdit(
 	precomputedHashes?: string[],
 	filePath?: string,
 	served?: (string | null)[],
+	servedCanons?: (string | null)[],
+	tombstone?: ReadonlySet<string>,
+	epochSnapshotId?: string,
+	curSnapshotId?: string,
+	strictPos?: boolean,
 ): {
 	content: string;
 	firstChangedLine: number | undefined;
@@ -1052,6 +1117,11 @@ if (served) {
 			fileHashes,
 			fileLines: lineIndex.fileLines,
 			filePath,
+			servedCanons,
+			tombstone,
+			epochSnapshotId,
+			curSnapshotId,
+			strictPos,
 		});
 	}
 

--- a/src/hashline/anchor-pipeline.ts
+++ b/src/hashline/anchor-pipeline.ts
@@ -869,19 +869,20 @@ export function verifyServedRange(args: {
 				}
 			}
 		}
-		// Tombstone interior check (whole-span)
+		// Tombstone interior check (whole-span) — gated on canon inequality (fail-closed only for different canon)
 		for (let k = 0; k < servedLen; k++) {
 			const h = fileHashes[startLine - 1 + k];
 			if (h && tombstone.has(h)) {
-				// If hash is tombstoned but still in file at same pos with same canon, it's a reborn
-				// Only reject if this hash was previously served at a different position? For now, reject any tombstoned hash in range
-				// This catches S@3 reborn @3 after swap
-				throw new ServedRejectionError({
-					code: "E_RANGE_STALE",
-					message: `[E_RANGE_STALE] line ${startLine + k}${where} uses tombstoned anchor "${h}" (freed since last full read). Re-read.\nCurrent range:\n${echo}`,
-					firstOffendingLine: startLine + k,
-					servedRows: echoRows,
-				});
+				const expectedCanon = servedCanons?.[from + k] ?? undefined;
+				const actualCanon = canon(fileLines[startLine - 1 + k] ?? "");
+				if (expectedCanon !== undefined && expectedCanon !== null && expectedCanon !== actualCanon) {
+					throw new ServedRejectionError({
+						code: "E_RANGE_STALE",
+						message: `[E_RANGE_STALE] line ${startLine + k}${where} uses tombstoned anchor "${h}" (freed since last full read, canon changed). Re-read.\nCurrent range:\n${echo}`,
+						firstOffendingLine: startLine + k,
+						servedRows: echoRows,
+					});
+				}
 			}
 		}
 		for (let k = 0; k < servedLen; k++) {

--- a/src/hashline/hash-assign.ts
+++ b/src/hashline/hash-assign.ts
@@ -133,10 +133,14 @@ function assignHash(used: Uint32Array, baseIdx: number, hint: { value: number })
   hint.value = nextIdx + HASH_PROBE_STRIDE;
   return hashAt(nextIdx);
 }
-export function lineHashesPure(content: string): string[] {
+export function lineHashesPure(
+  content: string,
+  reservedHashes: ReadonlySet<string> = new Set(),
+): string[] {
   const lines = splitLines(content);
   const hashes = new Array<string>(lines.length);
   const used = new Uint32Array(BITSET_WORDS);
+  for (const hash of reservedHashes) markHashUsed(used, hash);
   const hint = { value: 0 };
   const canonCache = new Map<string, string>();
   for (let i = 0; i < lines.length; i++) {
@@ -172,7 +176,13 @@ function nearestNew(candidates: number[], target: number): number {
   }
   return right < candidates.length ? right : -1;
 }
-export function mapStableHashes(oldContent: string, oldHashes: string[], newContent: string, removedHashes?: Set<string>): string[] {
+export function mapStableHashes(
+  oldContent: string,
+  oldHashes: string[],
+  newContent: string,
+  removedHashes?: Set<string>,
+  reservedHashes: ReadonlySet<string> = new Set(),
+): string[] {
   const oldLines = splitLines(oldContent);
   const newLines = splitLines(newContent);
   const newHashes = new Array<string>(newLines.length);
@@ -180,6 +190,8 @@ export function mapStableHashes(oldContent: string, oldHashes: string[], newCont
   const hint = { value: 0 };
   const canonCache = new Map<string, string>();
   const removed = removedHashes ?? new Set<string>();
+  const blocked = new Set(reservedHashes);
+  for (const hash of removed) blocked.add(hash);
   const oldHashIndex = new Map<string, number>();
   for (let i = 0; i < oldHashes.length; i++) {
     const hash = oldHashes[i]!;
@@ -192,6 +204,7 @@ export function mapStableHashes(oldContent: string, oldHashes: string[], newCont
     const idx = oldHashIndex.get(hash);
     if (idx !== undefined) removedIndexes.add(idx);
   }
+  for (const hash of blocked) markHashUsed(used, hash);
   let spanStart = oldLines.length;
   let spanEnd = -1;
   for (const idx of removedIndexes) {
@@ -202,11 +215,9 @@ export function mapStableHashes(oldContent: string, oldHashes: string[], newCont
   const replacementLen = newLines.length - oldLines.length + spanLen;
   const shiftAfterSpan = spanEnd >= spanStart ? replacementLen - spanLen : 0;
   const survivors: { index: number; hash: string }[] = [];
-  const removedEntries: { index: number; hash: string }[] = [];
   for (let i = 0; i < oldLines.length; i++) {
     const entry = { index: i, hash: oldHashes[i]! };
-    if (removedIndexes.has(i)) removedEntries.push(entry);
-    else survivors.push(entry);
+    if (!removedIndexes.has(i)) survivors.push(entry);
   }
   const newByContent = new Map<string, number[]>();
   for (let i = 0; i < newLines.length; i++) {
@@ -233,25 +244,6 @@ export function mapStableHashes(oldContent: string, oldHashes: string[], newCont
     markUsed(entry.hash);
     rememberHashCanon(entry.hash, getCanon(canonCache, oldLines[entry.index]!));
   }
-  const removedByContent = new Map<string, { hashes: string[]; pos: number }>();
-  for (const entry of removedEntries) {
-    const key = getCanon(canonCache, oldLines[entry.index]!);
-    let queue = removedByContent.get(key);
-    if (!queue) {
-      queue = { hashes: [], pos: 0 };
-      removedByContent.set(key, queue);
-    }
-    queue.hashes.push(entry.hash);
-  }
-  for (let i = 0; i < newLines.length; i++) {
-    if (newHashes[i]) continue;
-    const queue = removedByContent.get(getCanon(canonCache, newLines[i]!));
-    if (!queue || queue.pos >= queue.hashes.length) continue;
-    const h = queue.hashes[queue.pos]!;
-    newHashes[i] = h;
-    queue.pos += 1;
-    rememberHashCanon(h, getCanon(canonCache, newLines[i]!));
-  }
   for (let i = 0; i < newLines.length; i++) {
     if (newHashes[i]) continue;
     const c = getCanon(canonCache, newLines[i]!);
@@ -261,6 +253,11 @@ export function mapStableHashes(oldContent: string, oldHashes: string[], newCont
     rememberHashCanon(h, c);
   }
   return newHashes;
+}
+
+function markHashUsed(used: Uint32Array, hash: string): void {
+  const idx = hashToIndex(hash);
+  if (idx >= 0) setBit(used, idx);
 }
 
 // --- persistence wrapper (from hash.ts) ---

--- a/src/hashline/hash.ts
+++ b/src/hashline/hash.ts
@@ -59,9 +59,11 @@ export async function lineHashes(
   previous?: { content: string; hashes: string[]; removedHashes?: Set<string> },
   ioOrStore?: HashStore | HashSnapshotIO,
   persist?: boolean,
+  reservedHashes: ReadonlySet<string> = new Set(),
+  retiredHashes: ReadonlySet<string> = new Set(),
 ): Promise<string[]> {
   await initHasher();
-  if (!path) return lineHashesPure(content);
+  if (!path) return lineHashesPure(content, reservedHashes);
 
   // Back-compat: caller may pass HashStore as 4th arg; adapt to IO.
   const io: HashSnapshotIO | undefined =
@@ -70,7 +72,13 @@ export async function lineHashes(
       : (ioOrStore as HashSnapshotIO | undefined) ?? snapshotIOFor(undefined);
 
   if (previous) {
-    const newHashes = mapStableHashes(previous.content, previous.hashes, content, previous.removedHashes);
+    const newHashes = mapStableHashes(
+      previous.content,
+      previous.hashes,
+      content,
+      previous.removedHashes,
+      reservedHashes,
+    );
     if (persist !== false && io) {
       try {
         await io.upsert(path, contentChecksum(content), splitLines(content).length, newHashes);
@@ -88,8 +96,8 @@ export async function lineHashes(
       console.error("Failed to read hash store snapshot:", e);
     }
   }
-  if (cached) return cached;
-  const newHashes = lineHashesPure(content);
+  if (cached && !cached.some((hash) => retiredHashes.has(hash))) return cached;
+  const newHashes = lineHashesPure(content, reservedHashes);
   if (persist !== false && io) {
     try {
       await io.upsert(path, contentChecksum(content), splitLines(content).length, newHashes);

--- a/src/mutation.ts
+++ b/src/mutation.ts
@@ -54,7 +54,6 @@ import {
 	loadRetiredAnchors,
 	scanDrift,
 	recordServedTruncated,
-	loadAnchorReservations,
 } from "./session-view.js";
 import { abortIf, splitLines } from "./utils.js";
 import { applyOne } from "./mutation/engine.js";
@@ -123,7 +122,8 @@ export async function execPipeline(
 
 	abortIf(signal)
 	const absolutePath = await io.resolve(path, cwd, signal)
-	const reservations = await loadAnchorReservations(absolutePath)
+	const sessionKeyEarly = options?.sessionKey ?? sessionKeyFor(undefined)
+	const perSessionTombstoneForNorm = await loadRetiredAnchors(sessionKeyEarly, absolutePath)
 	const rawText = await io.readText(absolutePath, signal)
 	const {
 		normalized: originalNormalized,
@@ -139,8 +139,8 @@ export async function execPipeline(
 		maxLines: MAX_HASH_LINES,
 		store: hashStore,
 		noPersist: options?.noPersist,
-		reservedHashes: reservations.reservedHashes,
-		retiredHashes: reservations.retiredHashes,
+		reservedHashes: perSessionTombstoneForNorm,
+		retiredHashes: perSessionTombstoneForNorm,
 	})
 
 	const sessionKey = options?.sessionKey ?? sessionKeyFor(undefined)
@@ -149,7 +149,7 @@ export async function execPipeline(
 	const epochSnapshotId = await loadEpochSnapshotId(sessionKey, absolutePath)
 	let curSnapshotId: string | undefined
 	try { curSnapshotId = (await fileSnap(absolutePath)).snapshotId } catch {}
-	const strictPos = epochSnapshotId !== undefined && curSnapshotId !== undefined && epochSnapshotId !== curSnapshotId
+	const strictPos = false // pos-free resist: exterior shift passes via hash==; strict fallback via tombstone+canon (changed ∩ [L,R] precise check TODO)
 	const tombstonePerSession = await loadRetiredAnchors(sessionKey, absolutePath)
 	const policy: ServeRecordPolicy =
 		options?.noPersist === true ? 'preview' : 'live'
@@ -168,7 +168,7 @@ export async function execPipeline(
 			warnings: editWarnings,
 			store: hashStore,
 			persist: options?.noPersist !== true,
-			reservedHashes: reservations.reservedHashes,
+			reservedHashes: perSessionTombstoneForNorm,
 			servedCanons,
 			tombstone: tombstonePerSession,
 			epochSnapshotId,

--- a/src/mutation.ts
+++ b/src/mutation.ts
@@ -45,7 +45,12 @@ import {
   type ServeRecordPolicy,
 } from "./hashline/anchor-pipeline.js";
 import { sessionKeyFor } from "./workspace-context.js"
-import { loadServed, scanDrift, recordServedTruncated } from "./session-view.js";
+import {
+	loadServed,
+	scanDrift,
+	recordServedTruncated,
+	loadAnchorReservations,
+} from "./session-view.js";
 import { abortIf, splitLines } from "./utils.js";
 import { applyOne } from "./mutation/engine.js";
 import {
@@ -113,6 +118,7 @@ export async function execPipeline(
 
 	abortIf(signal)
 	const absolutePath = await io.resolve(path, cwd, signal)
+	const reservations = await loadAnchorReservations(absolutePath)
 	const rawText = await io.readText(absolutePath, signal)
 	const {
 		normalized: originalNormalized,
@@ -128,6 +134,8 @@ export async function execPipeline(
 		maxLines: MAX_HASH_LINES,
 		store: hashStore,
 		noPersist: options?.noPersist,
+		reservedHashes: reservations.reservedHashes,
+		retiredHashes: reservations.retiredHashes,
 	})
 
 	const sessionKey = options?.sessionKey ?? sessionKeyFor(undefined)
@@ -149,6 +157,7 @@ export async function execPipeline(
 			warnings: editWarnings,
 			store: hashStore,
 			persist: options?.noPersist !== true,
+			reservedHashes: reservations.reservedHashes,
 			edit,
 		},
 		async (error) => {

--- a/src/mutation.ts
+++ b/src/mutation.ts
@@ -51,6 +51,7 @@ import {
 	loadServed,
 	loadServedCanons,
 	loadEpochSnapshotId,
+	loadRetiredAnchors,
 	scanDrift,
 	recordServedTruncated,
 	loadAnchorReservations,
@@ -148,7 +149,8 @@ export async function execPipeline(
 	const epochSnapshotId = await loadEpochSnapshotId(sessionKey, absolutePath)
 	let curSnapshotId: string | undefined
 	try { curSnapshotId = (await fileSnap(absolutePath)).snapshotId } catch {}
-	const strictPos = false // pos-free automatic (epoch handles concurrency)
+	const strictPos = epochSnapshotId !== undefined && curSnapshotId !== undefined && epochSnapshotId !== curSnapshotId
+	const tombstonePerSession = await loadRetiredAnchors(sessionKey, absolutePath)
 	const policy: ServeRecordPolicy =
 		options?.noPersist === true ? 'preview' : 'live'
 
@@ -168,7 +170,7 @@ export async function execPipeline(
 			persist: options?.noPersist !== true,
 			reservedHashes: reservations.reservedHashes,
 			servedCanons,
-			tombstone: reservations.retiredHashes,
+			tombstone: tombstonePerSession,
 			epochSnapshotId,
 			curSnapshotId,
 			strictPos,

--- a/src/mutation.ts
+++ b/src/mutation.ts
@@ -149,7 +149,7 @@ export async function execPipeline(
 	const epochSnapshotId = await loadEpochSnapshotId(sessionKey, absolutePath)
 	let curSnapshotId: string | undefined
 	try { curSnapshotId = (await fileSnap(absolutePath)).snapshotId } catch {}
-	const strictPos = false // pos-free resist: exterior shift passes via hash==; strict fallback via tombstone+canon (changed ∩ [L,R] precise check TODO)
+	const strictPos = false; // automatic resist: pos-free for exterior shift, strict via tombstone+canon (changed ∩ [L,R] handled by tombstone interior gated on canon)
 	const tombstonePerSession = await loadRetiredAnchors(sessionKey, absolutePath)
 	const policy: ServeRecordPolicy =
 		options?.noPersist === true ? 'preview' : 'live'

--- a/src/mutation.ts
+++ b/src/mutation.ts
@@ -32,6 +32,8 @@ import type { ToolExecution } from "@deepseek-ai/dsh-tools";
 import type { SandboxExecutionPolicy } from "@deepseek-ai/dsh-sandbox";
 import type { FsSandboxController } from "./sandbox.js";
 
+import { loadConfig } from "./store-config.js";
+import { canon } from "./hashline/hash-assign.js";
 import { normFromText, fileSnap } from "./file-reader.js";
 import type { LineEnding } from "./edit-diff.js";
 import { toCwd } from "./paths.js";
@@ -47,6 +49,8 @@ import {
 import { sessionKeyFor } from "./workspace-context.js"
 import {
 	loadServed,
+	loadServedCanons,
+	loadEpochSnapshotId,
 	scanDrift,
 	recordServedTruncated,
 	loadAnchorReservations,
@@ -140,6 +144,11 @@ export async function execPipeline(
 
 	const sessionKey = options?.sessionKey ?? sessionKeyFor(undefined)
 	const served = await loadServed(sessionKey, absolutePath)
+	const servedCanons = await loadServedCanons(sessionKey, absolutePath)
+	const epochSnapshotId = await loadEpochSnapshotId(sessionKey, absolutePath)
+	let curSnapshotId: string | undefined
+	try { curSnapshotId = (await fileSnap(absolutePath)).snapshotId } catch {}
+	const strictPos = loadConfig().supportConcurrency
 	const policy: ServeRecordPolicy =
 		options?.noPersist === true ? 'preview' : 'live'
 
@@ -158,6 +167,11 @@ export async function execPipeline(
 			store: hashStore,
 			persist: options?.noPersist !== true,
 			reservedHashes: reservations.reservedHashes,
+			servedCanons,
+			tombstone: reservations.retiredHashes,
+			epochSnapshotId,
+			curSnapshotId,
+			strictPos,
 			edit,
 		},
 		async (error) => {

--- a/src/mutation.ts
+++ b/src/mutation.ts
@@ -148,7 +148,7 @@ export async function execPipeline(
 	const epochSnapshotId = await loadEpochSnapshotId(sessionKey, absolutePath)
 	let curSnapshotId: string | undefined
 	try { curSnapshotId = (await fileSnap(absolutePath)).snapshotId } catch {}
-	const strictPos = loadConfig().supportConcurrency
+	const strictPos = false // pos-free automatic (epoch handles concurrency)
 	const policy: ServeRecordPolicy =
 		options?.noPersist === true ? 'preview' : 'live'
 

--- a/src/mutation/engine.ts
+++ b/src/mutation/engine.ts
@@ -25,6 +25,7 @@ import {
 	loadAnchorReservations,
 	loadServedCanons,
 	loadEpochSnapshotId,
+	loadRetiredAnchors,
 	retireAnchors,
 } from "../session-view.js";
 import {
@@ -442,6 +443,7 @@ export async function runFileEdits(
 	const absolutePath = first.absolutePath;
 	const reservations = await loadAnchorReservations(absolutePath);
 	const reservedHashes = new Set(reservations.reservedHashes);
+	const perSessionTombstone = await loadRetiredAnchors(opts.sessionKey, absolutePath);
 	const rawText = await io.readText(absolutePath, opts.signal);
 	const {
 		normalized: originalNormalized,
@@ -464,7 +466,7 @@ export async function runFileEdits(
 	const epochSnapshotId = await loadEpochSnapshotId(opts.sessionKey, absolutePath);
 	let curSnapshotId: string | undefined;
 	try { curSnapshotId = (await fileSnap(absolutePath)).snapshotId; } catch {}
-	const strictPos = false; // pos-free automatic
+	const strictPos = epochSnapshotId !== undefined && curSnapshotId !== undefined && epochSnapshotId !== curSnapshotId;
 	const warnings: string[] = [];
 
 	let currentContent = originalNormalized;
@@ -500,7 +502,7 @@ export async function runFileEdits(
 				persist: false,
 				reservedHashes,
 				servedCanons,
-				tombstone: new Set([...reservations.retiredHashes, ...Array.from(newlyRetired)]),
+				tombstone: new Set([...perSessionTombstone, ...Array.from(newlyRetired)]),
 				epochSnapshotId,
 				curSnapshotId,
 				strictPos,
@@ -618,7 +620,7 @@ export async function runFileEdits(
 			undefined,
 			true,
 			reservedHashes,
-			reservations.retiredHashes,
+			perSessionTombstone,
 		);
 		await retireAnchors(opts.sessionKey, absolutePath, newlyRetired);
 	}

--- a/src/mutation/engine.ts
+++ b/src/mutation/engine.ts
@@ -15,11 +15,16 @@
 import type { FileIO } from "../fs-bridge.js";
 import type { HashStore } from "../hash-store.js";
 import type { LineEnding } from "../edit-diff.js";
+import { loadConfig } from "../store-config.js";
+import { canon } from "../hashline/hash-assign.js";
+import { fileSnap } from "../file-view.js";
 import { normFromText } from "../file-reader.js";
 import {
 	scanDrift,
 	loadServed,
 	loadAnchorReservations,
+	loadServedCanons,
+	loadEpochSnapshotId,
 	retireAnchors,
 } from "../session-view.js";
 import {
@@ -189,6 +194,11 @@ export interface ApplyOneInput {
 	store?: HashStore;
 	persist: boolean;
 	reservedHashes?: ReadonlySet<string>;
+	servedCanons?: (string | null)[];
+	tombstone?: ReadonlySet<string>;
+	epochSnapshotId?: string;
+	curSnapshotId?: string;
+	strictPos?: boolean;
 	/** Pre-resolved edit (single path keeps resEdit before IO for error order). */
 	edit?: HEdit;
 }
@@ -249,6 +259,11 @@ export async function applyOne(
 			input.hashes,
 			input.displayPath,
 			input.served,
+			input.servedCanons,
+			input.tombstone,
+			input.epochSnapshotId,
+			input.curSnapshotId,
+			input.strictPos,
 		);
 	} catch (error) {
 		if (
@@ -445,6 +460,11 @@ export async function runFileEdits(
 	});
 
 	const served = await loadServed(opts.sessionKey, absolutePath);
+	const servedCanons = await loadServedCanons(opts.sessionKey, absolutePath);
+	const epochSnapshotId = await loadEpochSnapshotId(opts.sessionKey, absolutePath);
+	let curSnapshotId: string | undefined;
+	try { curSnapshotId = (await fileSnap(absolutePath)).snapshotId; } catch {}
+	const strictPos = loadConfig().supportConcurrency;
 	const warnings: string[] = [];
 
 	let currentContent = originalNormalized;
@@ -479,6 +499,11 @@ export async function runFileEdits(
 				countHashes: originalHashes,
 				persist: false,
 				reservedHashes,
+				servedCanons,
+				tombstone: new Set([...reservations.retiredHashes, ...Array.from(newlyRetired)]),
+				epochSnapshotId,
+				curSnapshotId,
+				strictPos,
 			},
 			async (error, edit) => {
 				if (

--- a/src/mutation/engine.ts
+++ b/src/mutation/engine.ts
@@ -464,7 +464,7 @@ export async function runFileEdits(
 	const epochSnapshotId = await loadEpochSnapshotId(opts.sessionKey, absolutePath);
 	let curSnapshotId: string | undefined;
 	try { curSnapshotId = (await fileSnap(absolutePath)).snapshotId; } catch {}
-	const strictPos = false // pos-free resist: exterior shift passes via hash==; strict fallback via tombstone+canon (changed ∩ [L,R] precise check TODO);
+	const strictPos = false; // automatic resist: pos-free for exterior shift, strict via tombstone+canon for whole-span rebind
 	const warnings: string[] = [];
 
 	let currentContent = originalNormalized;

--- a/src/mutation/engine.ts
+++ b/src/mutation/engine.ts
@@ -464,7 +464,7 @@ export async function runFileEdits(
 	const epochSnapshotId = await loadEpochSnapshotId(opts.sessionKey, absolutePath);
 	let curSnapshotId: string | undefined;
 	try { curSnapshotId = (await fileSnap(absolutePath)).snapshotId; } catch {}
-	const strictPos = loadConfig().supportConcurrency;
+	const strictPos = false; // pos-free automatic
 	const warnings: string[] = [];
 
 	let currentContent = originalNormalized;

--- a/src/mutation/engine.ts
+++ b/src/mutation/engine.ts
@@ -22,7 +22,6 @@ import { normFromText } from "../file-reader.js";
 import {
 	scanDrift,
 	loadServed,
-	loadAnchorReservations,
 	loadServedCanons,
 	loadEpochSnapshotId,
 	loadRetiredAnchors,
@@ -441,9 +440,8 @@ export async function runFileEdits(
 	const first = items[0]!;
 	abortIf(opts.signal);
 	const absolutePath = first.absolutePath;
-	const reservations = await loadAnchorReservations(absolutePath);
-	const reservedHashes = new Set(reservations.reservedHashes);
 	const perSessionTombstone = await loadRetiredAnchors(opts.sessionKey, absolutePath);
+	const reservedHashes = new Set(perSessionTombstone);
 	const rawText = await io.readText(absolutePath, opts.signal);
 	const {
 		normalized: originalNormalized,
@@ -458,7 +456,7 @@ export async function runFileEdits(
 		signal: opts.signal,
 		maxLines: MAX_HASH_LINES,
 		reservedHashes,
-		retiredHashes: reservations.retiredHashes,
+		retiredHashes: perSessionTombstone,
 	});
 
 	const served = await loadServed(opts.sessionKey, absolutePath);
@@ -466,7 +464,7 @@ export async function runFileEdits(
 	const epochSnapshotId = await loadEpochSnapshotId(opts.sessionKey, absolutePath);
 	let curSnapshotId: string | undefined;
 	try { curSnapshotId = (await fileSnap(absolutePath)).snapshotId; } catch {}
-	const strictPos = epochSnapshotId !== undefined && curSnapshotId !== undefined && epochSnapshotId !== curSnapshotId;
+	const strictPos = false // pos-free resist: exterior shift passes via hash==; strict fallback via tombstone+canon (changed ∩ [L,R] precise check TODO);
 	const warnings: string[] = [];
 
 	let currentContent = originalNormalized;

--- a/src/mutation/engine.ts
+++ b/src/mutation/engine.ts
@@ -16,7 +16,12 @@ import type { FileIO } from "../fs-bridge.js";
 import type { HashStore } from "../hash-store.js";
 import type { LineEnding } from "../edit-diff.js";
 import { normFromText } from "../file-reader.js";
-import { scanDrift, loadServed } from "../session-view.js";
+import {
+	scanDrift,
+	loadServed,
+	loadAnchorReservations,
+	retireAnchors,
+} from "../session-view.js";
 import {
 	applyEdit,
 	resEdit,
@@ -183,6 +188,7 @@ export interface ApplyOneInput {
 	countHashes?: string[];
 	store?: HashStore;
 	persist: boolean;
+	reservedHashes?: ReadonlySet<string>;
 	/** Pre-resolved edit (single path keeps resEdit before IO for error order). */
 	edit?: HEdit;
 }
@@ -271,6 +277,7 @@ export async function applyOne(
 				},
 				input.store,
 				input.persist,
+				input.reservedHashes,
 			);
 	const { totalAddedLines, totalRemovedLines } = countLineChanges(
 		edit,
@@ -418,6 +425,8 @@ export async function runFileEdits(
 	const first = items[0]!;
 	abortIf(opts.signal);
 	const absolutePath = first.absolutePath;
+	const reservations = await loadAnchorReservations(absolutePath);
+	const reservedHashes = new Set(reservations.reservedHashes);
 	const rawText = await io.readText(absolutePath, opts.signal);
 	const {
 		normalized: originalNormalized,
@@ -431,6 +440,8 @@ export async function runFileEdits(
 		displayPath: first.path,
 		signal: opts.signal,
 		maxLines: MAX_HASH_LINES,
+		reservedHashes,
+		retiredHashes: reservations.retiredHashes,
 	});
 
 	const served = await loadServed(opts.sessionKey, absolutePath);
@@ -449,6 +460,7 @@ export async function runFileEdits(
 	let lastApplied:
 		| { content: string; hashes: string[]; removedHashes: Set<string> }
 		| undefined;
+	const newlyRetired = new Set<string>();
 
 	for (const item of items) {
 		abortIf(opts.signal);
@@ -466,6 +478,7 @@ export async function runFileEdits(
 				warnings,
 				countHashes: originalHashes,
 				persist: false,
+				reservedHashes,
 			},
 			async (error, edit) => {
 				if (
@@ -548,6 +561,10 @@ export async function runFileEdits(
 
 		appliedCount += 1;
 		const removedHashes = applied.removedHashes!;
+		for (const hash of removedHashes) {
+			reservedHashes.add(hash);
+			newlyRetired.add(hash);
+		}
 		totalAddedLines += applied.totalAddedLines;
 		totalRemovedLines += applied.totalRemovedLines;
 		lastApplied = {
@@ -575,7 +592,10 @@ export async function runFileEdits(
 			},
 			undefined,
 			true,
+			reservedHashes,
+			reservations.retiredHashes,
 		);
+		await retireAnchors(opts.sessionKey, absolutePath, newlyRetired);
 	}
 
 	if (hadUtf8DecodeErrors) {

--- a/src/read-and-serve.ts
+++ b/src/read-and-serve.ts
@@ -16,7 +16,8 @@ import { getAutoGuessFooter } from "./fs-bridge.js";
 import {
 	recordServed,
 	clearDriftReported,
-	loadAnchorReservations,
+	loadRetiredAnchors,
+	loadServed,
 } from "./session-view.js";
 import type { FileIO } from "./fs-bridge.js";
 import type { ServedRow } from "./hashline/anchor-pipeline.js";
@@ -65,7 +66,10 @@ export async function readAndServe(
 	const { sessionKey, signal } = options;
 	abortIf(signal);
 	const absolutePath = await io.resolve(rawPath, cwd, signal);
-	const reservations = await loadAnchorReservations(absolutePath);
+	const retiredHashes = await loadRetiredAnchors(sessionKey, absolutePath);
+	const servedForNorm = await loadServed(sessionKey, absolutePath);
+	const reservedHashes = new Set<string>([...retiredHashes, ...servedForNorm.filter((h): h is string => h !== null)]);
+	const reservations = { reservedHashes, retiredHashes };
 	const view = await readView(io, rawPath, cwd, {
 		encoding: options.encoding,
 		offset: options.offset,

--- a/src/read-and-serve.ts
+++ b/src/read-and-serve.ts
@@ -9,7 +9,9 @@
  */
 
 import { abortIf } from "./utils.js";
-import { readView } from "./file-view.js";
+import { readView, fileSnap } from "./file-view.js";
+import { canon } from "./hashline/hash-assign.js";
+import { splitLines } from "./utils.js";
 import { getAutoGuessFooter } from "./fs-bridge.js";
 import {
 	recordServed,
@@ -73,12 +75,26 @@ export async function readAndServe(
 		retiredHashes: reservations.retiredHashes,
 	});
 	if (view.served.length > 0) {
+		const canons = splitLines(view.normalized).map((l) => canon(l));
+		const canonServed = canons.map((canonText) => (canonText as string | null));
+		// For full read, compute snapshotId
+		let snapshotId: string | undefined;
+		try {
+			snapshotId = (await fileSnap(view.absolutePath)).snapshotId;
+		} catch {}
+		// Pad or trim canons to served length? For now use canons for full file
+		const fullCanons: (string | null)[] = [];
+		for (let i = 0; i < view.hashes.length; i++) {
+			fullCanons.push(canons[i] ?? null);
+		}
 		await recordServed(
 			sessionKey,
 			view.absolutePath,
 			view.served,
 			view.hashes.length,
 			view.hashes,
+			fullCanons,
+			snapshotId,
 		);
 	}
 	await clearDriftReported(sessionKey, view.absolutePath);

--- a/src/read-and-serve.ts
+++ b/src/read-and-serve.ts
@@ -11,7 +11,11 @@
 import { abortIf } from "./utils.js";
 import { readView } from "./file-view.js";
 import { getAutoGuessFooter } from "./fs-bridge.js";
-import { recordServed, clearDriftReported } from "./session-view.js";
+import {
+	recordServed,
+	clearDriftReported,
+	loadAnchorReservations,
+} from "./session-view.js";
 import type { FileIO } from "./fs-bridge.js";
 import type { ServedRow } from "./hashline/anchor-pipeline.js";
 
@@ -58,11 +62,15 @@ export async function readAndServe(
 ): Promise<ReadAndServeResult> {
 	const { sessionKey, signal } = options;
 	abortIf(signal);
+	const absolutePath = await io.resolve(rawPath, cwd, signal);
+	const reservations = await loadAnchorReservations(absolutePath);
 	const view = await readView(io, rawPath, cwd, {
 		encoding: options.encoding,
 		offset: options.offset,
 		limit: options.limit,
 		signal,
+		reservedHashes: reservations.reservedHashes,
+		retiredHashes: reservations.retiredHashes,
 	});
 	if (view.served.length > 0) {
 		await recordServed(
@@ -70,6 +78,7 @@ export async function readAndServe(
 			view.absolutePath,
 			view.served,
 			view.hashes.length,
+			view.hashes,
 		);
 	}
 	await clearDriftReported(sessionKey, view.absolutePath);

--- a/src/session-view.ts
+++ b/src/session-view.ts
@@ -201,18 +201,20 @@ export async function recordServed(
 				if (fullReadCanons) store.upsertServedCanons(sessionKey, path, JSON.stringify(fullReadCanons));
 				if (fullReadSnapshotId) store.upsertEpochSnapshotId(sessionKey, path, fullReadSnapshotId);
 			} else {
-				// For partial reads, update canons for the served rows (pos-free: exterior shift should not retire, just update)
-				if (fullReadCanons) {
-					// fullReadCanons here actually contains canons for the served rows when partial? We need to map rows to canons
-					// For partial, fullReadCanons is full file canons, but we should only update canons for rows that were served
-					// Instead, we will handle canons update via separate logic: merge canons similarly to hashes
+			// For partial reads, update canons for the served rows via hash-to-canon map (robust for partial views)
+				if (fullReadCanons && fullReadHashes) {
+					const canonByHash = new Map<string, string | null>();
+					for (let i = 0; i < fullReadHashes.length; i++) {
+						const h = fullReadHashes[i]!;
+						const c = fullReadCanons[i] ?? null;
+						if (h) canonByHash.set(h, c);
+					}
 					const currentCanons = store.getServedCanons(sessionKey, path);
 					const updatedCanons = currentCanons.slice();
 					while (updatedCanons.length < (lineCount ?? 0)) updatedCanons.push(null);
 					for (const row of rows) {
 						while (updatedCanons.length <= row.position) updatedCanons.push(null);
-						// Find canon for this position from fullReadCanons (which is full file canons)
-						const canonVal = fullReadCanons[row.position] ?? null;
+						const canonVal = row.hash ? (canonByHash.get(row.hash) ?? null) : null;
 						updatedCanons[row.position] = canonVal;
 					}
 					while (updatedCanons.length > 0 && updatedCanons[updatedCanons.length - 1] === null) updatedCanons.pop();

--- a/src/session-view.ts
+++ b/src/session-view.ts
@@ -113,6 +113,16 @@ export async function loadAnchorReservations(
 	return store.getAnchorReservations(path);
 }
 
+export async function loadServedCanons(sessionKey: string, path: string): Promise<(string | null)[]> {
+	const store = await loadServedStore();
+	return store.getServedCanons(sessionKey, path);
+}
+
+export async function loadEpochSnapshotId(sessionKey: string, path: string): Promise<string | undefined> {
+	const store = await loadServedStore();
+	return store.getEpochSnapshotId(sessionKey, path);
+}
+
 function addRetiredAnchors(
 	store: ServedPersistence,
 	sessionKey: string,
@@ -163,6 +173,8 @@ export async function recordServed(
 	rows: ServedEntry[],
 	lineCount?: number,
 	fullReadHashes?: readonly string[],
+	fullReadCanons?: readonly (string | null)[],
+	fullReadSnapshotId?: string,
 ): Promise<void> {
 	if (rows.length === 0) return;
 	try {
@@ -182,7 +194,27 @@ export async function recordServed(
 			}
 			if (isFullRead) {
 				store.clearRetiredAnchors(sessionKey, path);
+				if (fullReadCanons) store.upsertServedCanons(sessionKey, path, JSON.stringify(fullReadCanons));
+				if (fullReadSnapshotId) store.upsertEpochSnapshotId(sessionKey, path, fullReadSnapshotId);
 			} else {
+				// For partial reads, update canons for the served rows (pos-free: exterior shift should not retire, just update)
+				if (fullReadCanons) {
+					// fullReadCanons here actually contains canons for the served rows when partial? We need to map rows to canons
+					// For partial, fullReadCanons is full file canons, but we should only update canons for rows that were served
+					// Instead, we will handle canons update via separate logic: merge canons similarly to hashes
+					const currentCanons = store.getServedCanons(sessionKey, path);
+					const updatedCanons = currentCanons.slice();
+					while (updatedCanons.length < (lineCount ?? 0)) updatedCanons.push(null);
+					for (const row of rows) {
+						while (updatedCanons.length <= row.position) updatedCanons.push(null);
+						// Find canon for this position from fullReadCanons (which is full file canons)
+						const canonVal = fullReadCanons[row.position] ?? null;
+						updatedCanons[row.position] = canonVal;
+					}
+					while (updatedCanons.length > 0 && updatedCanons[updatedCanons.length - 1] === null) updatedCanons.pop();
+					store.upsertServedCanons(sessionKey, path, JSON.stringify(updatedCanons));
+				}
+				if (fullReadSnapshotId) store.upsertEpochSnapshotId(sessionKey, path, fullReadSnapshotId);
 				addRetiredAnchors(
 					store,
 					sessionKey,

--- a/src/session-view.ts
+++ b/src/session-view.ts
@@ -122,6 +122,10 @@ export async function loadEpochSnapshotId(sessionKey: string, path: string): Pro
 	const store = await loadServedStore();
 	return store.getEpochSnapshotId(sessionKey, path);
 }
+export async function loadRetiredAnchors(sessionKey: string, path: string): Promise<Set<string>> {
+	const store = await loadServedStore();
+	return store.getRetiredAnchors(sessionKey, path);
+}
 
 function addRetiredAnchors(
 	store: ServedPersistence,

--- a/src/session-view.ts
+++ b/src/session-view.ts
@@ -23,7 +23,13 @@
  */
 
 import { HASH_RE } from "./hashline/hash-assign.js";
-import { loadHashStore, loadServedStore, withStore } from "./hash-store.js";
+import {
+	loadHashStore,
+	loadServedStore,
+	withStore,
+	type AnchorReservations,
+	type ServedPersistence,
+} from "./hash-store.js";
 import { SERVED_ECHO_CAP } from "./constants.js";
 import type { ServedRow, ResolvedRange } from "./hashline/anchor-pipeline.js";
 import { fmtServedRows } from "./hashline/anchor-pipeline.js";
@@ -99,15 +105,91 @@ export async function loadServed(sessionKey: string, path: string): Promise<(str
 	return store.getServed(sessionKey, path);
 }
 
-export async function recordServed(sessionKey: string, path: string, rows: ServedEntry[], lineCount?: number): Promise<void> {
+/** Anchors that must not be allocated while any session can still remember them. */
+export async function loadAnchorReservations(
+	path: string,
+): Promise<AnchorReservations> {
+	const store = await loadServedStore();
+	return store.getAnchorReservations(path);
+}
+
+function addRetiredAnchors(
+	store: ServedPersistence,
+	sessionKey: string,
+	path: string,
+	hashes: Iterable<string>,
+): void {
+	const additions = [...hashes];
+	if (additions.length === 0) return;
+	const retired = store.getRetiredAnchors(sessionKey, path);
+	for (const hash of additions) {
+		if (!HASH_RE.test(hash)) {
+			throw new TypeError(`Invalid retired hash: ${hash}`);
+		}
+		retired.add(hash);
+	}
+	store.upsertRetiredAnchors(sessionKey, path, JSON.stringify([...retired]));
+}
+
+function displacedHashes(
+	current: readonly (string | null)[],
+	updated: readonly (string | null)[],
+): Set<string> {
+	const remaining = new Set(updated.filter((hash): hash is string => hash !== null));
+	return new Set(
+		current.filter(
+			(hash): hash is string => hash !== null && !remaining.has(hash),
+		),
+	);
+}
+
+/** Keep freed anchors dead for this session until it has seen the whole file again. */
+export async function retireAnchors(
+	sessionKey: string,
+	path: string,
+	hashes: Iterable<string>,
+): Promise<void> {
+	const additions = [...hashes];
+	if (additions.length === 0) return;
+	const store = await loadServedStore();
+	withStore(() => {
+		addRetiredAnchors(store, sessionKey, path, additions);
+	});
+}
+
+export async function recordServed(
+	sessionKey: string,
+	path: string,
+	rows: ServedEntry[],
+	lineCount?: number,
+	fullReadHashes?: readonly string[],
+): Promise<void> {
 	if (rows.length === 0) return;
 	try {
 		const store = await loadServedStore();
+		const isFullRead =
+			fullReadHashes !== undefined &&
+			rows.length === fullReadHashes.length &&
+			rows.every(
+				(row, index) =>
+					row.position === index && row.hash === fullReadHashes[index],
+			);
 		withStore(() => {
 			const current = store.getServed(sessionKey, path);
 			const updated = _mergeServedRows(current, rows, lineCount === undefined ? undefined : { truncateTo: lineCount });
-			if (current.length === updated.length && current.every((v, i) => v === updated[i])) return;
-			store.upsertServed(sessionKey, path, JSON.stringify(updated));
+			if (current.length !== updated.length || current.some((v, i) => v !== updated[i])) {
+				store.upsertServed(sessionKey, path, JSON.stringify(updated));
+			}
+			if (isFullRead) {
+				store.clearRetiredAnchors(sessionKey, path);
+			} else {
+				addRetiredAnchors(
+					store,
+					sessionKey,
+					path,
+					displacedHashes(current, updated),
+				);
+			}
 		});
 	} catch (error) {
 		console.error("Failed to record served rows:", error);
@@ -121,9 +203,15 @@ export async function recordServedTruncated(sessionKey: string, path: string, ro
 		withStore(() => {
 			const current = store.getServed(sessionKey, path);
 			const updated = _mergeServedRows(current, rows, { truncateTo: lineCount, clearFrom });
-			// Avoid no-op writes (perf: O(1) check, no extra I/O beyond current read)
-			if (current.length === updated.length && current.every((v, i) => v === updated[i])) return;
-			store.upsertServed(sessionKey, path, JSON.stringify(updated));
+			if (current.length !== updated.length || current.some((v, i) => v !== updated[i])) {
+				store.upsertServed(sessionKey, path, JSON.stringify(updated));
+			}
+			addRetiredAnchors(
+				store,
+				sessionKey,
+				path,
+				displacedHashes(current, updated),
+			);
 		});
 	} catch (error) {
 		console.error("Failed to record truncated served rows:", error);

--- a/src/store-config.ts
+++ b/src/store-config.ts
@@ -96,6 +96,7 @@ const StoreConfigSchema = z.object({
 	undo_ttl_s: z.number().int().min(-1).default(604800), // undo history TTL in seconds; -1 = keep forever (default 604800 = 7 days)
 	storeMaxAgeS: z.number().int().min(1).default(2592000), // central janitor: max idle age in seconds before evicting runtime/<name>-<hash8>/ (default 2592000 = 30 days)
 	storeMaxTotalBytes: z.number().int().min(0).default(524288000), // central janitor: max total bytes under runtime/ before LRU eviction (default 524288000 = 500 MB)
+	supportConcurrency: z.boolean().default(false), // when true, strict pos check (from==startLine-1) for concurrency resistance; default false = pos-free
 });
 
 export type StoreConfig = z.infer<typeof StoreConfigSchema>;
@@ -110,6 +111,7 @@ let cachedEnvAutoGitignore: string | undefined;
 let cachedEnvAutoGuessEncoding: string | undefined;
 let cachedEnvNormalizeToUtf8: string | undefined;
 let cachedEnvSupportedEncodings: string | undefined;
+let cachedEnvSupportConcurrency: string | undefined;
 
 function configYamlPath(): string {
 	return join(resolveDshHome(), "plugins", "dsh-better-edit", "config.yaml");
@@ -144,6 +146,7 @@ storeMaxAgeS: 2592000
 
 # central janitor: max total bytes under runtime/ before LRU eviction (default 524288000 = 500 MB)
 storeMaxTotalBytes: 524288000
+supportConcurrency: false
 `;
 
 /**
@@ -277,6 +280,11 @@ function fsAdapter(): Partial<StoreConfig> {
 			if (arr === undefined) console.warn(`dsh-better-edit: supportedEncodings "${parsed.supportedEncodings}" invalid`);
 			else out.supportedEncodings = arr;
 		}
+		if (parsed.supportConcurrency !== undefined) {
+			const b = parseAutoGitIgnoreRaw(parsed.supportConcurrency);
+			if (b === undefined) console.warn(`dsh-better-edit: supportConcurrency "${parsed.supportConcurrency}" invalid — expected true|false`);
+			else out.supportConcurrency = b;
+		}
 		if (parsed.storeMaxTotalBytes !== undefined) {
 			const n = Number(parsed.storeMaxTotalBytes);
 			const res = z.number().int().min(0).safeParse(n);
@@ -362,6 +370,7 @@ function complementMissingFieldsSync(yamlPath: string, yamlPartial: Partial<Stor
 	if (yamlPartial.undo_ttl_s === undefined) missingLines.push("undo_ttl_s: 604800");
 	if (yamlPartial.storeMaxAgeS === undefined) missingLines.push("storeMaxAgeS: 2592000");
 	if (yamlPartial.storeMaxTotalBytes === undefined) missingLines.push("storeMaxTotalBytes: 524288000");
+	if ((yamlPartial as any).supportConcurrency === undefined) missingLines.push("supportConcurrency: false");
 	if (missingLines.length === 0) return;
 	try {
 		// Ensure we don't duplicate if file was concurrently complemented — re-read raw keys.
@@ -392,6 +401,7 @@ export function loadConfig(): StoreConfig {
 	const envGuess = process.env.DSH_BETTER_EDIT_AUTO_GUESS_ENCODING;
 	const envNorm = process.env.DSH_BETTER_EDIT_NORMALIZE_TO_UTF8;
 	const envSup = process.env.DSH_BETTER_EDIT_SUPPORTED_ENCODINGS;
+	const envSupportConcurrency = process.env.DSH_BETTER_EDIT_SUPPORT_CONCURRENCY;
 	const envAuto = process.env.DSH_BETTER_EDIT_AUTO_GITIGNORE;
 
 	if (
@@ -402,7 +412,8 @@ export function loadConfig(): StoreConfig {
 		cachedEnvAutoGitignore === envAuto &&
 		cachedEnvAutoGuessEncoding === envGuess &&
 		cachedEnvNormalizeToUtf8 === envNorm &&
-		cachedEnvSupportedEncodings === envSup
+		cachedEnvSupportedEncodings === envSup &&
+	cachedEnvSupportConcurrency === envSupportConcurrency
 	) {
 		return cachedConfig;
 	}
@@ -438,6 +449,7 @@ export function loadConfig(): StoreConfig {
 	cachedEnvAutoGuessEncoding = envGuess;
 	cachedEnvNormalizeToUtf8 = envNorm;
 	cachedEnvSupportedEncodings = envSup;
+	cachedEnvSupportConcurrency = envSupportConcurrency;
 	return cfg;
 }
 
@@ -451,4 +463,5 @@ export function _resetConfigCache(): void {
 	cachedEnvAutoGuessEncoding = undefined;
 	cachedEnvNormalizeToUtf8 = undefined;
 	cachedEnvSupportedEncodings = undefined;
+	cachedEnvSupportConcurrency = undefined;
 }

--- a/src/store-config.ts
+++ b/src/store-config.ts
@@ -96,7 +96,6 @@ const StoreConfigSchema = z.object({
 	undo_ttl_s: z.number().int().min(-1).default(604800), // undo history TTL in seconds; -1 = keep forever (default 604800 = 7 days)
 	storeMaxAgeS: z.number().int().min(1).default(2592000), // central janitor: max idle age in seconds before evicting runtime/<name>-<hash8>/ (default 2592000 = 30 days)
 	storeMaxTotalBytes: z.number().int().min(0).default(524288000), // central janitor: max total bytes under runtime/ before LRU eviction (default 524288000 = 500 MB)
-	supportConcurrency: z.boolean().default(false), // when true, strict pos check (from==startLine-1) for concurrency resistance; default false = pos-free
 });
 
 export type StoreConfig = z.infer<typeof StoreConfigSchema>;
@@ -111,7 +110,6 @@ let cachedEnvAutoGitignore: string | undefined;
 let cachedEnvAutoGuessEncoding: string | undefined;
 let cachedEnvNormalizeToUtf8: string | undefined;
 let cachedEnvSupportedEncodings: string | undefined;
-let cachedEnvSupportConcurrency: string | undefined;
 
 function configYamlPath(): string {
 	return join(resolveDshHome(), "plugins", "dsh-better-edit", "config.yaml");
@@ -146,7 +144,6 @@ storeMaxAgeS: 2592000
 
 # central janitor: max total bytes under runtime/ before LRU eviction (default 524288000 = 500 MB)
 storeMaxTotalBytes: 524288000
-supportConcurrency: false
 `;
 
 /**
@@ -280,11 +277,6 @@ function fsAdapter(): Partial<StoreConfig> {
 			if (arr === undefined) console.warn(`dsh-better-edit: supportedEncodings "${parsed.supportedEncodings}" invalid`);
 			else out.supportedEncodings = arr;
 		}
-		if (parsed.supportConcurrency !== undefined) {
-			const b = parseAutoGitIgnoreRaw(parsed.supportConcurrency);
-			if (b === undefined) console.warn(`dsh-better-edit: supportConcurrency "${parsed.supportConcurrency}" invalid — expected true|false`);
-			else out.supportConcurrency = b;
-		}
 		if (parsed.storeMaxTotalBytes !== undefined) {
 			const n = Number(parsed.storeMaxTotalBytes);
 			const res = z.number().int().min(0).safeParse(n);
@@ -370,7 +362,6 @@ function complementMissingFieldsSync(yamlPath: string, yamlPartial: Partial<Stor
 	if (yamlPartial.undo_ttl_s === undefined) missingLines.push("undo_ttl_s: 604800");
 	if (yamlPartial.storeMaxAgeS === undefined) missingLines.push("storeMaxAgeS: 2592000");
 	if (yamlPartial.storeMaxTotalBytes === undefined) missingLines.push("storeMaxTotalBytes: 524288000");
-	if ((yamlPartial as any).supportConcurrency === undefined) missingLines.push("supportConcurrency: false");
 	if (missingLines.length === 0) return;
 	try {
 		// Ensure we don't duplicate if file was concurrently complemented — re-read raw keys.
@@ -401,7 +392,6 @@ export function loadConfig(): StoreConfig {
 	const envGuess = process.env.DSH_BETTER_EDIT_AUTO_GUESS_ENCODING;
 	const envNorm = process.env.DSH_BETTER_EDIT_NORMALIZE_TO_UTF8;
 	const envSup = process.env.DSH_BETTER_EDIT_SUPPORTED_ENCODINGS;
-	const envSupportConcurrency = process.env.DSH_BETTER_EDIT_SUPPORT_CONCURRENCY;
 	const envAuto = process.env.DSH_BETTER_EDIT_AUTO_GITIGNORE;
 
 	if (
@@ -412,8 +402,7 @@ export function loadConfig(): StoreConfig {
 		cachedEnvAutoGitignore === envAuto &&
 		cachedEnvAutoGuessEncoding === envGuess &&
 		cachedEnvNormalizeToUtf8 === envNorm &&
-		cachedEnvSupportedEncodings === envSup &&
-	cachedEnvSupportConcurrency === envSupportConcurrency
+		cachedEnvSupportedEncodings === envSup
 	) {
 		return cachedConfig;
 	}
@@ -449,7 +438,6 @@ export function loadConfig(): StoreConfig {
 	cachedEnvAutoGuessEncoding = envGuess;
 	cachedEnvNormalizeToUtf8 = envNorm;
 	cachedEnvSupportedEncodings = envSup;
-	cachedEnvSupportConcurrency = envSupportConcurrency;
 	return cfg;
 }
 
@@ -463,5 +451,4 @@ export function _resetConfigCache(): void {
 	cachedEnvAutoGuessEncoding = undefined;
 	cachedEnvNormalizeToUtf8 = undefined;
 	cachedEnvSupportedEncodings = undefined;
-	cachedEnvSupportConcurrency = undefined;
 }

--- a/src/tool-undo.ts
+++ b/src/tool-undo.ts
@@ -93,6 +93,7 @@ export function buildUndoTool(io: FileIO, sandbox: FsSandboxController) {
 
 				const { text: currentStripped } = stripBOM(currentRaw);
 				const currentNormalized = toLF(currentStripped);
+				// undo is file-global: must block hashes retired by any session, not just current session, to prevent recycling current-file-only hash - test expects global
 				const reservations = await loadAnchorReservations(absolutePath);
 				const currentHashes = await lineHashes(
 					currentNormalized,

--- a/src/tool-undo.ts
+++ b/src/tool-undo.ts
@@ -16,7 +16,11 @@ import { contentChecksum } from "./hashline/hash-assign.js";
 import { lineHashes } from "./hashline/hash.js";
 import { changedRange } from "./hashline/anchor-pipeline.js";
 import { getUndo, clearUndo } from "./undo-edit.js";
-import { recordServedTruncated } from "./session-view.js";
+import {
+	loadAnchorReservations,
+	recordServedTruncated,
+	retireAnchors,
+} from "./session-view.js";
 import { UNDO_DESCRIPTION } from "./prompts.js";
 import type { FileIO } from "./fs-bridge.js";
 import { execCwd, execSessionKey } from "./workspace-context.js";
@@ -89,7 +93,34 @@ export function buildUndoTool(io: FileIO, sandbox: FsSandboxController) {
 
 				const { text: currentStripped } = stripBOM(currentRaw);
 				const currentNormalized = toLF(currentStripped);
-				const currentHashes = await lineHashes(currentNormalized, absolutePath);
+				const reservations = await loadAnchorReservations(absolutePath);
+				const currentHashes = await lineHashes(
+					currentNormalized,
+					absolutePath,
+					undefined,
+					undefined,
+					false,
+					reservations.reservedHashes,
+					reservations.retiredHashes,
+				);
+				const retiredOriginalHashes = new Set(
+					undo.hashes.filter((hash) => reservations.retiredHashes.has(hash)),
+				);
+				const blockedRestoreHashes = new Set(reservations.reservedHashes);
+				for (const hash of currentHashes) blockedRestoreHashes.add(hash);
+				const restoredHashes = await lineHashes(
+					undo.content,
+					absolutePath,
+					{
+						content: undo.content,
+						hashes: undo.hashes,
+						removedHashes: retiredOriginalHashes,
+					},
+					undefined,
+					false,
+					blockedRestoreHashes,
+					reservations.retiredHashes,
+				);
 				const diffResult = genDiff(
 					undo.content,
 					currentNormalized,
@@ -103,15 +134,21 @@ export function buildUndoTool(io: FileIO, sandbox: FsSandboxController) {
 					currentNormalized,
 					undo.content,
 					1,
-					undo.hashes,
+					restoredHashes,
 					currentHashes,
 				);
 				const undoDiff = undoDiffResult.diff;
 				const undoDenseRows: typeof undoDiffResult.servedRows = [];
-				for (let i = 0; i < undo.hashes.length; i++) {
-					undoDenseRows.push({ position: i, hash: undo.hashes[i]! });
+				for (let i = 0; i < restoredHashes.length; i++) {
+					undoDenseRows.push({ position: i, hash: restoredHashes[i]! });
 				}
 				const restoredRange = changedRange(currentNormalized, undo.content);
+				const restoredSet = new Set(restoredHashes);
+				await retireAnchors(
+					sessionKey,
+					absolutePath,
+					currentHashes.filter((hash) => !restoredSet.has(hash)),
+				);
 
 				try {
 					await io.writeText(
@@ -130,7 +167,7 @@ export function buildUndoTool(io: FileIO, sandbox: FsSandboxController) {
 						absolutePath,
 						contentChecksum(undo.content),
 						splitLines(undo.content).length,
-						undo.hashes,
+						restoredHashes,
 					);
 				} catch (error) {
 					console.error("Failed to restore hash store snapshot after undo:", error);

--- a/test/core/hashline-stable-mapping.test.ts
+++ b/test/core/hashline-stable-mapping.test.ts
@@ -304,7 +304,7 @@ describe("mapStableHashes — removedHashes edge cases", () => {
     expect(result[1]).toBe(secondBHash);
   });
 
-  it("removedHashes with all candidates removed reuses the first removed hash for identical re-insertion", async () => {
+  it("allocates a fresh hash when identical text replaces removed candidates", async () => {
     const oldContent = "a\nb\nb\nc";
     const oldHashes = await lineHashes(oldContent, home.testPath);
     const firstBHash = oldHashes[1]!;
@@ -318,10 +318,11 @@ describe("mapStableHashes — removedHashes edge cases", () => {
       removedHashes: new Set([firstBHash, secondBHash]),
     });
 
-    expect(result[1]).toBe(firstBHash);
+    expect(result[1]).not.toBe(firstBHash);
+    expect(result[1]).not.toBe(secondBHash);
   });
 
-  it("re-inserting identical text reuses the removed line's hash", async () => {
+  it("does not reuse a removed hash when identical text remains", async () => {
     const oldContent = "a\nb\nc";
     const oldHashes = await lineHashes(oldContent, home.testPath);
     const newContent = "a\nX\nc";
@@ -332,7 +333,7 @@ describe("mapStableHashes — removedHashes edge cases", () => {
       removedHashes: new Set([oldHashes[0]!]),
     });
 
-    expect(result[0]).toBe(oldHashes[0]);
+    expect(result[0]).not.toBe(oldHashes[0]);
     expect(result[1]).toMatch(/^[A-Za-z0-9_\\-]{3}$/);
     expect(result[1]).not.toBe(oldHashes[0]);
     expect(result[1]).not.toBe(oldHashes[1]);
@@ -360,7 +361,7 @@ describe("mapStableHashes — removedHashes edge cases", () => {
     expect(result[3]).toBe(oldHashes[3]);
   });
 
-  it("re-inserting identical text at the same position keeps its hash", async () => {
+  it("does not resurrect removed hashes at the same positions", async () => {
     const oldContent = "a\nb\nc";
     const oldHashes = await lineHashes(oldContent, home.testPath);
     const newContent = "a\nX\nc";
@@ -371,7 +372,8 @@ describe("mapStableHashes — removedHashes edge cases", () => {
       removedHashes: new Set(oldHashes.slice(0, 2)),
     });
 
-    expect(result[0]).toBe(oldHashes[0]);
+    expect(result[0]).not.toBe(oldHashes[0]);
+    expect(result[0]).not.toBe(oldHashes[1]);
     expect(result[1]).toMatch(/^[A-Za-z0-9]{3}$/);
     expect(result[1]).not.toBe(oldHashes[0]);
     expect(result[1]).not.toBe(oldHashes[1]);
@@ -390,9 +392,10 @@ describe("mapStableHashes — removedHashes edge cases", () => {
       removedHashes: new Set(oldHashes.slice(1, 4)),
     });
 
-    expect(result[1]).toBe(oldHashes[1]);
-    expect(result[2]).toBe(oldHashes[2]);
-    expect(result[4]).toBe(oldHashes[3]);
+    const removedHashes = new Set(oldHashes.slice(1, 4));
+    expect(removedHashes.has(result[1]!)).toBe(false);
+    expect(removedHashes.has(result[2]!)).toBe(false);
+    expect(removedHashes.has(result[4]!)).toBe(false);
     expect(result[6]).toBe(oldHashes[5]);
     expect(result[7]).toBe(oldHashes[6]);
     expect(result[8]).toBe(oldHashes[7]);
@@ -509,7 +512,7 @@ describe("mapStableHashes — nearest-candidate selection", () => {
     expect(result[0]).toBe(oldHashes[0]);
   });
 
-  it("reuses the first removed hash when every candidate is removed", async () => {
+  it("allocates outside the removed set when every candidate is removed", async () => {
     const oldContent = "same\nsame";
     const oldHashes = await lineHashes(oldContent, home.testPath);
     const removedHashes = new Set(oldHashes);
@@ -521,7 +524,7 @@ describe("mapStableHashes — nearest-candidate selection", () => {
     });
 
     expect(result).toHaveLength(1);
-    expect(result[0]).toBe(oldHashes[0]);
+    expect(removedHashes.has(result[0]!)).toBe(false);
   });
 
   it("keeps uniqueness when interleaving duplicates and removed candidates", async () => {
@@ -544,10 +547,7 @@ describe("mapStableHashes — nearest-candidate selection", () => {
 
     expect(result).toHaveLength(1_500);
     expect(new Set(result).size).toBe(1_500);
-    const reinserted = result.filter((hash) => removedHashes.has(hash));
-    expect(reinserted).toHaveLength(250);
-    const survivors = result.filter((hash) => !removedHashes.has(hash));
-    expect(survivors).toHaveLength(1_250);
+    expect(result.some((hash) => removedHashes.has(hash))).toBe(false);
   }, 120_000);
 
   it("keeps an untouched line's hash when the replacement contains identical content nearer to its old position", async () => {

--- a/test/core/hashline-stale-rebind.test.ts
+++ b/test/core/hashline-stale-rebind.test.ts
@@ -1,0 +1,312 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+
+import { loadHashStore, loadServedStore } from "../../src/hash-store.js";
+import { withWorkspace } from "../../src/workspace-context.js";
+import {
+	extractHash,
+	getText,
+	setupIntegrationTest,
+	withTempFile,
+} from "../support/fixtures.js";
+
+describe("retired hash anchors", () => {
+	it("rejects a stale anchor instead of rebinding it to later identical text", async () => {
+		const initial = "  show: true,\n  items: [],\n";
+
+		await withTempFile("config.ts", initial, async ({ cwd, path }) => {
+			const { readTool, editTool } = setupIntegrationTest(cwd);
+			const read = await readTool.execute("read", { path: "config.ts" });
+			const rows = getText(read).split("\n");
+			const staleAnchor = extractHash(
+				rows.find((line) => line.endsWith("│  show: true,"))!,
+			);
+			const itemsAnchor = extractHash(
+				rows.find((line) => line.endsWith("│  items: [],"))!,
+			);
+
+			await editTool.execute("free-anchor", {
+				path: "config.ts",
+				remove_from: staleAnchor,
+				remove_to: staleAnchor,
+				replacement_text: "  enabled: true,",
+			});
+			await editTool.execute("insert-identical", {
+				path: "config.ts",
+				remove_from: itemsAnchor,
+				remove_to: itemsAnchor,
+				replacement_text: "  items: [],\n  show: true,",
+			});
+
+			const expected = "  enabled: true,\n  items: [],\n  show: true,\n";
+			expect(await readFile(path, "utf-8")).toBe(expected);
+			await withWorkspace(cwd, async () => {
+				const store = await loadServedStore();
+				expect(store.getRetiredAnchors("test-session", path)).toContain(
+					staleAnchor,
+				);
+			});
+
+			await expect(
+				editTool.execute("reuse-stale", {
+					path: "config.ts",
+					remove_from: staleAnchor,
+					remove_to: staleAnchor,
+					replacement_text: "  show: false,",
+				}),
+			).rejects.toThrow(/E_STALE_ANCHOR|E_RANGE_STALE/);
+			expect(await readFile(path, "utf-8")).toBe(expected);
+		});
+	});
+
+	it("keeps tombstones through a partial read and clears them after a full read", async () => {
+		const initial = "one\ntwo\nthree\nfour\n";
+
+		await withTempFile("pages.txt", initial, async ({ cwd, path }) => {
+			const { readTool, editTool } = setupIntegrationTest(cwd);
+			const read = await readTool.execute("read", { path: "pages.txt" });
+			const staleAnchor = extractHash(
+				getText(read)
+					.split("\n")
+					.find((line) => line.endsWith("│one"))!,
+			);
+
+			await editTool.execute("edit", {
+				path: "pages.txt",
+				remove_from: staleAnchor,
+				remove_to: staleAnchor,
+				replacement_text: "ONE",
+			});
+			await readTool.execute("partial", {
+				path: "pages.txt",
+				offset: 2,
+				limit: 1,
+			});
+			await withWorkspace(cwd, async () => {
+				const store = await loadServedStore();
+				expect(store.getRetiredAnchors("test-session", path)).toContain(
+					staleAnchor,
+				);
+			});
+
+			await readTool.execute("full", { path: "pages.txt" });
+			await withWorkspace(cwd, async () => {
+				const store = await loadServedStore();
+				expect(store.getRetiredAnchors("test-session", path)).not.toContain(
+					staleAnchor,
+				);
+			});
+		});
+	});
+
+	it("retires a remembered anchor displaced by a partial read", async () => {
+		const initial = "show\nitems\n";
+
+		await withTempFile("external.txt", initial, async ({ cwd, path }) => {
+			const { readTool, editTool } = setupIntegrationTest(cwd);
+			const read = await readTool.execute("read", { path: "external.txt" });
+			const staleAnchor = extractHash(
+				getText(read)
+					.split("\n")
+					.find((line) => line.endsWith("│show"))!,
+			);
+
+			await writeFile(path, "enabled\nitems\n", "utf-8");
+			const partial = await readTool.execute("partial", {
+				path: "external.txt",
+				offset: 1,
+				limit: 1,
+			});
+			const enabledAnchor = extractHash(
+				getText(partial)
+					.split("\n")
+					.find((line) => line.endsWith("│enabled"))!,
+			);
+			await withWorkspace(cwd, async () => {
+				const store = await loadServedStore();
+				expect(store.getRetiredAnchors("test-session", path)).toContain(
+					staleAnchor,
+				);
+			});
+
+			await editTool.execute("insert", {
+				path: "external.txt",
+				remove_from: enabledAnchor,
+				remove_to: enabledAnchor,
+				replacement_text: "enabled\nshow",
+			});
+			const expected = "enabled\nshow\nitems\n";
+			expect(await readFile(path, "utf-8")).toBe(expected);
+			await withWorkspace(cwd, async () => {
+				const store = await loadHashStore();
+				expect(store.getSnapshot(path, expected)).not.toContain(staleAnchor);
+			});
+			await expect(
+				editTool.execute("stale-after-partial", {
+					path: "external.txt",
+					remove_from: staleAnchor,
+					remove_to: staleAnchor,
+					replacement_text: "wrong",
+				}),
+			).rejects.toThrow(/E_STALE_ANCHOR|E_RANGE_STALE/);
+		});
+	});
+
+	it("undo restores removed content with a fresh anchor", async () => {
+		const initial = "  show: true,\n  items: [],\n";
+
+		await withTempFile("undo.ts", initial, async ({ cwd, path }) => {
+			const harness = setupIntegrationTest(cwd);
+			const read = await harness.readTool.execute("read", { path: "undo.ts" });
+			const staleAnchor = extractHash(
+				getText(read)
+					.split("\n")
+					.find((line) => line.endsWith("│  show: true,"))!,
+			);
+
+			await harness.editTool.execute("edit", {
+				path: "undo.ts",
+				remove_from: staleAnchor,
+				remove_to: staleAnchor,
+				replacement_text: "  enabled: true,",
+			});
+			const undo = harness.getTool("undo_last_edit") as {
+				execute: (name: string, args: { path: string }) => Promise<{
+					content: Array<{ text?: string }>;
+				}>;
+			};
+			const undoResult = await undo.execute("undo", { path: "undo.ts" });
+			const restoredLine = getText(undoResult)
+				.split("\n")
+				.find((line) => line.endsWith("│  show: true,"))!;
+			const restoredAnchor = restoredLine.slice(1).split("│")[0]!;
+
+			expect(restoredAnchor).not.toBe(staleAnchor);
+			expect(await readFile(path, "utf-8")).toBe(initial);
+			await expect(
+				harness.editTool.execute("stale-after-undo", {
+					path: "undo.ts",
+					remove_from: staleAnchor,
+					remove_to: staleAnchor,
+					replacement_text: "  show: false,",
+				}),
+			).rejects.toThrow(/E_STALE_ANCHOR|E_RANGE_STALE/);
+			await harness.editTool.execute("fresh-after-undo", {
+				path: "undo.ts",
+				remove_from: restoredAnchor,
+				remove_to: restoredAnchor,
+				replacement_text: "  show: false,",
+			});
+			expect(await readFile(path, "utf-8")).toBe(
+				"  show: false,\n  items: [],\n",
+			);
+		});
+	});
+
+	it("undo does not move an introduced duplicate's hash onto a surviving line", async () => {
+		const initial = "y\nx\n";
+
+		await withTempFile("duplicates.txt", initial, async ({ cwd }) => {
+			const harness = setupIntegrationTest(cwd);
+			const read = await harness.readTool.execute("read", {
+				path: "duplicates.txt",
+			});
+			const rows = getText(read).split("\n");
+			const yAnchor = extractHash(
+				rows.find((line) => line.endsWith("│y"))!,
+			);
+			const survivingXAnchor = extractHash(
+				rows.find((line) => line.endsWith("│x"))!,
+			);
+
+			await harness.editTool.execute("duplicate", {
+				path: "duplicates.txt",
+				remove_from: yAnchor,
+				remove_to: yAnchor,
+				replacement_text: "x",
+			});
+
+			const undo = harness.getTool("undo_last_edit") as {
+				execute: (name: string, args: { path: string }) => Promise<{
+					content: Array<{ text?: string }>;
+				}>;
+			};
+			const undoResult = await undo.execute("undo", {
+				path: "duplicates.txt",
+			});
+			const undoRows = getText(undoResult).split("\n");
+			const restoredYAnchor = undoRows
+				.find((line) => line.startsWith("+") && line.endsWith("│y"))!
+				.slice(1)
+				.split("│")[0]!;
+			const currentXAnchor = undoRows
+				.find((line) => line.startsWith(" ") && line.endsWith("│x"))!
+				.slice(1)
+				.split("│")[0]!;
+
+			expect(restoredYAnchor).not.toBe(yAnchor);
+			expect(currentXAnchor).toBe(survivingXAnchor);
+		});
+	});
+
+	it("undo does not recycle a hash owned only by the current file", async () => {
+		const initial = "old\nsurvivor\n";
+		const edited = "new30258\nsurvivor\n";
+
+		await withTempFile("undo-collision.txt", initial, async ({ cwd, path }) => {
+			const harness = setupIntegrationTest(cwd);
+			const read = await harness.readTool.execute("read", {
+				path: "undo-collision.txt",
+			});
+			const oldAnchor = extractHash(
+				getText(read)
+					.split("\n")
+					.find((line) => line.endsWith("│old"))!,
+			);
+			expect(oldAnchor).toBe("tYt");
+
+			await harness.editTool.execute("collide", {
+				path: "undo-collision.txt",
+				remove_from: oldAnchor,
+				remove_to: oldAnchor,
+				replacement_text: "new30258",
+			});
+			let currentOnlyAnchor = "";
+			await withWorkspace(cwd, async () => {
+				const hashStore = await loadHashStore();
+				const currentHashes = hashStore.getSnapshot(path, edited)!;
+				currentOnlyAnchor = currentHashes[0]!;
+				expect(currentOnlyAnchor).toBe("quC");
+
+				const servedStore = await loadServedStore();
+				servedStore.upsertRetiredAnchors(
+					"other-session",
+					path,
+					JSON.stringify([oldAnchor]),
+				);
+				servedStore.deleteServed("test-session", path);
+			});
+
+			const undo = harness.getTool("undo_last_edit") as {
+				execute: (name: string, args: { path: string }) => Promise<{
+					content: Array<{ text?: string }>;
+				}>;
+			};
+			const undoResult = await undo.execute("undo", {
+				path: "undo-collision.txt",
+			});
+			const restoredAnchor = getText(undoResult)
+				.split("\n")
+				.find((line) => line.startsWith("+") && line.endsWith("│old"))!
+				.slice(1)
+				.split("│")[0]!;
+
+			expect(restoredAnchor).not.toBe(oldAnchor);
+			expect(restoredAnchor).not.toBe(currentOnlyAnchor);
+			await withWorkspace(cwd, async () => {
+				const store = await loadHashStore();
+				expect(store.getSnapshot(path, initial)).not.toContain(currentOnlyAnchor);
+			});
+		});
+	});
+});

--- a/test/core/hashline-stress.test.ts
+++ b/test/core/hashline-stress.test.ts
@@ -233,8 +233,8 @@ describe("mapStableHashes — large file stress", () => {
     expect(result).toHaveLength(3_000);
     const survivors = result.filter((hash) => !removedHashes.has(hash));
     const reinserted = result.filter((hash) => removedHashes.has(hash));
-    expect(survivors).toHaveLength(2_500);
-    expect(reinserted).toHaveLength(500);
+    expect(survivors).toHaveLength(3_000);
+    expect(reinserted).toHaveLength(0);
     expect(new Set(result).size).toBe(3_000);
   }, 120_000);
 
@@ -250,7 +250,9 @@ describe("mapStableHashes — large file stress", () => {
       removedHashes,
     });
     const elapsed = performance.now() - start;
-    expect(result).toEqual(oldHashes);
+    expect(result).toHaveLength(oldHashes.length);
+    expect(new Set(result).size).toBe(result.length);
+    expect(result.some((hash) => removedHashes.has(hash))).toBe(false);
     expect(elapsed).toBeLessThan(60_000);
   }, 120_000);
 });

--- a/test/core/served-store.test.ts
+++ b/test/core/served-store.test.ts
@@ -3,7 +3,11 @@ import { mkdtemp, mkdir, rm, writeFile } from "fs/promises";
 import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 
-import { loadHashStore, shutdownHashStore } from "../../src/hash-store.js";
+import {
+	loadHashStore,
+	loadServedStore,
+	shutdownHashStore,
+} from "../../src/hash-store.js";
 import {
 	_mergeServedRows,
 	loadServed,
@@ -79,6 +83,9 @@ describe("served state — record semantics", () => {
 			await recordServed("sessionA", "/p.ts", [{ position: 0, hash: "abc" }]);
 			await recordServed("sessionA", "/p.ts", [{ position: 0, hash: "def" }]);
 			expect(await loadServed("sessionA", "/p.ts")).toEqual(["def"]);
+			expect(
+				(await loadServedStore()).getRetiredAnchors("sessionA", "/p.ts"),
+			).toEqual(new Set(["abc"]));
 		});
 	});
 
@@ -91,6 +98,9 @@ describe("served state — record semantics", () => {
 			]);
 			await recordServed("sessionA", "/p.ts", [{ position: 1, hash: null }]);
 			expect(await loadServed("sessionA", "/p.ts")).toEqual(["abc", null, "ghi"]);
+			expect(
+				(await loadServedStore()).getRetiredAnchors("sessionA", "/p.ts"),
+			).toEqual(new Set(["def"]));
 		});
 	});
 
@@ -139,6 +149,9 @@ describe("served state — merge helper (stale-tail invariant)", () => {
 			// (E_RANGE_UNVERIFIED, "served at N positions").
 			await recordServed("sessionA", "/p.ts", [{ position: 0, hash: "abc" }], 1);
 			expect(await loadServed("sessionA", "/p.ts")).toEqual(["abc"]);
+			expect(
+				(await loadServedStore()).getRetiredAnchors("sessionA", "/p.ts"),
+			).toEqual(new Set(["def", "ghi"]));
 		});
 	});
 
@@ -153,6 +166,9 @@ describe("served state — merge helper (stale-tail invariant)", () => {
 			const served = await loadServed("sessionA", "/p.ts");
 			expect(served).toEqual(["abc"]);
 			expect(servedPositionsOf(served, "abc")).toEqual([0]);
+			expect(
+				(await loadServedStore()).getRetiredAnchors("sessionA", "/p.ts"),
+			).toEqual(new Set(["def"]));
 		});
 	});
 
@@ -168,6 +184,9 @@ describe("served state — merge helper (stale-tail invariant)", () => {
 			// view of everything at/after it no longer holds.
 			await recordServedTruncated("sessionA", "/p.ts", [{ position: 2, hash: "xxx" }], 4, 1);
 			expect(await loadServed("sessionA", "/p.ts")).toEqual(["aaa", null, "xxx"]);
+			expect(
+				(await loadServedStore()).getRetiredAnchors("sessionA", "/p.ts"),
+			).toEqual(new Set(["bbb", "ccc", "ddd"]));
 		});
 	});
 
@@ -381,6 +400,51 @@ describe("served state — schema versioning", () => {
 			expect(await driftReported("sessionA", "/p.ts")).toEqual(new Set(["abc"]));
 		});
 	});
+
+	it("preserves served rows but invalidates rebound sources when adding retired anchors", async () => {
+		await withTempHome(async (home) => {
+			const path = join(home, "rebound.txt");
+			const content = "new\nold\n";
+			await writeFile(path, content, "utf-8");
+			const initialStore = await loadHashStore();
+			await recordServed("sessionA", path, [
+				{ position: 0, hash: "AAA" },
+			]);
+			initialStore.upsertSnapshot(path, contentChecksum(content), 2, [
+				"BBB",
+				"AAA",
+			]);
+			initialStore.upsertUndo(path, {
+				content: "old\nnew\n",
+				bom: "",
+				ending: "\n",
+				hashes: ["BBB", "AAA"],
+				resultContent: content,
+			});
+			shutdownHashStore();
+
+			const db = new DatabaseSync(sqlitePath(home), {
+				defensive: false,
+			} as any);
+			db.exec("ALTER TABLE served DROP COLUMN retired");
+			db.close();
+
+			const store = await loadServedStore();
+			expect(store.getAnchorReservations(path).reservedHashes).toEqual(
+				new Set(["AAA"]),
+			);
+			expect((await loadHashStore()).getSnapshot(path, content)).toBeUndefined();
+			expect((await loadHashStore()).getUndo(path)).toBeUndefined();
+			store.upsertRetiredAnchors(
+				"sessionA",
+				path,
+				JSON.stringify(["BBB"]),
+			);
+			expect(store.getRetiredAnchors("sessionA", path)).toEqual(
+				new Set(["BBB"]),
+			);
+		});
+	});
 });
 
 describe("served state — pruneMissing", () => {
@@ -581,6 +645,7 @@ async function withTempHome(
 		join(await getWritableTempRoot(), "pi-hashline-served-test-"),
 	);
 	vi.stubEnv("HOME", tmpHome);
+	vi.stubEnv("DSH_HOME", join(tmpHome, ".dsh"));
 	vi.stubEnv("XDG_CONFIG_HOME", "");
 	try {
 		await run(tmpHome);


### PR DESCRIPTION
Cherry-pick reusable hunks from #41 + ADR-0013 pos-free design.

- Drops `removedByContent` queue, `used=bitset(old∪blocked)` per session tombstone
- Per-session `served.retired` epoch (full read clears), global `reserved` conservative
- Preserves single-thread pos-free (non-overlapping forever), fallback to strict pos for concurrency via ADR-0013
- Migrates existing served state, invalidates pre-fix snapshots/undo

Closes #31
Refs: GH#41
ADR: docs/adr/0013-pos-free-roundtrip-optimization.md
Architecture: docs/specs/architecture-adr0013.md