### PR TITLE
feat!: user/model audience split + glossary error codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 ## [Unreleased]
 
+### Features
+
+- user/model audience split + glossary error codes (Closes #45) (BREAKING CHANGE)
+
 ### Documentation
 
+- **absorb:** record v1.2.1→v1.6.0 audit triage (T1–T4, issues #45–#48)
 - migrate CLAUDE.md to AGENTS.md with symlink
 
 ## [0.6.3](https://github.com/Rianico/dsh-better-edit/compare/v0.6.2...v0.6.3) (2026-09-05)

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -21,9 +21,9 @@ _Avoid_: —
 **anchor philosophy**:
 The project's core contract: per-line anchors are content-derived with ASCII whitespace (`[ \t\r\n]`) stripped, stable for unchanged lines and across whitespace-only formatting, and position-independent; an anchor that cannot be resolved is rejected, never fuzzy-matched or silently relocated. Byte-level detection of non-whitespace changes is unchanged — token-level edits still rotate the anchor (ADR-0005).
 
-**boundary staleness**:
-An anchor that no longer resolves against the current file because the line's content changed since it was served.
-_Avoid_: stale anchor (ambiguous between boundary and range staleness)
+**anchor staleness**:
+An anchor (one line, `remove_from` or `remove_to`) that no longer resolves against the current file because the line's content changed since it was served (`hash`/`canon`/`tombstone` miss). The model must re-`read` for fresh anchors.
+_Avoid_: boundary staleness (use `anchor` for one line, `served range` for span)
 
 **interior**:
 The lines of a resolved range strictly between `remove_from` and `remove_to`.
@@ -39,11 +39,16 @@ _Avoid_: hunk
 **served span**:
 The contiguous run of served hashes between the two boundary anchors' served positions — the served-state reconstruction of the model's view of a range.
 
-**range staleness**:
-The condition where a resolved range's interior cannot be reconciled with served state: a served line's content changed since it was served, or the line was never served.
+**served range**:
+The model-facing word for the `served span` — the span between `remove_from` and `remove_to` as the model saw it. Alias to `served span` for glossary search.
+_Avoid_: range (use `served range` for verified span, `range` for current file run)
+
+**served-range staleness**:
+The condition where the `served range` (span between anchors) cannot be reconciled with served state: interior `served span` vs `current span` mismatch (`hash`/`canon`/`tombstone`/`len`). Reported as `[E_STALE_RANGE]` (changed) or `[E_UNSERVED_RANGE]` (never-served, `details.unservedKind` `boundary`|`interior`). Both do `reject-and-serve`.
+_Avoid_: range staleness (use `served range` for span)
 
 **never-served**:
-An interior line with no entry in the served record — the model was never shown that line. Reported as `[E_RANGE_UNSERVED]`; the response serves the current range so the model can retry.
+An interior line with no entry in the served record — the model was never shown that line. Reported as `[E_UNSERVED_RANGE]`; the response serves the current range so the model can retry.
 
 ### File Encoding
 
@@ -84,14 +89,14 @@ The informational section appended to a replace result (applied or noop, not und
 _Avoid_: warning (the operation succeeded; it is information, not a warning)
 
 **model-facing signal**:
-A model-visible signal the tool must include in `content` for correctness (e.g. boundary staleness, range staleness, E_RANGE_*, E_EDIT_HASH_ECHO). The model needs it to retry correctly.
+A model-visible signal the tool must include in `content` for correctness (e.g. `anchor staleness`, `served-range staleness`, `E_STALE_*`/`E_UNSERVED_*`, `E_SERVED_ECHO`). The model needs it to retry correctly.
 
 **user-facing signal**:
 A model-visible signal informative for the human only, emitted in `details`/`warnings` and rendered collapsed in TUI (e.g. drift notice, Batch drift note). Not in model content.
 
 **orphaned serve**:
 An entry in served state whose hash no longer matches the current file at that position — the mirror retained a hash that the file has moved or removed elsewhere. Contrast with never-served. An orphan is drift, but at a single position rather than a range.
-_Avoid_: stale serve (ambiguous with boundary staleness)
+_Avoid_: stale serve (ambiguous with anchor staleness)
 
 **orphaning re-serve**:
 The serve event that creates an orphan: re-serving the same hash at a new position without nulling its previous served position — typically a partial re-read (or an echo/diff that covers the new but not the old slot) after an external relocation that kept the hash. A full re-read heals by overwriting every position; an orphaning re-serve leaves the stale slot behind.
@@ -137,13 +142,9 @@ _Avoid_: patch language, array shorthand
 A candidate line that begins with the exact `HASH│` anchor served for the same session, canonical path, and line — tool output mistaken for file content. For `write` the check is absolute line `i` vs `served[i]`; for `edit` it is range-relative line `k` vs `served[startLine + k]` (AA: E1). Detected before dispatch/write, file stays byte-identical. Not a generic `^[A-Za-z0-9]{3}│` strip.
 _Avoid_: hash echo (without served qualification), anchor echo
 
-**E_WRITE_HASH_ECHO**:
-Refusal of a built-in `write` that copied a served hash echo — `[E_WRITE_HASH_ECHO] Refused write to ${path}: line ${n} begins with the exact ${hash}│ anchor served for this session, path, and line. Remove the entire copied anchor chain and retry. Nothing was written.`
-_Avoid_: E_HASH_ECHO (ambiguous between write/edit)
-
-**E_EDIT_HASH_ECHO**:
-Refusal of an `edit` whose `replacement_text` contains a served hash echo at the range-relative position — `[E_EDIT_HASH_ECHO] Refused edit to ${path}: replacement line ${k} begins with the exact ${hash}│ anchor served for this session, path, and range-relative line. Remove the copied anchors and retry. Nothing was written.` Deny, not strip — fail-loud, compensable (AA: A).
-_Avoid_: E_WRITE_HASH_ECHO (write-only), generic strip
+**E_SERVED_ECHO**:
+Refusal that `content` (for `write`) or `replacement_text` (for `edit`) copied a `served hash echo` — `[E_SERVED_ECHO] Refused write to ${path}: line ${n} begins with the exact ${hash}│ anchor served for this session, path, and line` or `Refused edit to ${path}: replacement line ${k} begins with the exact ${hash}│ anchor served for this session, path, and range-relative line`. Remove the copied anchors and retry. Nothing was written. Deny, not strip — fail-loud, compensable.
+_Avoid_: E_HASH_ECHO (ambiguous)
 
 **boundary duplicate (historical, removed by ADR-0007):**
 Auto-spliced `replacement_text` edge when it equaled an adjacent file line — `trailingDups`/`leadingDups` (byte `===`, 1-line) and `firstNewAfterDups`/`lastNewBeforeDups` (`canon()` + `sectionIsUnique`). Removed — tool is now pure `range = [remove_from, remove_to]` by hash, `replacement = exact replacement_text`; a duplicate stays as a loud duplicate the model fixes next turn (see ADR-0007).

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@
 | --- | --- |
 | Re-types old code (~5-6× billed) | Two `3-char` hashes, old text never echoed |
 | One insert shifts every number → silent wrong line | Content addresses — edits above don't move anchors below |
-| No check against what was shown | Every line verified; `[E_RANGE_STALE]`/`[E_RANGE_UNSERVED]` reject before write, then **reject-and-serve** returns fresh `HASH│content` |
+| No check against what was shown | Every line verified; `[E_STALE_RANGE]`/`[E_UNSERVED_RANGE]` reject before write, then **reject-and-serve** returns fresh `HASH│content` |
 
 > [!TIP]
 > **Shining points — honest:**
@@ -114,7 +114,7 @@ Returns a diff with fresh anchors — next edit needs no `read`:
   kQm │ }
 ```
 
-**Position-free in one line:** `read 1..5` → `insert @0` → `edit 10..12` still verifies `10..12` (`resist` mode). **Multi-session honesty:** `A:10..12+1` shifts `B:20..30→21..31` → `B` passes (drift notice); `B:12..13` overlapping `A` → `E_RANGE_STALE` + fresh rows, one retry.
+**Position-free in one line:** `read 1..5` → `insert @0` → `edit 10..12` still verifies `10..12` (`resist` mode). **Multi-session honesty:** `A:10..12+1` shifts `B:20..30→21..31` → `B` passes (drift notice); `B:12..13` overlapping `A` → `E_STALE_RANGE` + fresh rows, one retry.
 
 Batch atomically — one `edit`, up to 32 same-file ranges:
 
@@ -148,9 +148,9 @@ Env overrides yaml (`DSH_BETTER_EDIT_STORE_DIR`, `DSH_BETTER_EDIT_AUTO_GITIGNORE
 
 ## Why Hashline
 
-**Verified against what was served.** Every resolved line checked against `read`/diff/rejection rows. Stale or unseen → `[E_RANGE_STALE]`/`[E_RANGE_UNSERVED]`/`[E_RANGE_UNVERIFIED]` + fresh `HASH│content`, retry needs no `read`. Session-scoped — sub-agent serves never validate main edits.
+**Verified against what was served.** Every resolved line checked against `read`/diff/rejection rows. Stale or unseen → `[E_STALE_RANGE]`/`[E_UNSERVED_RANGE]` + fresh `HASH│content`, retry needs no `read`. Session-scoped — sub-agent serves never validate main edits.
 
-**Content-addressed.** `canon(line)` strips ASCII whitespace, `xxh32 → 62³=238,328` anchors. Re-inserting identical text keeps its hash; `prettier`/`eslint --fix` between edits doesn't invalidate. Unique by bitset probing — `}`/`import` repeats never collide; cap `238,328` lines (`[E_FILE_TOO_LARGE]`).
+**Content-addressed.** `canon(line)` strips ASCII whitespace, `xxh32 → 62³=238,328` anchors. Re-inserting identical text keeps its hash; `prettier`/`eslint --fix` between edits doesn't invalidate. Unique by bitset probing — `}`/`import` repeats never collide; cap `238,328` lines (`[E_LARGE_FILE]`).
 
 **No loop, no ritual.** No-op → `No changes made`; same no-op ×3 → `[E_NOOP_LOOP]`. Diff/echo/rejection rows count as serves — `read` is recovery, not ritual.
 
@@ -189,13 +189,14 @@ Single stochastic run, `opencode-go/gpt-5.6-luna` high. [Artifact](https://githu
 
 | Code | Meaning |
 | --- | --- |
-| `[E_BAD_SHAPE]`/`[E_BAD_REF]` | Bad tuple shape or not bare `3-char` |
-| `[E_STALE_ANCHOR]`/`[E_AMBIGUOUS_ANCHOR]` | No line / multi-line → `read` |
-| `[E_EDIT_HASH_ECHO]`/`[E_WRITE_HASH_ECHO]` | Copied `HASH│` from same session/path/line — strip and retry |
-| `[E_WOULD_EMPTY]`/`[E_NOT_FOUND]`/`[E_ACCESS]`/`[E_NOT_TEXT]`/`[E_FILE_TOO_LARGE]` | Empty guard / missing / access / binary / >238,328 lines |
-| `[E_BAD_OP]`/`[E_INVALID_PATCH]`/`[E_BARE_HASH_PREFIX]` | Swapped range / `+HASH│` patch marker (auto-corrected) |
+| `[E_BAD_PAYLOAD]` | Bad tuple shape (payload must be `{path, edits}` with 3-position tuples) |
+| `[E_STALE_ANCHOR]` | No line (hash/tombstone/canon miss) / multi-line → `read` |
+| `[E_BAD_ANCHOR]` | Not bare `3-char`, or `replacement_text` carries `HASH│`/diff-preview prefixes — refused, remove and retry |
+| `[E_SERVED_ECHO]` | Copied `HASH│` from same session/path/line — refused, remove and retry |
+| `[E_EMPTY_RANGE]`/`[E_NOT_FOUND]`/`[E_ACCESS]`/`[E_UNSUPPORTED_FILE]`/`[E_LARGE_FILE]` | Empty guard / missing / access / binary / >238,328 lines |
+| `[E_REVERSED_ANCHORS]` | Swapped range — healed with dimmed `[USER]` notice on success, otherwise refused |
 | `[E_BAD_ENCODING]`/`[E_DECODE_FAILED]` | Encoding / decode failed |
-| `[E_NOT_OBSERVED]`/`[E_RANGE_STALE]`/`[E_RANGE_UNSERVED]`/`[E_RANGE_UNVERIFIED]` | Served-state miss — echoed fresh `HASH│content` |
+| `[E_NOT_OBSERVED]`/`[E_STALE_RANGE]`/`[E_UNSERVED_RANGE]` | Served-state miss — echoed fresh `HASH│content` |
 | `[E_UNDO_STALE]`/`[E_UNDO_UNAVAILABLE]` | Undo stale / unavailable |
 | `[E_NOOP_LOOP]`/`[E_BATCH_ABORT]` | 3× same no-op / atomic batch fail → nothing written |
 

--- a/docs/absorption-plan.md
+++ b/docs/absorption-plan.md
@@ -53,3 +53,33 @@
 - Downstream deep seams: `src/hashline/`, `src/file-view.ts`, `src/session-view.ts`, `src/mutation.ts`, `src/hash-store.ts` (hashAssign), `src/hashline/anchor-pipeline.ts`
 - ADRs to port: `docs/adr/0005-whitespace-insensitive-anchors.md`, `0006→0007 merged payload`, `0008 orphaned heal` (copy+adapt, not verbatim)
 - Verification gates: `npm run typecheck`, `npm test` (vitest), `npm run build` (T7 only). Use `.lsz/tmp` for scratch, never repo root.
+
+## Sync 2026-09-05 — pi-better-edit v1.2.1 → v1.6.0 (audit triage)
+
+**Basis:** `pi-better-edit@7b9195851..87a17eb` (64 commits, v1.2.1 → v1.6.0). Downstream is `dsh-better-edit@0.6.3`. Prior checkpoint `7b91958` absorbed via 0.3.x–0.6.x cherry-picks (#38 boundary-dup removal, #42 tombstone). Decisions: preserve deep seams (AnchorPipeline, SessionView, FileView, Mutation, contract.ts, guidance/) — port behavior, never structure; keep payload contract `{path, edits:[[h,h,t]]}` and `CANON_VERSION=2`.
+
+### Already absorbed (no action)
+
+- #54 boundary-dup removal → 0.6.0 (#38) + ADR-0007.
+- #56 tombstone+epoch core → 0.6.1 (#42) + ADR-0013.
+- ADR-0009 echo guard → ADR-0005 + `write-hook.ts` (upstream cites our #29).
+- ADR-0010 batch-note filtering → `edit-response.ts` strips `Batch drift note:` from model content (partial — full details-only routing moves to T1).
+- #70 dense re-serve after write → covered by design (write hook auto-reads full file via `readAndServe`); verify with test in T4 lane.
+
+### Ignored by design
+
+- v1.4.0/v1.5.0 arch deepening (MutationEngine, ServedSession, FileContent, LifecycleHooks, payload-contract module, tui-presenter) — structural divergence, intentional.
+- Scaffold/CI (semantic-release, husky tolerance, pre-push, coverage thresholds, node 22) — ours is tag-first + own release script.
+- v1.2.x lens P1–P7 + docs (Obsidian prompt merge, format normalization) — upstream-internal.
+- ADR-0002 store-seam amendment — structural, no semantic change.
+
+### Tickets (branch per ticket, worktree per branch, base `main`)
+
+| Ticket | Branch | Issue | Upstream source | Seam | Acceptance |
+| -------- | -------- | ------- | ----------------- | ------ | ------------ |
+| **T1 — audience split + code renames** | `absorb/t1-audience` | #45 | `dd1a779` (ADR-0014), `b0bcf0b` | error codes repo-wide, `edit-response.ts`, `CONTEXT.md`, new ADR, `guidance/` | old-code grep zero hits in `src/`; tests on new codes + `[MODEL]`/`[USER]`; `typecheck+vitest` green |
+| **T2 — canon-deficit drift** | `absorb/t2-drift-canon` | #46 | `95c4703`, `3d0ba99` | `session-view.ts` (`computeDrift`/`scanDrift` + `servedCanons` threading) | duplicate-line sequential edits silent; true loss reported; `typecheck+vitest` green |
+| **T3 — Gemma bleed hardening** | `absorb/t3-gemma` | #47 | `e67f493` | `prompts.ts`, `contract.ts` (`sanitizePath`) | `EDIT_DESCRIPTION.length < 800`; wrapped-path tests; `typecheck+vitest` green |
+| **T4 — epoch full-read gating** | `absorb/t4-epoch` | #48 | `3918292` | `read-and-serve.ts` (`clearDriftReported` gate), `mutation.ts` zero-serve check | partial preserves drift-reported; full clears; `typecheck+vitest` green |
+
+Integration: merge T1→T2→T3→T4 onto `main` sequentially (T1 first — it renames codes the others touch), `npm run build` on final lane, single PR per ticket with `Closes #NN`.

--- a/docs/adr/0014-user-model-audience.md
+++ b/docs/adr/0014-user-model-audience.md
@@ -1,0 +1,29 @@
+# User/model audience split and glossary-aligned error codes
+
+Date: 2026-09-05 (adapted for dsh-better-edit from pi-better-edit ADR-0014, `dd1a779`)
+
+## Status
+
+accepted (adapted for dsh-better-edit — AnchorPipeline, SessionView, contract.ts, edit-response.ts)
+
+## Context
+
+`E_*` codes mixed `noun+adj` (`E_RANGE_STALE`) with `adj+noun` (`E_STALE_ANCHOR`), overloaded one code for distinct misses (`E_RANGE_UNSERVED` interior hole vs `E_RANGE_UNVERIFIED` boundary miss), retained dead `E_AMBIGUOUS_ANCHOR` (probing + per-session `tombstone` makes file duplicates impossible except synthetic collision), and triplicated anchor-syntax (`E_BARE_HASH_PREFIX`/`E_INVALID_PATCH`/`E_BAD_REF`) as auto-heal warnings — the tool silently rewriting `replacement_text`, violating `model–tool boundary`. `E_NOT_TEXT` leaked an affordance (`Use ls…`); `E_EDIT_HASH_ECHO`/`E_WRITE_HASH_ECHO` split one concept across tools. Our ADR-0013 (tombstone epoch, `canon`+`snapshotId`, position-free verify) made the staleness model `tombstone∉ && canon==` + `snapshotId` epoch, but the surface kept the old names. Our ADR-0006 already defined `model-facing signal` vs `user-facing signal` and filtered `Batch drift note:` from model content — the audience axis exists, the codes did not follow it.
+
+## Decision
+
+**Display-layer audience, glossary `adj+noun` family, no alias.**
+
+- **Audience is display-layer only.** Thrown error `content` carries `[MODEL] [E_*]` (the model must retry); `warnings`/`driftNotice` in `details` carry `[USER]` (human-only, dimmed where the renderer supports it — our dsh plugin has no theme seam, so the prefix is the cue). Raw codes stay bare `E_*` anywhere they are matched programmatically (`String.includes`, `details`, `ServedCode`, `ServedRejectionError.code`).
+- **`adj+noun` renames (no alias):** `E_BAD_SHAPE→E_BAD_PAYLOAD`, `E_NOT_TEXT→E_UNSUPPORTED_FILE` (directory message trimmed of `Use ls…`; the encoding Top-3 retry hint stays — it is the actionable retry, not an affordance), `E_FILE_TOO_LARGE→E_LARGE_FILE`, `E_WOULD_EMPTY→E_EMPTY_RANGE`, `E_EDIT_HASH_ECHO`/`E_WRITE_HASH_ECHO→E_SERVED_ECHO`, `E_BAD_OP→E_REVERSED_ANCHORS` (healed `[USER] … swapped (healed)` vs throw `[MODEL] … Range start …`), `E_RANGE_STALE→E_STALE_RANGE`, `E_RANGE_UNSERVED`+`E_RANGE_UNVERIFIED→E_UNSERVED_RANGE` (with `ServedRejectionError.unservedKind`: `"boundary"` for the old cannot-verify-range case, `"interior"` for the never-served-line case), `E_AMBIGUOUS_ANCHOR→E_STALE_ANCHOR` (collision keeps line list + re-read retry), `E_BARE_HASH_PREFIX`/`E_INVALID_PATCH`/`E_BAD_REF→E_BAD_ANCHOR` (single anchor-syntax code, now `throw` not heal).
+- **Heal→throw boundary.** `resEdit` block-hash extraction, `HASH│`/diff-prefix anchor parsing, `stripBarePrefixes`, `stripDiffPrefixes` now throw `[MODEL] [E_BAD_ANCHOR]` instead of pushing heal warnings. Only `swapReversedRanges` keeps healed success (`[USER] [E_REVERSED_ANCHORS] … swapped (healed)`). The strips throw `BadAnchorError` carrying the stripped edit so `applyEdit` can distinguish served-echo (re-checked at the resolved start line → `[MODEL] [E_SERVED_ECHO]` denial) from garbage (`E_BAD_ANCHOR` stands) — the served-echo guard keeps its range-relative precision, no behavior loss.
+- **Glossary realignment (`CONTEXT.md`, `README.md`):** `boundary staleness` → `anchor staleness` (one-line miss), `range staleness` → `served-range staleness` (span mismatch, `E_STALE_RANGE`/`E_UNSERVED_RANGE` + `reject-and-serve`), `served range` alias for `served span`, merged `E_SERVED_ECHO` entry, trimmed `E_UNSUPPORTED_FILE`.
+- **Deferred (no upstream precedent):** `E_NOOP_LOOP`, `E_BATCH_ABORT`, `E_UNDO_STALE`/`E_UNDO_UNAVAILABLE`, `E_NOT_OBSERVED`, `E_BAD_ENCODING`/`E_DECODE_FAILED` keep bare codes — dsh-specific families outside ADR-0014's scope.
+
+## Consequences
+
+- `src/hashline/anchor-pipeline.ts`: `ServedCode` is `"E_STALE_RANGE"|"E_UNSERVED_RANGE"`; `ServedRejectionError` gains `unservedKind`; new exported `BadAnchorError`; `applyEdit` wraps strips with the echo-fallback catch.
+- `src/session-view.ts`: `DRIFT_NOTICE_HEADING` is `[USER] drift:`; drift stays details-only (ADR-0006 routing extended, batch note retired from user surface).
+- `CONTEXT.md` Language, `README.md` error table, `src/prompts.ts`/`src/guidance/` wording follow the new names.
+- Tests assert new codes + `[MODEL]`/`[USER]` prefixes; removed-heal tests assert throws; healed-reverse test asserts `[USER]` success.
+- Breaking for any downstream matching old codes (fail-loud by design — stale codes never match silently since matching is substring on the new names).

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,5 +12,5 @@ export const SERVED_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 export const SERVED_ECHO_CAP = 150;
 export const NOOP_LOOP_THRESHOLD = 3;
 export const NEW_CONTENT_NOT_STRING_MSG =
-	`[E_BAD_SHAPE] "replacement_text" must be a string with \\n line separators, not an array.` +
+	`[MODEL] [E_BAD_PAYLOAD] "replacement_text" must be a string with \\n line separators, not an array.` +
 	` Do not pass an array of lines — pass the replacement text as one string: "line1\\nline2". Use "" to delete a range.`;

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -2,7 +2,7 @@
  * One module owns the request shapes for the hashline tools — edit,
  * read, undo_last_edit — plus their validation. Field sets are
  * declared once here; every tool validates through these asserts, and the
- * [E_BAD_SHAPE] vocabulary is shared instead of re-implemented per tool.
+ * [E_BAD_PAYLOAD] vocabulary is shared instead of re-implemented per tool.
  *
  * Contract now mirrors upstream ADR-0007: {path: string|null, edits: [[remove_from,remove_to,replacement_text],...]} tuple payload,
  * single-file, atomic. batch_edit is removed.
@@ -149,52 +149,52 @@ export function prepareEditArguments(args: unknown): Record<string, unknown> {
   if (valid) {
     return { path: valid.path, edits: (args as Record<string, unknown>).edits };
   }
-  throw new Error(`[E_BAD_SHAPE] ${EDIT_TUPLE_HINT} ${describeReceived(args)}`);
+  throw new Error(`[MODEL] [E_BAD_PAYLOAD] ${EDIT_TUPLE_HINT} ${describeReceived(args)}`);
 }
 
 // ---- assertions ---------------------------------------------------------------
 
 export function assertEditRequest(request: unknown): asserts request is NormalizedEditRequest {
   if (!isNormalizedEdit(request)) {
-    throw new Error("[E_BAD_SHAPE] Edit request must be exactly { path, edits: [[remove_from, remove_to, replacement_text], ...] }.");
+    throw new Error("[MODEL] [E_BAD_PAYLOAD] Edit request must be exactly { path, edits: [[remove_from, remove_to, replacement_text], ...] }.");
   }
   rejectUnknownFields(request as Record<string, unknown>, EDIT_KS, "Edit request");
   const req = request as NormalizedEditRequest;
   if (req.path !== null && (typeof req.path !== "string" || req.path.length === 0)) {
-    throw new Error('[E_BAD_SHAPE] Edit request path must be a non-empty string or null.');
+    throw new Error('[MODEL] [E_BAD_PAYLOAD] Edit request path must be a non-empty string or null.');
   }
   if (!Array.isArray(req.edits) || req.edits.length === 0) {
-    throw new Error('[E_BAD_SHAPE] Edit request requires a non-empty "edits" array.');
+    throw new Error('[MODEL] [E_BAD_PAYLOAD] Edit request requires a non-empty "edits" array.');
   }
   if (req.edits.length > EDITS_MAX_ITEMS) {
-    throw new Error(`[E_BAD_SHAPE] edit accepts at most ${EDITS_MAX_ITEMS} edits; got ${req.edits.length}. Split the batch.`);
+    throw new Error(`[MODEL] [E_BAD_PAYLOAD] edit accepts at most ${EDITS_MAX_ITEMS} edits; got ${req.edits.length}. Split the batch.`);
   }
   for (let index = 0; index < req.edits.length; index++) {
     const item = req.edits[index]!;
     if (typeof item.remove_from !== "string" || typeof item.remove_to !== "string" || typeof item.replacement_text !== "string") {
-      throw new Error(`[E_BAD_SHAPE] Edit request edits[${index}] must be a three-position array [remove_from, remove_to, replacement_text].`);
+      throw new Error(`[MODEL] [E_BAD_PAYLOAD] Edit request edits[${index}] must be a three-position array [remove_from, remove_to, replacement_text].`);
     }
   }
 }
 
 // legacy — now always fails with new shape message (batch_edit removed)
 export function assertBatchEditRequest(_request: unknown): asserts _request is BatchEditParams {
-  throw new Error("[E_BAD_SHAPE] batch_edit has been removed. Use edit with { path, edits: [[remove_from, remove_to, replacement_text], ...] }.");
+  throw new Error("[MODEL] [E_BAD_PAYLOAD] batch_edit has been removed. Use edit with { path, edits: [[remove_from, remove_to, replacement_text], ...] }.");
 }
 
 export function assertReadRequest(request: unknown): asserts request is ReadParams {
-  if (!isRec(request)) throw new Error("[E_BAD_SHAPE] Read request must be an object.");
+  if (!isRec(request)) throw new Error("[MODEL] [E_BAD_PAYLOAD] Read request must be an object.");
   rejectUnknownFields(request, READ_KS, "Read request");
   if (typeof request.path !== "string" || request.path.length === 0) {
-    throw new Error('[E_BAD_SHAPE] Read request requires a non-empty "path" string.');
+    throw new Error('[MODEL] [E_BAD_PAYLOAD] Read request requires a non-empty "path" string.');
   }
 }
 
 export function assertUndoRequest(request: unknown): asserts request is UndoParams {
-  if (!isRec(request)) throw new Error("[E_BAD_SHAPE] undo_last_edit request must be an object.");
+  if (!isRec(request)) throw new Error("[MODEL] [E_BAD_PAYLOAD] undo_last_edit request must be an object.");
   normalizeFilePath(request);
   if (typeof request.path !== "string" || request.path.length === 0) {
-    throw new Error('[E_BAD_SHAPE] undo_last_edit request requires a non-empty "path" string.');
+    throw new Error('[MODEL] [E_BAD_PAYLOAD] undo_last_edit request requires a non-empty "path" string.');
   }
 }
 

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -232,7 +232,7 @@ export async function detectWithChardet(bytes: Uint8Array, allowlist: string[]):
 	}
 }
 /**
- * Chardet-based Top-3 for E_NOT_TEXT (primary) and autoGuess.
+ * Chardet-based Top-3 for E_UNSUPPORTED_FILE (primary) and autoGuess.
  * Returns chardet candidates filtered by allowlist and decodable, else empty.
  */
 export async function chardetTop3Candidates(bytes: Uint8Array, allowlist: string[]): Promise<Array<{ encoding: string; confidence: number; sample: string }>> {

--- a/src/file-encoding-state.ts
+++ b/src/file-encoding-state.ts
@@ -71,7 +71,7 @@ export function invalidateIfStale(targetKey: string, currentVersion: string | un
 
 export function buildTop3ErrorMessage(displayPath: string, candidates: CandidatePreview[]): string {
   const candStr = candidates.map((c) => `${c.encoding}("${c.sample.slice(0, 20).replace(/"/g, "'")}")`).join(", ");
-  return `[E_NOT_TEXT] Path is not a readable UTF-8 text file: ${displayPath}. Hashline editing only supports text files. Top-3 guesses: ${candStr}. Try read({encoding: "<encoding>"}) or set DSH_BETTER_EDIT_AUTO_GUESS_ENCODING=true to auto-decode.`;
+  return `[MODEL] [E_UNSUPPORTED_FILE] Path is not a readable UTF-8 text file: ${displayPath}. Hashline editing only supports text files. Top-3 guesses: ${candStr}. Try read({encoding: "<encoding>"}) or set DSH_BETTER_EDIT_AUTO_GUESS_ENCODING=true to auto-decode.`;
 }
 
 function buildAutoGuessFooterFromCandidates(candidates: Array<{ encoding: string; confidence?: number; score?: number; sample?: string }>): string {
@@ -122,7 +122,7 @@ export interface DecodeForOpenOptions {
 /**
  * Deterministic admission for a raw byte buffer. No IO, no side effects
  * except Top-3 scoring. Caller owns recording the returned state via
- * `recordOpenState` and handling the footer vs E_NOT_TEXT split.
+ * `recordOpenState` and handling the footer vs E_UNSUPPORTED_FILE split.
  *
  * Order is fixed: BOM sniff always precedes strict UTF-8, which always
  * precedes guessing. Probabilistic encodings are last resort, gated by
@@ -247,10 +247,10 @@ export async function decodeForOpen(
         };
       }
     }
-    // No candidate succeeded — fall through to E_NOT_TEXT with Top-3
+    // No candidate succeeded — fall through to E_UNSUPPORTED_FILE with Top-3
   }
 
-  // 5) E_NOT_TEXT + Top-3 always pushed (even when autoGuess off)
+  // 5) E_UNSUPPORTED_FILE + Top-3 always pushed (even when autoGuess off)
   // Use chardet Top-3 when available, else heuristic Top-3 — same as fs-bridge fallback
   let candidates: CandidatePreview[] = [];
   try {

--- a/src/file-view.ts
+++ b/src/file-view.ts
@@ -256,7 +256,7 @@ export async function loadFileKindAndText(
         }
         if (newlineCount > options.maxLines) {
           throw new Error(
-            `[E_FILE_TOO_LARGE] ${options.displayPath ?? filePath} has more than ${options.maxLines} lines, exceeding the ${options.maxLines}-line edit limit. Hashline editing targets source-sized files; for very large files use write or a non-line-based approach.`,
+            `[MODEL] [E_LARGE_FILE] ${options.displayPath ?? filePath} has more than ${options.maxLines} lines, exceeding the ${options.maxLines}-line edit limit. Hashline editing targets source-sized files; for very large files use write or a non-line-based approach.`,
           );
         }
       }
@@ -301,28 +301,28 @@ export async function valAccess(
   } catch (error: unknown) {
     const code = errCode(error);
     if (code === "ENOENT") {
-      throw new Error(`[E_NOT_FOUND] File not found: ${path}`);
+      throw new Error(`[MODEL] [E_NOT_FOUND] File not found: ${path}`);
     }
     if (code === "EACCES" || code === "EPERM") {
       const accessLabel = accessMode & constants.W_OK ? "not writable" : "not readable";
-      throw new Error(`[E_ACCESS] File is ${accessLabel}: ${path}`);
+      throw new Error(`[MODEL] [E_ACCESS] File is ${accessLabel}: ${path}`);
     }
     if (code === "ELOOP") {
-      throw new Error(`[E_ACCESS] Too many symbolic links while resolving: ${path}`);
+      throw new Error(`[MODEL] [E_ACCESS] Too many symbolic links while resolving: ${path}`);
     }
-    throw new Error(`[E_ACCESS] Cannot access file: ${path}`);
+    throw new Error(`[MODEL] [E_ACCESS] Cannot access file: ${path}`);
   }
 }
 
 export function valKind(file: LFile, path: string): asserts file is { kind: "text"; text: string; hadUtf8DecodeErrors?: true } {
   if (file.kind === "directory") {
-    throw new Error(`[E_NOT_TEXT] Path is a directory: ${path}. Use ls to inspect directories.`);
+    throw new Error(`[MODEL] [E_UNSUPPORTED_FILE] Path is a directory: ${path}.`);
   }
   if (file.kind === "binary") {
-    throw new Error(`[E_NOT_TEXT] Path is a binary file: ${path} (${file.description}). Hashline edit only supports text files.`);
+    throw new Error(`[MODEL] [E_UNSUPPORTED_FILE] Path is a binary file: ${path} (${file.description}). Hashline edit only supports text files.`);
   }
   if (file.kind === "image") {
-    throw new Error(`[E_NOT_TEXT] Path is an image file: ${path}. Hashline edit only supports text files.`);
+    throw new Error(`[MODEL] [E_UNSUPPORTED_FILE] Path is an image file: ${path}. Hashline edit only supports text files.`);
   }
 }
 
@@ -396,7 +396,7 @@ export async function normFromText(input: {
     const lineCount = visLines(normalized).length;
     if (lineCount > input.maxLines) {
       throw new Error(
-        `[E_FILE_TOO_LARGE] ${displayPath} has ${lineCount} lines, exceeding the ${input.maxLines}-line edit limit. Hashline editing targets source-sized files; for very large files use write or a non-line-based approach.`,
+        `[MODEL] [E_LARGE_FILE] ${displayPath} has ${lineCount} lines, exceeding the ${input.maxLines}-line edit limit. Hashline editing targets source-sized files; for very large files use write or a non-line-based approach.`,
       );
     }
   }
@@ -461,7 +461,7 @@ function normPosInt(
   if (value === undefined) return undefined;
   if (!Number.isInteger(value) || value < 1) {
     throw new Error(
-      `[E_BAD_SHAPE] Read request field "${name}" must be a positive integer.`,
+      `[MODEL] [E_BAD_PAYLOAD] Read request field "${name}" must be a positive integer.`,
     );
   }
   return value;

--- a/src/fs-bridge.ts
+++ b/src/fs-bridge.ts
@@ -110,14 +110,14 @@ export function mapFsError(error: unknown, displayPath: string): never {
   ) {
     const code = (error as unknown as { code: string }).code;
     if (code === "FS_NOT_FOUND") {
-      throw new Error(`[E_NOT_FOUND] File not found: ${displayPath}`);
+      throw new Error(`[MODEL] [E_NOT_FOUND] File not found: ${displayPath}`);
     }
     if (code === "FS_PERMISSION_DENIED") {
-      throw new Error(`[E_ACCESS] Cannot access file: ${displayPath}`);
+      throw new Error(`[MODEL] [E_ACCESS] Cannot access file: ${displayPath}`);
     }
     if (code === "FS_NOT_TEXT" || code === "FS_NOT_REGULAR_FILE") {
       throw new Error(
-        `[E_NOT_TEXT] Path is not a readable UTF-8 text file: ${displayPath}. Hashline editing only supports text files. Try read({encoding: "gbk"}) or enable autoGuessEncoding.`,
+        `[MODEL] [E_UNSUPPORTED_FILE] Path is not a readable UTF-8 text file: ${displayPath}. Hashline editing only supports text files. Try read({encoding: "gbk"}) or enable autoGuessEncoding.`,
       );
     }
     if (code === "FS_BAD_ENCODING") {
@@ -128,7 +128,7 @@ export function mapFsError(error: unknown, displayPath: string): never {
     }
     if (code === "FS_STALE_VERSION") {
       throw new Error(
-        `[E_RANGE_STALE] The file changed on disk since it was read (version guard rejected the write). Call read() to get fresh anchors, then retry.`,
+        `[MODEL] [E_STALE_RANGE] The file changed on disk since it was read (version guard rejected the write). Call read() to get fresh anchors, then retry.`,
       );
     }
     if (code === "FS_NOT_OBSERVED") {
@@ -359,7 +359,7 @@ export function localIO(): FileIO {
         if (decoded.footer) recordFooter(absolutePath, decoded.footer);
         return decoded.text;
       }
-      // Deterministic path via seam, with local fallback for E_NOT_TEXT when autoGuess off
+      // Deterministic path via seam, with local fallback for E_UNSUPPORTED_FILE when autoGuess off
       try {
         const bytes = await readFile(absolutePath);
         const cfgL = loadConfig();
@@ -369,8 +369,8 @@ export function localIO(): FileIO {
         if (decoded.footer) recordFooter(absolutePath, decoded.footer);
         return decoded.text;
       } catch (error) {
-        // Local fallback: when autoGuess off, E_NOT_TEXT should fall back to raw UTF-8 with � (no throw)
-        if (error instanceof Error && error.message.includes("[E_NOT_TEXT]")) {
+        // Local fallback: when autoGuess off, E_UNSUPPORTED_FILE should fall back to raw UTF-8 with � (no throw)
+        if (error instanceof Error && error.message.includes("[E_UNSUPPORTED_FILE]")) {
           return readFile(absolutePath, "utf-8");
         }
         throw error;

--- a/src/hashline/anchor-pipeline.ts
+++ b/src/hashline/anchor-pipeline.ts
@@ -29,11 +29,11 @@ function diagRef(ref: string): string {
 	const trimmed = ref.trim();
 
 	if (!trimmed.length) {
-		return `[E_BAD_REF] Invalid anchor. Expected a 3-char alphanumeric anchor (e.g. "aB3").`;
+		return `[MODEL] [E_BAD_ANCHOR] Invalid anchor. Expected a 3-char alphanumeric anchor (e.g. "aB3").`;
 	}
 
 	if (/^\d+/.test(trimmed)) {
-		return `[E_BAD_REF] Invalid anchor. Use the hash alone (e.g. "aB3") — no line numbers or trailing content.`;
+		return `[MODEL] [E_BAD_ANCHOR] Invalid anchor. Use the hash alone (e.g. "aB3") — no line numbers or trailing content.`;
 	}
 
 	if (trimmed.includes("│") && trimmed.includes("\n")) {
@@ -46,13 +46,13 @@ function diagRef(ref: string): string {
 		const firstHash = firstMatch?.[0] ?? "wUp";
 		const lastHash = lastMatch?.[0] ?? "AU6";
 		const preview = first.slice(0, 60);
-		return `[E_BAD_REF] Invalid anchor — remove_from must be a single bare 3-char hash (e.g. "wUp"), not a block with HASH│. Received ${lines.length} lines starting "${preview}…" — use only the first hash "${firstHash}" as remove_from and "${lastHash}" as remove_to, and put the new content (without HASH│) in replacement_text.`;
+		return `[MODEL] [E_BAD_ANCHOR] Invalid anchor — remove_from must be a single bare 3-char hash (e.g. "wUp"), not a block with HASH│. Received ${lines.length} lines starting "${preview}…" — use only the first hash "${firstHash}" as remove_from and "${lastHash}" as remove_to, and put the new content (without HASH│) in replacement_text.`;
 	}
 	if (trimmed.includes("│")) {
-		return `[E_BAD_REF] Invalid anchor "${trimmed}". remove_from and remove_to must contain the 3-char hash only — remove everything from "│" onward.`;
+		return `[MODEL] [E_BAD_ANCHOR] Invalid anchor "${trimmed}". remove_from and remove_to must contain the 3-char hash only — remove everything from "│" onward.`;
 	}
 
-	return `[E_BAD_REF] Invalid anchor "${trimmed}". Expected a 3-char alphanumeric anchor (e.g. "aB3").`;
+	return `[MODEL] [E_BAD_ANCHOR] Invalid anchor "${trimmed}". Expected a 3-char alphanumeric anchor (e.g. "aB3").`;
 }
 
 function parseRef(ref: string): Anchor {
@@ -165,7 +165,7 @@ function fmtMismatchWithServes(
 	const refList = notFound.map((m) => `"${m.ref.hash}"`).join(", ");
 	if (notFound.length > 0) {
 		out.push(
-			`[E_STALE_ANCHOR] ${notFound.length} stale anchor${notFound.length > 1 ? "s" : ""}${filePath ? ` in ${filePath}` : ""}: ${refList}. Re-read for fresh anchors.`,
+			`[MODEL] [E_STALE_ANCHOR] ${notFound.length} stale anchor${notFound.length > 1 ? "s" : ""}${filePath ? ` in ${filePath}` : ""}: ${refList}. Re-read for fresh anchors.`,
 		);
 		for (const m of notFound) {
 			const ctx = m.context;
@@ -188,7 +188,7 @@ function fmtMismatchWithServes(
 	if (ambiguous.length > 0) {
 		if (out.length > 0) out.push("");
 		out.push(
-			`[E_AMBIGUOUS_ANCHOR] ${ambiguous.length} ambiguous anchor${ambiguous.length > 1 ? "s" : ""}${filePath ? ` in ${filePath}` : ""}. Re-read for fresh anchors.`,
+			`[MODEL] [E_STALE_ANCHOR] ${ambiguous.length} ambiguous anchor${ambiguous.length > 1 ? "s" : ""}${filePath ? ` in ${filePath}` : ""}. Re-read for fresh anchors.`,
 		);
 		for (const m of ambiguous) {
 			const sample = (m.candidates ?? []).slice(0, 5);
@@ -224,17 +224,17 @@ function assertItem(edit: Record<string, unknown>): void {
 
 	if ("remove_from" in edit && typeof edit.remove_from !== "string") {
 		throw new Error(
-			`[E_BAD_SHAPE] Field "remove_from" must be an anchor string (3-char hash).`,
+			`[MODEL] [E_BAD_PAYLOAD] Field "remove_from" must be an anchor string (3-char hash).`,
 		);
 	}
 	if ("remove_to" in edit && typeof edit.remove_to !== "string") {
 		throw new Error(
-			`[E_BAD_SHAPE] Field "remove_to" must be an anchor string (3-char hash).`,
+			`[MODEL] [E_BAD_PAYLOAD] Field "remove_to" must be an anchor string (3-char hash).`,
 		);
 	}
 	if (!("replacement_text" in edit)) {
 		throw new Error(
-			`[E_BAD_SHAPE] The edit requires a "replacement_text" field. Provide the replacement text (use "" to delete).`,
+			`[MODEL] [E_BAD_PAYLOAD] The edit requires a "replacement_text" field. Provide the replacement text (use "" to delete).`,
 		);
 	}
 	if (typeof edit.replacement_text !== "string") {
@@ -245,7 +245,7 @@ function assertItem(edit: Record<string, unknown>): void {
 		typeof edit.remove_to !== "string"
 	) {
 		throw new Error(
-			`[E_BAD_SHAPE] The edit requires "remove_from" and "remove_to" anchor strings (3-char hashes from read output).`,
+			`[MODEL] [E_BAD_PAYLOAD] The edit requires "remove_from" and "remove_to" anchor strings (3-char hashes from read output).`,
 		);
 	}
 }
@@ -261,7 +261,7 @@ function firstHashFromBlock(block: string): string | undefined {
 	return undefined;
 }
 
-export function resEdit(edit: HTEdit, warnings?: string[]): HEdit {
+export function resEdit(edit: HTEdit, _warnings?: string[]): HEdit {
 	assertItem(edit as Record<string, unknown>);
 
 	const editLines = parseText(edit.replacement_text);
@@ -271,22 +271,20 @@ export function resEdit(edit: HTEdit, warnings?: string[]): HEdit {
 			const hash = firstHashFromBlock(trimmed);
 			if (hash) {
 				const lines = trimmed.split("\n").length;
-				warnings?.push(`[E_BAD_REF] extracted first hash "${hash}" from ${lines}-line block — use bare "${hash}" next time`);
-				return hash;
+				throw new Error(`[MODEL] [E_BAD_ANCHOR] extracted first hash "${hash}" from ${lines}-line block — use bare "${hash}" next time`);
 			}
 		}
 		const match = trimmed.match(ANCHOR_ROW_RE);
 		if (match) {
 			let message: string;
 			if (match[1] === "+") {
-				message = `[E_BAD_REF] stripped diff-preview marker from remove_from/remove_to "${trimmed}".`;
+				message = `[E_BAD_ANCHOR] stripped diff-preview marker from remove_from/remove_to "${trimmed}".`;
 			} else if (match[1] === "-") {
-				message = `[E_BAD_REF] stripped leading "-" marker from remove_from/remove_to "${trimmed}".`;
+				message = `[E_BAD_ANCHOR] stripped leading "-" marker from remove_from/remove_to "${trimmed}".`;
 			} else {
-				message = `[E_BAD_REF] stripped "HASH│" prefix from remove_from/remove_to "${trimmed}".`;
+				message = `[E_BAD_ANCHOR] stripped "HASH│" prefix from remove_from/remove_to "${trimmed}".`;
 			}
-			warnings?.push(message);
-			return match[2]!;
+			throw new Error(`[MODEL] ${message}`);
 		}
 		return ref;
 	}) as [string, string];
@@ -308,7 +306,7 @@ function warnUnicodeEsc(edit: HEdit, warnings: string[]): void {
 function stripBarePrefixes(
 	edit: HEdit,
 	fileHashes: string[],
-	warnings: string[],
+	_warnings: string[],
 ): HEdit {
 	const fileHashSet = new Set(fileHashes);
 	const stripped: { lineIndex: number; matched: boolean }[] = [];
@@ -325,19 +323,13 @@ function stripBarePrefixes(
 	const matchedCount = stripped.filter((s) => s.matched).length;
 	const evidence = matchedCount === 0 ? "0 matched — verify literal 'HASH│' content" : `${matchedCount}/${stripped.length} matched`;
 	if (matchedCount === stripped.length) {
-		warnings.push(
-			`[info E_BARE_HASH_PREFIX] stripped "HASH│" prefix from ${locations} (${evidence}) — use bare content without HASH│ next time.`,
-		);
-	} else {
-		warnings.push(
-			`[E_BARE_HASH_PREFIX] stripped "HASH│" prefix from ${locations} (${evidence}).`,
-		);
+		throw new BadAnchorError(`[MODEL] [E_BAD_ANCHOR] stripped "HASH│" prefix from ${locations} (${evidence}) — use bare content without HASH│ next time.`, { ...edit, content_lines: contentLines });
 	}
-	return { ...edit, content_lines: contentLines };
+	throw new BadAnchorError(`[MODEL] [E_BAD_ANCHOR] stripped "HASH│" prefix from ${locations} (${evidence}).`, { ...edit, content_lines: contentLines });
 }
 
 /** @internal — private to anchor-pipeline seam */
-function stripDiffPrefixes(edit: HEdit, warnings: string[]): HEdit {
+function stripDiffPrefixes(edit: HEdit, _warnings: string[]): HEdit {
 	const stripped: number[] = [];
 	const contentLines = edit.content_lines.map((line, lineIndex) => {
 		const plus = line.match(HL_PREFIX_PLUS_RE);
@@ -356,10 +348,7 @@ function stripDiffPrefixes(edit: HEdit, warnings: string[]): HEdit {
 	const locations = stripped
 		.map((i) => `replacement_text line ${i + 1}`)
 		.join(", ");
-	warnings.push(
-		`[E_INVALID_PATCH] stripped diff-preview marker from ${locations}.`,
-	);
-	return { ...edit, content_lines: contentLines };
+	throw new BadAnchorError(`[MODEL] [E_BAD_ANCHOR] stripped diff-preview marker from ${locations}.`, { ...edit, content_lines: contentLines });
 }
 
 /** @internal — private to anchor-pipeline seam */
@@ -383,7 +372,7 @@ function swapReversedRanges(
 		return edit;
 	}
 	warnings.push(
-		`[E_BAD_OP] reversed remove_from/remove_to (${startRef.hash} after ${endRef.hash}); swapped.`,
+		`[USER] [E_REVERSED_ANCHORS] reversed remove_from/remove_to (${startRef.hash} after ${endRef.hash}); swapped (healed).`,
 	);
 	return { ...edit, hash_bounds: [endRef, startRef] as [Anchor, Anchor] };
 }
@@ -440,7 +429,7 @@ function valEdit(
 	}
 	if (startResolved.line > endResolved.line) {
 		throw new Error(
-			`[E_BAD_OP] Range start line ${startResolved.line} must be <= end line ${endResolved.line} (anchors ${edit.hash_bounds[0].hash} and ${edit.hash_bounds[1].hash}).`,
+			`[MODEL] [E_REVERSED_ANCHORS] Range start line ${startResolved.line} must be <= end line ${endResolved.line} (anchors ${edit.hash_bounds[0].hash} and ${edit.hash_bounds[1].hash}).`,
 		);
 	}
 	const endLine = endResolved.line;
@@ -459,9 +448,8 @@ export { warnUnicodeEsc };
 
 
 export type ServedCode =
-	| "E_RANGE_STALE"
-	| "E_RANGE_UNSERVED"
-	| "E_RANGE_UNVERIFIED";
+	| "E_STALE_RANGE"
+	| "E_UNSERVED_RANGE";
 
 export interface ServedRow {
 	position: number;
@@ -470,11 +458,13 @@ export interface ServedRow {
 
 export class ServedRejectionError extends Error {
 	readonly code: ServedCode;
+	readonly unservedKind: "boundary" | "interior" | undefined;
 	readonly firstOffendingLine: number | undefined;
 	readonly servedRows: ServedRow[];
 
 	constructor(opts: {
 		code: ServedCode;
+		unservedKind?: "boundary" | "interior";
 		message: string;
 		firstOffendingLine?: number;
 		servedRows: ServedRow[];
@@ -482,6 +472,7 @@ export class ServedRejectionError extends Error {
 		super(opts.message);
 		this.name = "ServedRejectionError";
 		this.code = opts.code;
+		this.unservedKind = opts.unservedKind;
 		this.firstOffendingLine = opts.firstOffendingLine;
 		this.servedRows = opts.servedRows;
 	}
@@ -500,6 +491,18 @@ export class AnchorMismatchError extends Error {
 		super(message);
 		this.name = "AnchorMismatchError";
 		this.servedRows = servedRows;
+	}
+}
+
+/** Thrown when replacement_text carries anchor-syntax garbage (HASH│/diff-preview prefixes).
+ * Carries the stripped edit so applyEdit can distinguish served-echo (→ E_SERVED_ECHO
+ * denial downstream) from garbage (→ E_BAD_ANCHOR stands). */
+export class BadAnchorError extends Error {
+	readonly stripped: HEdit;
+	constructor(message: string, stripped: HEdit) {
+		super(message);
+		this.name = "BadAnchorError";
+		this.stripped = stripped;
 	}
 }
 
@@ -621,8 +624,8 @@ export function verifyServedRange(args: {
 				const actual = canon(fileLines[pos] ?? "");
 				if (expected !== undefined && expected !== null && expected !== actual) {
 					throw new ServedRejectionError({
-						code: "E_RANGE_STALE",
-						message: `[E_RANGE_STALE] anchor "${tombstonedHash}" was freed since last full read (tombstoned, canon changed from "${expected}" to "${actual}"). Re-read.\nCurrent range:\n${echo}`,
+						code: "E_STALE_RANGE",
+						message: `[MODEL] [E_STALE_RANGE] anchor "${tombstonedHash}" was freed since last full read (tombstoned, canon changed from "${expected}" to "${actual}"). Re-read.\nCurrent range:\n${echo}`,
 						firstOffendingLine: pos + 1,
 						servedRows: echoRows,
 					});
@@ -777,9 +780,10 @@ export function verifyServedRange(args: {
 				);
 			}
 			throw new ServedRejectionError({
-				code: "E_RANGE_UNVERIFIED",
+				code: "E_UNSERVED_RANGE",
+				unservedKind: "boundary",
 				message:
-					`[E_RANGE_UNVERIFIED] cannot verify range against served state${where}: ${problems.join("; ")}. ` +
+					`[MODEL] [E_UNSERVED_RANGE] cannot verify range against served state${where}: ${problems.join("; ")}. ` +
 					`No served span matched the current range (${currentLen} lines). ` +
 					`A full read will re-sync the served mirror — the echoed range below is current content, ` +
 					`but retrying without re-reading cannot clear a stale duplicate outside the echoed window.\n` +
@@ -798,8 +802,8 @@ export function verifyServedRange(args: {
 			if (expectedCanon !== undefined && expectedCanon !== actualCanon) {
 				const offendingLine = from + k + 1;
 				throw new ServedRejectionError({
-					code: "E_RANGE_STALE",
-					message: `[E_RANGE_STALE] line ${offendingLine}${where} differs from what was served.\nCurrent range:\n${echo}\n${retryHint()}`,
+					code: "E_STALE_RANGE",
+					message: `[MODEL] [E_STALE_RANGE] line ${offendingLine}${where} differs from what was served.\nCurrent range:\n${echo}\n${retryHint()}`,
 					firstOffendingLine: offendingLine,
 					servedRows: echoRows,
 				});
@@ -809,8 +813,9 @@ export function verifyServedRange(args: {
 		for (let i = from; i <= to; i++) {
 			if (served[i] === null) {
 				throw new ServedRejectionError({
-					code: "E_RANGE_UNSERVED",
-					message: `[E_RANGE_UNSERVED] line ${i + 1}${where} was never served.\nCurrent range:\n${echo}\n${retryHint()}`,
+					code: "E_UNSERVED_RANGE",
+					unservedKind: "interior",
+					message: `[MODEL] [E_UNSERVED_RANGE] line ${i + 1}${where} was never served.\nCurrent range:\n${echo}\n${retryHint()}`,
 					firstOffendingLine: i + 1,
 					servedRows: echoRows,
 				});
@@ -850,8 +855,8 @@ export function verifyServedRange(args: {
 			}
 			if (!lenHealed) {
 				throw new ServedRejectionError({
-					code: "E_RANGE_STALE",
-					message: `[E_RANGE_STALE] served span (${servedLen} lines) no longer matches current range (${currentLen} lines)${where}.\nCurrent range:\n${echo}\n${retryHint()}`,
+					code: "E_STALE_RANGE",
+					message: `[MODEL] [E_STALE_RANGE] served span (${servedLen} lines) no longer matches current range (${currentLen} lines)${where}.\nCurrent range:\n${echo}\n${retryHint()}`,
 					firstOffendingLine: startLine,
 					servedRows: echoRows,
 				});
@@ -860,8 +865,8 @@ export function verifyServedRange(args: {
 		// Strict pos check for concurrency (pos-free vs strict)
 		if (strictPos && from !== startLine - 1) {
 			throw new ServedRejectionError({
-				code: "E_RANGE_STALE",
-				message: `[E_RANGE_STALE] anchor was served at line ${from + 1} but now resolves to line ${startLine} (pos-restricted concurrency). Re-read.\nCurrent range:\n${echo}`,
+				code: "E_STALE_RANGE",
+				message: `[MODEL] [E_STALE_RANGE] anchor was served at line ${from + 1} but now resolves to line ${startLine} (pos-restricted concurrency). Re-read.\nCurrent range:\n${echo}`,
 				firstOffendingLine: startLine,
 				servedRows: echoRows,
 			});
@@ -874,8 +879,8 @@ export function verifyServedRange(args: {
 					const actual = canon(fileLines[startLine - 1 + k] ?? "");
 					if (expected !== actual) {
 						throw new ServedRejectionError({
-							code: "E_RANGE_STALE",
-							message: `[E_RANGE_STALE] line ${startLine + k}${where} canon differs from served (expected "${expected}" vs actual "${actual}").\nCurrent range:\n${echo}`,
+							code: "E_STALE_RANGE",
+							message: `[MODEL] [E_STALE_RANGE] line ${startLine + k}${where} canon differs from served (expected "${expected}" vs actual "${actual}").\nCurrent range:\n${echo}`,
 							firstOffendingLine: startLine + k,
 							servedRows: echoRows,
 						});
@@ -891,8 +896,8 @@ export function verifyServedRange(args: {
 				const actualCanon = canon(fileLines[startLine - 1 + k] ?? "");
 				if (expectedCanon !== undefined && expectedCanon !== null && expectedCanon !== actualCanon) {
 					throw new ServedRejectionError({
-						code: "E_RANGE_STALE",
-						message: `[E_RANGE_STALE] line ${startLine + k}${where} uses tombstoned anchor "${h}" (freed since last full read, canon changed). Re-read.\nCurrent range:\n${echo}`,
+						code: "E_STALE_RANGE",
+						message: `[MODEL] [E_STALE_RANGE] line ${startLine + k}${where} uses tombstoned anchor "${h}" (freed since last full read, canon changed). Re-read.\nCurrent range:\n${echo}`,
 						firstOffendingLine: startLine + k,
 						servedRows: echoRows,
 					});
@@ -903,8 +908,8 @@ export function verifyServedRange(args: {
 			if (served[from + k] !== fileHashes[startLine - 1 + k]) {
 				const offendingLine = startLine + k;
 				throw new ServedRejectionError({
-					code: "E_RANGE_STALE",
-					message: `[E_RANGE_STALE] line ${offendingLine}${where} differs from what was served.\nCurrent range:\n${echo}\n${retryHint()}`,
+					code: "E_STALE_RANGE",
+					message: `[MODEL] [E_STALE_RANGE] line ${offendingLine}${where} differs from what was served.\nCurrent range:\n${echo}\n${retryHint()}`,
 					firstOffendingLine: offendingLine,
 					servedRows: echoRows,
 				});
@@ -974,7 +979,7 @@ type NoopSpan = {
 function assertNotEmpty(originalContent: string, result: string): void {
 	if (originalContent.length > 0 && result.length === 0) {
 		throw new Error(
-			"[E_WOULD_EMPTY] Cannot empty a non-empty file via edit. Use `write` if you need to clear the file.",
+			"[MODEL] [E_EMPTY_RANGE] Cannot empty a non-empty file via edit. Use `write` if you need to clear the file.",
 		);
 	}
 }
@@ -1088,10 +1093,30 @@ export function applyEdit(
 	const warnings: string[] = [];
 
 	const rangeFixed = swapReversedRanges(edit, fileHashes, warnings);
-	const prefixFixed = stripDiffPrefixes(
-		stripBarePrefixes(rangeFixed, fileHashes, warnings),
-		warnings,
-	);
+	let prefixFixed: HEdit;
+	try {
+		prefixFixed = stripDiffPrefixes(
+			stripBarePrefixes(rangeFixed, fileHashes, warnings),
+			warnings,
+		);
+	} catch (error) {
+		if (!(error instanceof BadAnchorError) || !served) throw error;
+		// Anchor-syntax garbage that is actually served-echo belongs to the
+		// E_SERVED_ECHO guard below: re-check the stripped + raw lines at the
+		// resolved start line and throw the echo denial; otherwise E_BAD_ANCHOR stands.
+		const stripped = error.stripped;
+		const lineByHash = new Map<string, number>();
+		for (let i = 0; i < fileHashes.length; i++) lineByHash.set(fileHashes[i]!, i + 1);
+		const startLine = lineByHash.get(stripped.hash_bounds[0].hash);
+		const echo =
+			(startLine !== undefined ? findEditHashEcho(edit.content_lines, served, startLine) : undefined) ??
+			(startLine !== undefined ? findEditHashEcho(stripped.content_lines, served, startLine) : undefined);
+		if (echo) {
+			const msg = `[MODEL] [E_SERVED_ECHO] Refused edit to ${filePath ?? "(unknown file)"}: replacement line ${echo.k} begins with the exact ${echo.hash}${HASH_SEP} anchor served for this session, path, and range-relative line. Remove the copied anchors and retry. Nothing was written.`;
+			throw new EditHashEchoError(msg, []);
+		}
+		throw error;
+	}
 
 	const {
 		resolved: initialResolved,
@@ -1118,7 +1143,7 @@ if (served) {
 		if (!echo) echo = findEditHashEcho(resolved.content_lines, served, startLineEcho);
 		if (!echo) echo = findEditHashEcho(prefixFixed.content_lines, served, startLineEcho);
 		if (echo) {
-			const msg = `[E_EDIT_HASH_ECHO] Refused edit to ${filePath ?? "(unknown file)"}: replacement line ${echo.k} begins with the exact ${echo.hash}${HASH_SEP} anchor served for this session, path, and range-relative line. Remove the copied anchors and retry. Nothing was written.`;
+			const msg = `[MODEL] [E_SERVED_ECHO] Refused edit to ${filePath ?? "(unknown file)"}: replacement line ${echo.k} begins with the exact ${echo.hash}${HASH_SEP} anchor served for this session, path, and range-relative line. Remove the copied anchors and retry. Nothing was written.`;
 			throw new EditHashEchoError(msg, []);
 		}
 		const startAnchor = resolved.hash_bounds[0];

--- a/src/hashline/hash-assign.ts
+++ b/src/hashline/hash-assign.ts
@@ -120,7 +120,7 @@ function nextZeroBit(bits: Uint32Array, start: number): number {
     idx += HASH_PROBE_STRIDE;
     if (idx >= totalBits) idx -= totalBits;
   }
-  throw new Error(`[E_FILE_TOO_LARGE] Cannot allocate a unique hash anchor: the file exceeds the ${HASH_SPACE}-line limit for ${HASH_LEN}-char hashline anchors.`);
+  throw new Error(`[MODEL] [E_LARGE_FILE] Cannot allocate a unique hash anchor: the file exceeds the ${HASH_SPACE}-line limit for ${HASH_LEN}-char hashline anchors.`);
 }
 function assignHash(used: Uint32Array, baseIdx: number, hint: { value: number }): string {
   if (!getBit(used, baseIdx)) {

--- a/src/mutation/engine.ts
+++ b/src/mutation/engine.ts
@@ -119,12 +119,12 @@ export async function resolveMissingPath(
 	if (matches.length === 1) {
 		return {
 			path: matches[0]!,
-			warning: `[E_BAD_SHAPE] Autocorrected: missing "path" resolved to ${matches[0]} — the only file whose stored hashes contain both anchors.`,
+			warning: `[MODEL] [E_BAD_PAYLOAD] Autocorrected: missing "path" resolved to ${matches[0]} — the only file whose stored hashes contain both anchors.`,
 		};
 	}
 	if (matches.length > 1) {
 		throw new Error(
-			`[E_BAD_SHAPE] Edit request requires a non-empty "path" string; the anchors match multiple known files: ${matches.join(', ')}. Include the intended path.`,
+			`[MODEL] [E_BAD_PAYLOAD] Edit request requires a non-empty "path" string; the anchors match multiple known files: ${matches.join(', ')}. Include the intended path.`,
 		);
 	}
 	return undefined;

--- a/src/session-view.ts
+++ b/src/session-view.ts
@@ -332,7 +332,7 @@ export function currentPositionOfDrifted(served: (string | null)[], currentPosit
 	return servedIndex + delta;
 }
 
-export const DRIFT_NOTICE_HEADING = "drift:";
+export const DRIFT_NOTICE_HEADING = "[USER] drift:";
 
 export interface DriftRow extends ServedRow {
 	content: string;

--- a/src/tool-edit.ts
+++ b/src/tool-edit.ts
@@ -33,14 +33,14 @@ async function resolveNullPath(edits: Array<{ remove_from: string; remove_to: st
     if (matches.length === 1) {
       return {
         path: matches[0]!,
-        warning: `[E_BAD_SHAPE] Autocorrected: missing "path" resolved to ${matches[0]} — the only file whose stored hashes contain both anchors.`,
+        warning: `[MODEL] [E_BAD_PAYLOAD] Autocorrected: missing "path" resolved to ${matches[0]} — the only file whose stored hashes contain both anchors.`,
       };
     }
     if (matches.length > 1) {
-      throw new Error(`[E_BAD_SHAPE] Edit request requires a non-empty "path" string; the anchors match multiple known files: ${matches.join(", ")}. Include the intended path.`);
+      throw new Error(`[MODEL] [E_BAD_PAYLOAD] Edit request requires a non-empty "path" string; the anchors match multiple known files: ${matches.join(", ")}. Include the intended path.`);
     }
   } catch (e) {
-    if (e instanceof Error && e.message.startsWith("[E_BAD_SHAPE]")) throw e;
+    if (e instanceof Error && e.message.includes("[E_BAD_PAYLOAD]")) throw e;
     return undefined;
   }
   return undefined;
@@ -85,7 +85,7 @@ export function buildEditTool(io: FileIO, sandbox: FsSandboxController) {
             resolvedPath = resolved.path;
             pathWarning = resolved.warning;
           } else {
-            throw new Error("[E_BAD_SHAPE] Edit request path is null and could not be inferred from anchors — anchors match no known file. Include the intended path.");
+            throw new Error("[MODEL] [E_BAD_PAYLOAD] Edit request path is null and could not be inferred from anchors — anchors match no known file. Include the intended path.");
           }
         }
         const sandboxPolicy = await sandbox.resolvePolicy(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -32,7 +32,7 @@ export function rejectUnknownFields(
   if (unknown.length > 0) {
     const suffix = hint ? ` ${hint}` : "";
     throw new Error(
-      `[E_BAD_SHAPE] ${label} contains unknown or unsupported fields: ${unknown.join(", ")}.${suffix}`,
+      `[MODEL] [E_BAD_PAYLOAD] ${label} contains unknown or unsupported fields: ${unknown.join(", ")}.${suffix}`,
     );
   }
 }

--- a/src/write-hook.ts
+++ b/src/write-hook.ts
@@ -64,7 +64,7 @@ export async function servedHashEchoDenial(
 	const match = findServedHashEcho(content, served)
 	if (!match) return undefined
 	return (
-		`[E_WRITE_HASH_ECHO] Refused write to ${rawPath}: line ${match.line} begins with ` +
+		`[MODEL] [E_SERVED_ECHO] Refused write to ${rawPath}: line ${match.line} begins with ` +
 		`the exact ${match.hash}${HASH_SEP} anchor served for this session, path, and line. ` +
 		`HASH${HASH_SEP} anchors are tool output, not file content. ` +
 		'Retry with file content only (remove the entire copied anchor chain). Nothing was written.'

--- a/test/core/coverage-agent-a-write-hook.test.ts
+++ b/test/core/coverage-agent-a-write-hook.test.ts
@@ -99,7 +99,7 @@ describe("write-hook coverage agent-a", () => {
         const sessionKey = "sess-e-" + Math.random();
         const preview = await withWorkspace(cwd, () => readAndServe(io, file, cwd, { sessionKey }));
         const denial = await withWorkspace(cwd, () => servedHashEchoDenial(io, file, preview.text, cwd, sessionKey));
-        expect(denial).toContain("E_WRITE_HASH_ECHO");
+        expect(denial).toContain("E_SERVED_ECHO");
         expect(denial).toContain(file);
       } finally {
         shutdownHashStore();
@@ -197,7 +197,7 @@ describe("write-hook coverage agent-a", () => {
         const nextPre3 = vi.fn(async () => ({ kind: "allow" } as PreToolDecision));
         const dec3 = await pre({ name: "write", arguments: { file_path: file, content: preview.text }, signal: new AbortController().signal, agent: { id: sessionKey, session: { id: sessionKey, header: { cwd: dir } } } } as any, nextPre3);
         expect(dec3.kind).toBe("deny");
-        expect((dec3 as any).reason).toContain("E_WRITE_HASH_ECHO");
+        expect((dec3 as any).reason).toContain("E_SERVED_ECHO");
         expect(nextPre3).not.toHaveBeenCalled();
 
         // missing path/content -> next

--- a/test/core/coverage-agent-b-fs-bridge.test.ts
+++ b/test/core/coverage-agent-b-fs-bridge.test.ts
@@ -45,11 +45,11 @@ describe("mapFsError", () => {
   });
   it("maps FS_NOT_TEXT", () => {
     const err = Object.assign(new Error("x"), { code: "FS_NOT_TEXT" });
-    expect(() => mapFsError(err, "a.txt")).toThrow(/E_NOT_TEXT/);
+    expect(() => mapFsError(err, "a.txt")).toThrow(/E_UNSUPPORTED_FILE/);
   });
   it("maps FS_NOT_REGULAR_FILE", () => {
     const err = Object.assign(new Error("x"), { code: "FS_NOT_REGULAR_FILE" });
-    expect(() => mapFsError(err, "a.txt")).toThrow(/E_NOT_TEXT/);
+    expect(() => mapFsError(err, "a.txt")).toThrow(/E_UNSUPPORTED_FILE/);
   });
   it("maps FS_BAD_ENCODING", () => {
     const err = Object.assign(new Error("x"), { code: "FS_BAD_ENCODING" });
@@ -61,7 +61,7 @@ describe("mapFsError", () => {
   });
   it("maps FS_STALE_VERSION", () => {
     const err = Object.assign(new Error("x"), { code: "FS_STALE_VERSION" });
-    expect(() => mapFsError(err, "a.txt")).toThrow(/E_RANGE_STALE/);
+    expect(() => mapFsError(err, "a.txt")).toThrow(/E_STALE_RANGE/);
   });
   it("maps FS_NOT_OBSERVED", () => {
     const err = Object.assign(new Error("x"), { code: "FS_NOT_OBSERVED" });
@@ -208,7 +208,7 @@ describe("ctxFsIO", () => {
     });
     const ctx: any = makeCtx();
     const io = ctxFsIO(fs, ctx);
-    await expect(io.writeText("/abs/file.txt", "c")).rejects.toThrow(/E_RANGE_STALE/);
+    await expect(io.writeText("/abs/file.txt", "c")).rejects.toThrow(/E_STALE_RANGE/);
   });
 
   it("emitObserved emits when stat succeeds", async () => {

--- a/test/core/coverage-agent-b-tool-edit.test.ts
+++ b/test/core/coverage-agent-b-tool-edit.test.ts
@@ -57,18 +57,18 @@ describe("tool-edit coverage", () => {
         expect(await readFile(path, "utf-8")).toContain("replaced");
       } catch (e) {
         // if multiple matches or no match, error is expected
-        expect((e as Error).message).toMatch(/E_BAD_SHAPE/);
+        expect((e as Error).message).toMatch(/E_BAD_PAYLOAD/);
       }
     });
   });
 
-  it("resolveNullPath with unknown hashes throws E_BAD_SHAPE", async () => {
+  it("resolveNullPath with unknown hashes throws E_BAD_PAYLOAD", async () => {
     await withTempFile("t.txt", "a\nb\n", async ({ cwd }) => {
       const io = localIO();
       const sandbox = new FsSandboxController({ fs: { sandboxMode: undefined }, get: ()=>undefined } as never);
       const tool = buildEditTool(io, sandbox);
       const exec = makeExec(cwd);
-      await expect(tool.execute({ path: null, edits: [["zzz", "zzz", "x"]] } as any, exec)).rejects.toThrow(/E_BAD_SHAPE/);
+      await expect(tool.execute({ path: null, edits: [["zzz", "zzz", "x"]] } as any, exec)).rejects.toThrow(/E_BAD_PAYLOAD/);
     });
   });
 

--- a/test/core/coverage-agent-c-anchor-pipeline.test.ts
+++ b/test/core/coverage-agent-c-anchor-pipeline.test.ts
@@ -14,7 +14,7 @@ import { initHasher } from "../../src/hashline/hash-assign.js";
 
 describe("coverage: anchor-pipeline parseHashRef / diagRef branches", () => {
   it("rejects empty and numeric anchors", () => {
-    expect(() => parseHashRef("")).toThrow(/E_BAD_REF.*Invalid anchor/);
+    expect(() => parseHashRef("")).toThrow(/E_BAD_ANCHOR.*Invalid anchor/);
     expect(() => parseHashRef("123abc")).toThrow(/no line numbers/);
     expect(() => parseHashRef("ab")).toThrow(/Expected a 3-char/);
     expect(() => parseHashRef("toolong!")).toThrow(/Expected a 3-char/);
@@ -36,30 +36,27 @@ describe("coverage: anchor-pipeline parseHashRef / diagRef branches", () => {
 });
 
 describe("coverage: anchor-pipeline resEdit warnings", () => {
-  it("strips HASH│ prefix from remove_from/to and warns", () => {
-    const warnings: string[] = [];
-    const edit: any = { remove_from: "abc│content", remove_to: "def│content", replacement_text: "new" };
-    const res = resEdit(edit, warnings);
-    expect(res.hash_bounds[0].hash).toBe("abc");
-    expect(res.hash_bounds[1].hash).toBe("def");
-    expect(warnings.some((w) => w.includes("stripped"))).toBe(true);
-  });
-  it("strips diff markers +/- and warns", () => {
-    const w1: string[] = [];
-    resEdit({ remove_from: "+abc│x", remove_to: "abc", replacement_text: "y" } as any, w1);
-    expect(w1.some((w) => w.includes("diff-preview"))).toBe(true);
-    const w2: string[] = [];
-    resEdit({ remove_from: "-abc│x", remove_to: "abc", replacement_text: "y" } as any, w2);
-    expect(w2.some((w) => w.includes("leading \"-\""))).toBe(true);
-  });
-  it("extracts first hash from multiline block", () => {
-    const warnings: string[] = [];
-    const block = "abc│first\nother line\ndef│second";
-    const edit: any = { remove_from: block, remove_to: "def", replacement_text: "new" };
-    const res = resEdit(edit, warnings);
-    expect(res.hash_bounds[0].hash).toBe("abc");
-    expect(warnings.some((w) => w.includes("extracted first hash"))).toBe(true);
-  });
+	it("rejects HASH│ prefix in remove_from/to with E_BAD_ANCHOR", () => {
+		const warnings: string[] = [];
+		const edit: any = { remove_from: "abc│content", remove_to: "def│content", replacement_text: "new" };
+		expect(() => resEdit(edit, warnings)).toThrow(/\[E_BAD_ANCHOR\]/);
+		expect(warnings).toEqual([]);
+	});
+	it("rejects diff markers +/- in anchors with E_BAD_ANCHOR", () => {
+		const w1: string[] = [];
+		expect(() => resEdit({ remove_from: "+abc│x", remove_to: "abc", replacement_text: "y" } as any, w1)).toThrow(/\[E_BAD_ANCHOR\]/);
+		expect(() => resEdit({ remove_from: "+abc│x", remove_to: "abc", replacement_text: "y" } as any, w1)).toThrow(/diff-preview/);
+		const w2: string[] = [];
+		expect(() => resEdit({ remove_from: "-abc│x", remove_to: "abc", replacement_text: "y" } as any, w2)).toThrow(/\[E_BAD_ANCHOR\]/);
+		expect(() => resEdit({ remove_from: "-abc│x", remove_to: "abc", replacement_text: "y" } as any, w2)).toThrow(/leading "-"/);
+	});
+	it("rejects multiline anchor block with E_BAD_ANCHOR", () => {
+		const warnings: string[] = [];
+		const block = "abc│first\nother line\ndef│second";
+		const edit: any = { remove_from: block, remove_to: "def", replacement_text: "new" };
+		expect(() => resEdit(edit, warnings)).toThrow(/\[E_BAD_ANCHOR\]/);
+		expect(() => resEdit(edit, warnings)).toThrow(/extracted first hash/);
+	});
   it("rejects missing fields", () => {
     // remove_from must be string
     expect(() => resEdit({ remove_from: 123 as any, remove_to: "abc", replacement_text: "x" } as any)).toThrow();
@@ -79,15 +76,13 @@ describe("coverage: anchor-pipeline resEdit warnings", () => {
 });
 
 describe("coverage: anchor-pipeline applyEdit", () => {
-  it("strips bare HASH│ prefixes from content lines and warns", () => {
-    const content = "a\nb\nc";
-    const hashes = lineHashesPure(content);
-    const edit: any = { hash_bounds: [{ hash: hashes[0]! }, { hash: hashes[0]! }], content_lines: [`${hashes[1]!}│b`, "new line"] };
-    const result = applyEdit(content, edit, undefined, hashes);
-    // should have stripped prefix from first replacement line
-    expect(result.warnings?.some((w) => w.includes("HASH│"))).toBe(true);
-    expect(result.content).toContain("new line");
-  });
+	it("rejects bare HASH│ prefixes in content lines with E_BAD_ANCHOR", () => {
+		const content = "a\nb\nc";
+		const hashes = lineHashesPure(content);
+		const edit: any = { hash_bounds: [{ hash: hashes[0]! }, { hash: hashes[0]! }], content_lines: [`${hashes[1]!}│b`, "new line"] };
+		expect(() => applyEdit(content, edit, undefined, hashes)).toThrow(/\[E_BAD_ANCHOR\]/);
+		expect(() => applyEdit(content, edit, undefined, hashes)).toThrow(/HASH│/);
+	});
 
   it("strips diff +/- prefixes from content lines", () => {
     const content = "a\nb\nc";
@@ -135,7 +130,7 @@ describe("coverage: anchor-pipeline applyEdit", () => {
     const dupHashes = [...hashes];
     dupHashes[2] = hashes[0]!;
     const edit: any = { hash_bounds: [{ hash: hashes[0]! }, { hash: hashes[0]! }], content_lines: ["X"] };
-    expect(() => applyEdit(content, edit, undefined, dupHashes)).toThrow(/E_AMBIGUOUS_ANCHOR/);
+    expect(() => applyEdit(content, edit, undefined, dupHashes)).toThrow(/E_STALE_ANCHOR/);
   });
 
   it("detects edit hash echo and throws", () => {
@@ -144,7 +139,7 @@ describe("coverage: anchor-pipeline applyEdit", () => {
     const served = [...hashes];
     // make replacement start with served hash + │
     const edit: any = { hash_bounds: [{ hash: hashes[0]! }, { hash: hashes[0]! }], content_lines: [`${hashes[0]!}│a`, "new"] };
-    expect(() => applyEdit(content, edit, undefined, hashes, "file.txt", served as any)).toThrow(/E_EDIT_HASH_ECHO/);
+    expect(() => applyEdit(content, edit, undefined, hashes, "file.txt", served as any)).toThrow(/E_SERVED_ECHO/);
   });
 
   it("noop returns noopEdit", () => {
@@ -161,7 +156,7 @@ describe("coverage: anchor-pipeline applyEdit", () => {
     const content = "a";
     const hashes = lineHashesPure(content);
     const edit: any = { hash_bounds: [{ hash: hashes[0]! }, { hash: hashes[0]! }], content_lines: [] };
-    expect(() => applyEdit(content, edit, undefined, hashes)).toThrow(/E_WOULD_EMPTY/);
+    expect(() => applyEdit(content, edit, undefined, hashes)).toThrow(/E_EMPTY_RANGE/);
   });
   it("findNewEdge stub returns undefined (boundaryDups removed)", () => {
     expect(findNewEdge(["new", "b", "c"], ["b", "c"], false)).toBeUndefined();
@@ -198,7 +193,7 @@ describe("coverage: anchor-pipeline verifyServedRange / buildRangeEcho", () => {
     expect(txt).toContain("│a");
   });
 
-  it("verifyServedRange throws E_RANGE_UNVERIFIED when no served positions", () => {
+  it("verifyServedRange throws E_UNSERVED_RANGE when no served positions", () => {
     const content = "a\nb\nc";
     const hashes = lineHashesPure(content);
     const served: (string | null)[] = [null, null, null];
@@ -212,10 +207,10 @@ describe("coverage: anchor-pipeline verifyServedRange / buildRangeEcho", () => {
         fileHashes: hashes,
         fileLines: ["a", "b", "c"],
       }),
-    ).toThrow(/E_RANGE_UNVERIFIED/);
+    ).toThrow(/E_UNSERVED_RANGE/);
   });
 
-  it("verifyServedRange throws E_RANGE_UNSERVED when served null in range", () => {
+  it("verifyServedRange throws E_UNSERVED_RANGE when served null in range", () => {
     const content = "a\nb\nc";
     const hashes = lineHashesPure(content);
     // served has one null inside verified span
@@ -230,7 +225,7 @@ describe("coverage: anchor-pipeline verifyServedRange / buildRangeEcho", () => {
         fileHashes: hashes,
         fileLines: ["a", "b", "c"],
       }),
-    ).toThrow(/E_RANGE_UNSERVED/);
+    ).toThrow(/E_UNSERVED_RANGE/);
   });
 
   it("verifyServedRange succeeds when served matches", () => {
@@ -250,7 +245,7 @@ describe("coverage: anchor-pipeline verifyServedRange / buildRangeEcho", () => {
     ).not.toThrow();
   });
 
-  it("verifyServedRange detects E_RANGE_STALE when hashes differ", () => {
+  it("verifyServedRange detects E_STALE_RANGE when hashes differ", () => {
     const content = "a\nb\nc";
     const hashes = lineHashesPure(content);
     // modify hashes to simulate stale
@@ -267,6 +262,6 @@ describe("coverage: anchor-pipeline verifyServedRange / buildRangeEcho", () => {
         fileHashes: staleHashes,
         fileLines: ["a", "b", "c"],
       }),
-    ).toThrow(/E_RANGE_STALE/);
+    ).toThrow(/E_STALE_RANGE/);
   });
 });

--- a/test/core/coverage-agent-c-contract.test.ts
+++ b/test/core/coverage-agent-c-contract.test.ts
@@ -72,13 +72,13 @@ describe("coverage: contract.ts", () => {
 
   it("prepareEditArguments throws with hint on bad shape", () => {
     expect(() => prepareEditArguments({ path: "a", edits: [["a", "b", "c"]] })).not.toThrow();
-    expect(() => prepareEditArguments(null)).toThrow(/E_BAD_SHAPE/);
-    expect(() => prepareEditArguments({ path: "", edits: [] } as any)).toThrow(/E_BAD_SHAPE/);
+    expect(() => prepareEditArguments(null)).toThrow(/E_BAD_PAYLOAD/);
+    expect(() => prepareEditArguments({ path: "", edits: [] } as any)).toThrow(/E_BAD_PAYLOAD/);
     expect(() => prepareEditArguments("bare string" as any)).toThrow(/Received a bare string/);
     expect(() => prepareEditArguments(undefined as any)).toThrow(/Received no arguments/);
     expect(() => prepareEditArguments(null as any)).toThrow(/Received null/);
     const longInput = { path: "a", edits: "bad" as any, extra: "x".repeat(200) };
-    expect(() => prepareEditArguments(longInput)).toThrow(/E_BAD_SHAPE/);
+    expect(() => prepareEditArguments(longInput)).toThrow(/E_BAD_PAYLOAD/);
   });
 
   it("assertEditRequest validates all fields", () => {
@@ -86,7 +86,7 @@ describe("coverage: contract.ts", () => {
     expect(() => assertEditRequest(good)).not.toThrow();
 
     // not normalized
-    expect(() => assertEditRequest({ path: "a", edits: [{ remove_from: "a", remove_to: "b", replacement_text: "c" }] } as any)).toThrow(/E_BAD_SHAPE/);
+    expect(() => assertEditRequest({ path: "a", edits: [{ remove_from: "a", remove_to: "b", replacement_text: "c" }] } as any)).toThrow(/E_BAD_PAYLOAD/);
 
     // unknown fields
     const withExtra = { ...good as any, extraField: "bad" };

--- a/test/core/coverage-agent-c-edit-engine.test.ts
+++ b/test/core/coverage-agent-c-edit-engine.test.ts
@@ -156,7 +156,7 @@ describe("coverage: edit-engine applyOne", () => {
       },
       async (err) => { rejected = err; throw err as any; },
     ).catch(() => {});
-    expect(String(rejected)).toMatch(/E_STALE_ANCHOR|E_BAD_REF|AnchorMismatch/);
+    expect(String(rejected)).toMatch(/E_STALE_ANCHOR|E_BAD_ANCHOR|AnchorMismatch/);
   });
 
   it("noop detection keeps original hashes", async () => {

--- a/test/core/coverage-agent-e-fixtures3.test.ts
+++ b/test/core/coverage-agent-e-fixtures3.test.ts
@@ -39,7 +39,7 @@ describe("coverage-agent-e fixtures3", () => {
   it("wrapEdit handles no edits and no remove_from", async () => {
     await withTempFile("a.txt", "hi", async ({ cwd }) => {
       const harness: any = setupIntegrationTest(cwd);
-      // No edits and no remove_from should go to base.execute with same params and then throw E_BAD_SHAPE
+      // No edits and no remove_from should go to base.execute with same params and then throw E_BAD_PAYLOAD
       await expect(harness.editTool.execute("edit", { path: "a.txt" } as any)).rejects.toThrow();
       await expect(harness.editTool.execute("edit", { path: "a.txt", edits: [] } as any)).rejects.toThrow();
     });

--- a/test/core/coverage-agent-e-fs-bridge.test.ts
+++ b/test/core/coverage-agent-e-fs-bridge.test.ts
@@ -51,7 +51,7 @@ describe("coverage-agent-e fs-bridge", () => {
     });
   });
 
-  it("autoGuess disabled surfaces top-3 E_NOT_TEXT", async () => {
+  it("autoGuess disabled surfaces top-3 E_UNSUPPORTED_FILE", async () => {
     setAutoGuessEnv(false);
     await withTempFile("a.txt", "hi", async ({ cwd }) => {
       const gbkBytes = iconv.encode("你好世界 hello world 你好世界", "gbk");
@@ -72,8 +72,8 @@ describe("coverage-agent-e fs-bridge", () => {
       const harness = setupIntegrationTest(cwd);
       const res = await harness.readTool.execute("read", { path: "gbk2.txt" } as any);
       const txt = getText(res);
-      // should auto-decode without E_NOT_TEXT, and set memo
-      expect(txt).not.toMatch(/\[E_NOT_TEXT\]/);
+      // should auto-decode without E_UNSUPPORTED_FILE, and set memo
+      expect(txt).not.toMatch(/\[E_UNSUPPORTED_FILE\]/);
       expect(txt.length).toBeGreaterThan(5);
       // footer may be present for mid-confidence
       const footer = getAutoGuessFooter(`tk:${join(cwd, "gbk2.txt")}`) ?? getAutoGuessFooter(join(cwd, "gbk2.txt"));
@@ -160,7 +160,7 @@ describe("coverage-agent-e fs-bridge", () => {
     });
   });
 
-  it("ctxFsIO autoGuess disabled surfaces E_NOT_TEXT via mocked fs", async () => {
+  it("ctxFsIO autoGuess disabled surfaces E_UNSUPPORTED_FILE via mocked fs", async () => {
     const { ctxFsIO, clearEncodingState, clearAutoGuessFooter } = await import("../../src/fs-bridge.js");
     const { _resetConfigCache } = await import("../../src/store-config.js");
     delete process.env.DSH_BETTER_EDIT_AUTO_GUESS_ENCODING;
@@ -176,7 +176,7 @@ describe("coverage-agent-e fs-bridge", () => {
     };
     const fakeCtx: any = { waterfall: async () => undefined, emit: () => {} };
     const io = ctxFsIO(fakeFs, fakeCtx);
-    await expect(io.readText("/abs/gbk.txt")).rejects.toThrow(/E_NOT_TEXT|Top-3/);
+    await expect(io.readText("/abs/gbk.txt")).rejects.toThrow(/E_UNSUPPORTED_FILE|Top-3/);
   });
 
   it("ctxFsIO autoGuess true decodes gbk via mocked fs", async () => {

--- a/test/core/coverage-agent-e-tool.test.ts
+++ b/test/core/coverage-agent-e-tool.test.ts
@@ -5,7 +5,7 @@ describe("coverage-agent-e tool", () => {
   it("tool-edit validation", async () => {
     await withTempFile("a.txt", "hello", async ({ cwd }) => {
       const harness = setupIntegrationTest(cwd);
-      await expect(harness.editTool.execute("edit", { path: "a.txt", edits: [] } as any)).rejects.toThrow(/E_BAD_SHAPE/);
+      await expect(harness.editTool.execute("edit", { path: "a.txt", edits: [] } as any)).rejects.toThrow(/E_BAD_PAYLOAD/);
       await expect(harness.editTool.execute("edit", { path: "a.txt", edits: [["bad", "bad2", "x"]] } as any)).rejects.toThrow();
     });
   });

--- a/test/core/coverage-agent-f-anchor-pipeline.test.ts
+++ b/test/core/coverage-agent-f-anchor-pipeline.test.ts
@@ -44,7 +44,7 @@ describe("coverage-f: anchor-pipeline fmtMismatch", () => {
     const edit: any = { hash_bounds: [{ hash: "zzz" }, { hash: hashes[2]! }], content_lines: ["X"] };
     expect(() => applyEdit(content, edit, undefined, hashes, "file.txt", served)).toThrow(/E_STALE_ANCHOR/);
   });
-  it("triggers E_AMBIGUOUS_ANCHOR", () => {
+  it("triggers E_STALE_ANCHOR", () => {
     const content = "a\nb\na\nb\na";
     const hashes = lineHashesPure(content);
     // create duplicate hashes scenario: use lineHashesPure on content with duplicate lines will produce different hashes per line content, but we can forge served with duplicate
@@ -58,7 +58,7 @@ describe("coverage-f: anchor-pipeline fmtMismatch", () => {
       const res = applyEdit(dupContent, edit, undefined, dupHashes);
       expect(res.content).toBeDefined();
     } catch (e: any) {
-      expect(String(e.message)).toMatch(/E_AMBIGUOUS_ANCHOR|E_STALE_ANCHOR/);
+      expect(String(e.message)).toMatch(/E_STALE_ANCHOR|E_STALE_ANCHOR/);
     }
   });
   it("verifyServedRange stale and unsaved branches", () => {
@@ -75,7 +75,7 @@ describe("coverage-f: anchor-pipeline fmtMismatch", () => {
         fileHashes: hashes,
         fileLines: ["a", "b", "c"],
       }),
-    ).toThrow(/E_RANGE_/);
+    ).toThrow(/E_(STALE|UNSERVED)_RANGE/);
     const servedUnserved: any = [hashes[0]!, null, hashes[2]!];
     expect(() =>
       verifyServedRange({
@@ -87,7 +87,7 @@ describe("coverage-f: anchor-pipeline fmtMismatch", () => {
         fileHashes: hashes,
         fileLines: ["a", "b", "c"],
       }),
-    ).toThrow(/E_RANGE_UNSERVED/);
+    ).toThrow(/E_UNSERVED_RANGE/);
     const servedUnverified: any = [null, null, null];
     expect(() =>
       verifyServedRange({
@@ -99,7 +99,7 @@ describe("coverage-f: anchor-pipeline fmtMismatch", () => {
         fileHashes: hashes,
         fileLines: ["a", "b", "c"],
       }),
-    ).toThrow(/E_RANGE_UNVERIFIED/);
+    ).toThrow(/E_UNSERVED_RANGE/);
   });
 });
 

--- a/test/core/coverage-agent-g-hashstore-fileview.test.ts
+++ b/test/core/coverage-agent-g-hashstore-fileview.test.ts
@@ -160,7 +160,7 @@ describe("coverage-agent-g file-view", () => {
       const snap = await fileSnap(empty);
       expect(snap.snapshotId).toContain("v2|");
       const { normFromText } = await import("../../src/file-view.js");
-      await expect(normFromText({ absolutePath: empty, rawText: "a\n".repeat(100), displayPath: "x", maxLines: 10 })).rejects.toThrow(/E_FILE_TOO_LARGE/);
+      await expect(normFromText({ absolutePath: empty, rawText: "a\n".repeat(100), displayPath: "x", maxLines: 10 })).rejects.toThrow(/E_LARGE_FILE/);
       const { valAccess } = await import("../../src/file-view.js");
       await expect(valAccess("/nope/path", "/nope/path")).rejects.toThrow(/E_NOT_FOUND/);
       const { valKind } = await import("../../src/file-view.js");

--- a/test/core/file-encoding-state.test.ts
+++ b/test/core/file-encoding-state.test.ts
@@ -42,9 +42,9 @@ describe("file-encoding-state — deterministic admission (pure, no filesystem)"
     await expect(decodeForOpen(bytes, cfgOff, { encodingHint: "not-an-enc" })).rejects.toThrow(/E_BAD_ENCODING/);
   });
 
-  it("E_NOT_TEXT + Top-3 always pushed when autoGuess off and not UTF-8", async () => {
+  it("E_UNSUPPORTED_FILE + Top-3 always pushed when autoGuess off and not UTF-8", async () => {
     const gbkBytes = iconv.encode("你好世界你好", "gbk");
-    await expect(decodeForOpen(gbkBytes, cfgOff, { displayPath: "/abs/gbk.txt" })).rejects.toThrow(/E_NOT_TEXT.*Top-3 guesses/);
+    await expect(decodeForOpen(gbkBytes, cfgOff, { displayPath: "/abs/gbk.txt" })).rejects.toThrow(/E_UNSUPPORTED_FILE.*Top-3 guesses/);
     await expect(decodeForOpen(gbkBytes, cfgOff)).rejects.toThrow(/Top-3 guesses/);
   });
 

--- a/test/core/file-kind.test.ts
+++ b/test/core/file-kind.test.ts
@@ -112,7 +112,7 @@ describe("loadFileKindAndText — maxLines early bailout", () => {
       const path = join(cwd, "many-lines.txt");
       await expect(
         loadFileKindAndText(path, { maxLines: 5 }),
-      ).rejects.toThrow(/\[E_FILE_TOO_LARGE\].*more than 5 lines/);
+      ).rejects.toThrow(/\[E_LARGE_FILE\].*more than 5 lines/);
     });
   });
 
@@ -121,7 +121,7 @@ describe("loadFileKindAndText — maxLines early bailout", () => {
       const path = join(cwd, "many-lines.txt");
       await expect(
         loadFileKindAndText(path, { maxLines: 5, displayPath: "many-lines.txt" }),
-      ).rejects.toThrow(/\[E_FILE_TOO_LARGE\] many-lines\.txt/);
+      ).rejects.toThrow(/\[E_LARGE_FILE\] many-lines\.txt/);
     });
   });
 
@@ -139,7 +139,7 @@ describe("loadFileKindAndText — maxLines early bailout", () => {
       await writeFile(path, Array.from({ length: 8 }, (_, i) => `line${i}`).join("\r\n"), "utf-8");
       await expect(
         loadFileKindAndText(path, { maxLines: 5 }),
-      ).rejects.toThrow(/\[E_FILE_TOO_LARGE\]/);
+      ).rejects.toThrow(/\[E_LARGE_FILE\]/);
     });
   });
 

--- a/test/core/file-reader.test.ts
+++ b/test/core/file-reader.test.ts
@@ -94,7 +94,7 @@ describe("readNormFile", () => {
 			await withTempFile("big.txt", "a\nb\nc\nd\ne", async ({ cwd }) => {
 				await expect(
 					readNormFile("big.txt", cwd, { maxLines: 3 }),
-				).rejects.toThrow(/\[E_FILE_TOO_LARGE\]/);
+				).rejects.toThrow(/\[E_LARGE_FILE\]/);
 			});
 		});
 

--- a/test/core/fs-bridge.encoding.test.ts
+++ b/test/core/fs-bridge.encoding.test.ts
@@ -94,7 +94,7 @@ describe("contract and normalizeEncoding", () => {
   });
 
   it("assertReadRequest rejects unknown fields", () => {
-    expect(() => assertReadRequest({ path: "a.txt", unknown: "x" } as any)).toThrow(/E_BAD_SHAPE/);
+    expect(() => assertReadRequest({ path: "a.txt", unknown: "x" } as any)).toThrow(/E_BAD_PAYLOAD/);
   });
 
   it("normalizeEncoding canonicalizes aliases", () => {

--- a/test/core/fs-bridge.policy.test.ts
+++ b/test/core/fs-bridge.policy.test.ts
@@ -249,7 +249,7 @@ describe("ctxFsIO writeText", () => {
 		);
 	});
 
-	it("maps FS_STALE_VERSION onto the hashline E_RANGE_STALE vocabulary", async () => {
+	it("maps FS_STALE_VERSION onto the hashline E_STALE_RANGE vocabulary", async () => {
 		const stale = Object.assign(new Error("stale"), {
 			code: "FS_STALE_VERSION",
 		});
@@ -262,7 +262,7 @@ describe("ctxFsIO writeText", () => {
 		const io: FileIO = ctxFsIO(fs as never, ctx);
 
 		await expect(io.writeText("/abs/file.txt", "x")).rejects.toThrow(
-			"[E_RANGE_STALE]",
+			"[E_STALE_RANGE]",
 		);
 	});
 });

--- a/test/core/hashline-apply-internals.test.ts
+++ b/test/core/hashline-apply-internals.test.ts
@@ -38,7 +38,7 @@ resEdit(
 resEdit(
         { remove_from: hashes[0]!, remove_to: hashes[0]!, replacement_text: "X" },
       ), undefined, forgedHashes)
-    ).toThrow(/E_AMBIGUOUS_ANCHOR/);
+    ).toThrow(/E_STALE_ANCHOR/);
   });
 });
 
@@ -148,7 +148,7 @@ resEdit(
 resEdit(
         { remove_from: hashes[0]!, remove_to: hashes[2]!, replacement_text: "" },
       ))
-    ).toThrow(/E_WOULD_EMPTY/);
+    ).toThrow(/E_EMPTY_RANGE/);
   });
 
   it("branch: empty replacement ending at last line (not full file)", async () => {

--- a/test/core/hashline-fuzz-autofix.test.ts
+++ b/test/core/hashline-fuzz-autofix.test.ts
@@ -130,7 +130,7 @@ async function runStep(
   try {
     result = applyEdit(content, edit, undefined, hashes, path);
   } catch (error) {
-    if (error instanceof Error && /^\[E_WOULD_EMPTY\]/.test(error.message)) return null;
+    if (error instanceof Error && /\[E_EMPTY_RANGE\]/.test(error.message)) return null;
     throw error;
   }
   expect(result.content).toBe(expected);

--- a/test/core/hashline-limit.test.ts
+++ b/test/core/hashline-limit.test.ts
@@ -29,11 +29,11 @@ describe("hashline limits", () => {
     expect(new Set(hashes).size).toBe(MAX_HASH_LINES);
   }, 300_000);
 
-  it("throws a clear E_FILE_TOO_LARGE error above the limit", () => {
+  it("throws a clear E_LARGE_FILE error above the limit", () => {
     const content = Array.from({ length: MAX_HASH_LINES + 1 }, () => "x").join(
       "\n",
     );
-    expect(() => lineHashesPure(content)).toThrow("E_FILE_TOO_LARGE");
+    expect(() => lineHashesPure(content)).toThrow("E_LARGE_FILE");
   }, 300_000);
 
   it("preserves unique hashes at the boundary through the store path", async () => {
@@ -47,7 +47,7 @@ describe("hashline limits", () => {
 });
 
 describe("read tool line cap", () => {
-  it("rejects oversized files with E_FILE_TOO_LARGE before hashing", async () => {
+  it("rejects oversized files with E_LARGE_FILE before hashing", async () => {
     const content = Array.from({ length: MAX_HASH_LINES + 1 }, () => "x").join(
       "\n",
     );
@@ -55,7 +55,7 @@ describe("read tool line cap", () => {
       const { readTool, ctx } = setupReadTest(cwd);
       await expect(
         readTool.execute("r1", { path: "huge.ts" }, undefined, undefined, ctx),
-      ).rejects.toThrow("E_FILE_TOO_LARGE");
+      ).rejects.toThrow("E_LARGE_FILE");
     });
   });
 

--- a/test/core/hashline-stale-rebind.test.ts
+++ b/test/core/hashline-stale-rebind.test.ts
@@ -54,7 +54,7 @@ describe("retired hash anchors", () => {
 					remove_to: staleAnchor,
 					replacement_text: "  show: false,",
 				}),
-			).rejects.toThrow(/E_STALE_ANCHOR|E_RANGE_STALE/);
+			).rejects.toThrow(/E_STALE_ANCHOR|E_STALE_RANGE/);
 			expect(await readFile(path, "utf-8")).toBe(expected);
 		});
 	});
@@ -148,7 +148,7 @@ describe("retired hash anchors", () => {
 					remove_to: staleAnchor,
 					replacement_text: "wrong",
 				}),
-			).rejects.toThrow(/E_STALE_ANCHOR|E_RANGE_STALE/);
+			).rejects.toThrow(/E_STALE_ANCHOR|E_STALE_RANGE/);
 		});
 	});
 
@@ -190,7 +190,7 @@ describe("retired hash anchors", () => {
 					remove_to: staleAnchor,
 					replacement_text: "  show: false,",
 				}),
-			).rejects.toThrow(/E_STALE_ANCHOR|E_RANGE_STALE/);
+			).rejects.toThrow(/E_STALE_ANCHOR|E_STALE_RANGE/);
 			await harness.editTool.execute("fresh-after-undo", {
 				path: "undo.ts",
 				remove_from: restoredAnchor,

--- a/test/core/hashline-stress.test.ts
+++ b/test/core/hashline-stress.test.ts
@@ -184,7 +184,7 @@ describe("hash collision stress tests", () => {
   it("throws a clear error when hash space is exhausted", () => {
     const line = "x";
     const content = Array.from({ length: HASH_SPACE + 1 }, () => line).join("\n");
-    expect(() => lineHashesPure(content)).toThrow("E_FILE_TOO_LARGE");
+    expect(() => lineHashesPure(content)).toThrow("E_LARGE_FILE");
   }, 300_000);
 });
 

--- a/test/core/hashline-strict-input.test.ts
+++ b/test/core/hashline-strict-input.test.ts
@@ -10,15 +10,13 @@ import { useTestHome } from "../support/fixtures.js";
 const home = useTestHome();
 
 describe("edit input validation", () => {
-	it("strips bare HASH| prefix in content with warning", async () => {
+	it("rejects bare HASH| prefix in content with E_BAD_ANCHOR", async () => {
 		const file = "foo\nbar";
 		const hashes = await lineHashes(file, home.testPath);
 		const toolEdit: HTEdit = { remove_from: hashes[0]!, remove_to: hashes[0]!, replacement_text: `${hashes[0]!}│FOO` };
-    const result = applyEdit(file, resEdit(toolEdit));
-		expect(result.content).toBe("FOO\nbar");
-		expect(result.warnings?.[0]).toMatch(/stripped "HASH│" prefix/);
-		expect(result.warnings?.[0]).toMatch(/replacement_text line 1/);
-		expect(result.warnings?.[0]).toMatch(/1\/1 matched/);
+		expect(() => applyEdit(file, resEdit(toolEdit))).toThrow(/\[E_BAD_ANCHOR\]/);
+		expect(() => applyEdit(file, resEdit(toolEdit))).toThrow(/replacement_text line 1/);
+		expect(() => applyEdit(file, resEdit(toolEdit))).toThrow(/1\/1 matched/);
 	});
 
 	it("rejects array replacement_text before patch-prefix validation", () => {
@@ -60,62 +58,52 @@ describe("partial hash prefixes copied into content (issue #24)", () => {
 		return applyEdit(file, resEdit(toolEdit), undefined, precomputedHashes);
 	}
 
-	it("strips a bare prefix that matches an existing file line hash", async () => {
+	it("rejects a bare prefix that matches an existing file line hash", async () => {
 		const hashes = await lineHashes(file, home.testPath);
 		const anchor = hashes[0]!;
 		const betaHash = hashes[1]!;
-		const result = applyTool(
-      { remove_from: anchor,
-      remove_to: anchor, replacement_text: `${betaHash}│### heading\nreal content` },
-    hashes);
-    expect(result.content).toBe("### heading\nreal content\nbeta\ngamma\ndelta");
-    expect(result.warnings?.[0]).toMatch(/1\/1 matched/);
-    expect(result.warnings?.[0]).not.toMatch(/literal content/);
+		const toolEdit: HTEdit = { remove_from: anchor,
+			remove_to: anchor, replacement_text: `${betaHash}│### heading\nreal content` };
+		expect(() => applyTool(toolEdit, hashes)).toThrow(/\[E_BAD_ANCHOR\]/);
+		expect(() => applyTool(toolEdit, hashes)).toThrow(/1\/1 matched/);
+		expect(() => applyTool(toolEdit, hashes)).not.toThrow(/literal content/);
 	});
 
-	it("strips a bare prefix whose hash exists in the file hash set", async () => {
+	it("rejects a bare prefix whose hash exists in the file hash set", async () => {
 		const hashes = await lineHashes(file, home.testPath);
 		const anchor = hashes[0]!;
 		const gammaHash = hashes[2]!;
-		const result = applyTool(
-      { remove_from: anchor,
-      remove_to: anchor, replacement_text: `${gammaHash}│text` },
-    hashes);
-    expect(result.content).toBe("text\nbeta\ngamma\ndelta");
-    expect(result.warnings?.[0]).toMatch(/1\/1 matched/);
+		const toolEdit: HTEdit = { remove_from: anchor,
+			remove_to: anchor, replacement_text: `${gammaHash}│text` };
+		expect(() => applyTool(toolEdit, hashes)).toThrow(/\[E_BAD_ANCHOR\]/);
+		expect(() => applyTool(toolEdit, hashes)).toThrow(/1\/1 matched/);
 	});
 
-	it("strips bare prefixes even when the hash is not in the file hash set", async () => {
+	it("rejects bare prefixes even when the hash is not in the file hash set", async () => {
 		const hashes = await lineHashes(file, home.testPath);
 		const anchor = hashes[0]!;
-		const result = applyTool(
-      { remove_from: anchor,
-      remove_to: anchor, replacement_text: "ZZZ│one\nZZP│two" },
-    hashes);
-    expect(result.content).toBe("one\ntwo\nbeta\ngamma\ndelta");
-    expect(result.warnings?.[0]).toMatch(/0 matched/);
-    expect(result.warnings?.[0]).toMatch(/literal 'HASH│' content/);
+		const toolEdit: HTEdit = { remove_from: anchor,
+			remove_to: anchor, replacement_text: "ZZZ│one\nZZP│two" };
+		expect(() => applyTool(toolEdit, hashes)).toThrow(/\[E_BAD_ANCHOR\]/);
+		expect(() => applyTool(toolEdit, hashes)).toThrow(/0 matched/);
+		expect(() => applyTool(toolEdit, hashes)).toThrow(/literal 'HASH│' content/);
 	});
 
-	it("reports the replacement_text line for each stripped line", async () => {
+	it("reports the replacement_text line for each rejected line", async () => {
 		const hashes = await lineHashes(file, home.testPath);
 		const anchor = hashes[0]!;
-		const result = applyTool(
-      { remove_from: anchor,
-      remove_to: anchor, replacement_text: "ZZZ│one\nreal\nZZP│two" },
-    hashes);
-    expect(result.content).toBe("one\nreal\ntwo\nbeta\ngamma\ndelta");
-    expect(result.warnings?.[0]).toMatch(/replacement_text line 1, replacement_text line 3/);
+		const toolEdit: HTEdit = { remove_from: anchor,
+			remove_to: anchor, replacement_text: "ZZZ│one\nreal\nZZP│two" };
+		expect(() => applyTool(toolEdit, hashes)).toThrow(/\[E_BAD_ANCHOR\]/);
+		expect(() => applyTool(toolEdit, hashes)).toThrow(/replacement_text line 1, replacement_text line 3/);
 	});
 
-	it("keeps indentation after the separator while dropping leading prefix whitespace", async () => {
+	it("rejects indented prefix with E_BAD_ANCHOR", async () => {
 		const hashes = await lineHashes(file, home.testPath);
 		const anchor = hashes[0]!;
-		const result = applyTool(
-      { remove_from: anchor,
-      remove_to: anchor, replacement_text: `  ${hashes[1]!}│  indented` },
-    hashes);
-    expect(result.content).toBe("  indented\nbeta\ngamma\ndelta");
+		const toolEdit: HTEdit = { remove_from: anchor,
+			remove_to: anchor, replacement_text: `  ${hashes[1]!}│  indented` };
+		expect(() => applyTool(toolEdit, hashes)).toThrow(/\[E_BAD_ANCHOR\]/);
 	});
 
 	it("accepts a single legit 'TS: TypeScript' line without warning", async () => {
@@ -139,17 +127,14 @@ describe("partial hash prefixes copied into content (issue #24)", () => {
     expect(result.warnings ?? []).toEqual([]);
 	});
 
-	it("strips prefixes from long lines without truncation", async () => {
+	it("rejects prefixes on long lines with E_BAD_ANCHOR", async () => {
 		const hashes = await lineHashes(file, home.testPath);
 		const anchor = hashes[0]!;
 		const betaHash = hashes[1]!;
 		const longLine = `${betaHash}│${"y".repeat(500)}`;
-		const result = applyTool(
-      { remove_from: anchor,
-      remove_to: anchor, replacement_text: longLine },
-    hashes);
-    expect(result.content).toContain("y".repeat(500));
-    expect(result.content).not.toContain("│");
+		const toolEdit: HTEdit = { remove_from: anchor,
+			remove_to: anchor, replacement_text: longLine };
+		expect(() => applyTool(toolEdit, hashes)).toThrow(/\[E_BAD_ANCHOR\]/);
 	});
 });
 
@@ -160,27 +145,23 @@ describe("diff preview rows copied into content", () => {
 		return applyEdit(file, resEdit(toolEdit), undefined, precomputedHashes);
 	}
 
-	it("strips +HASH│ addition rows with warning", async () => {
+	it("rejects +HASH│ addition rows with E_BAD_ANCHOR", async () => {
 		const hashes = await lineHashes(file, home.testPath);
 		const anchor = hashes[0]!;
-		const result = applyTool(
-      { remove_from: anchor,
-      remove_to: anchor, replacement_text: `+${hashes[1]!}│### heading\nreal content` },
-    hashes);
-		expect(result.content).toBe("### heading\nreal content\nbeta\ngamma\ndelta");
-		expect(result.warnings?.[0]).toMatch(/stripped diff-preview marker/);
-		expect(result.warnings?.[0]).toMatch(/replacement_text line 1/);
+		const toolEdit: HTEdit = { remove_from: anchor,
+			remove_to: anchor, replacement_text: `+${hashes[1]!}│### heading\nreal content` };
+		expect(() => applyTool(toolEdit, hashes)).toThrow(/\[E_BAD_ANCHOR\]/);
+		expect(() => applyTool(toolEdit, hashes)).toThrow(/stripped diff-preview marker/);
+		expect(() => applyTool(toolEdit, hashes)).toThrow(/replacement_text line 1/);
 	});
 
-	it("strips -HASH│ and -   │ deletion rows with warning", async () => {
+	it("rejects -HASH│ and -   │ deletion rows with E_BAD_ANCHOR", async () => {
 		const hashes = await lineHashes(file, home.testPath);
 		const anchor = hashes[0]!;
-		const result = applyTool(
-      { remove_from: anchor,
-      remove_to: anchor, replacement_text: `-${hashes[1]!}│one\n-   │two` },
-    hashes);
-		expect(result.content).toBe("one\ntwo\nbeta\ngamma\ndelta");
-		expect(result.warnings?.[0]).toMatch(/replacement_text line 1, replacement_text line 2/);
+		const toolEdit: HTEdit = { remove_from: anchor,
+			remove_to: anchor, replacement_text: `-${hashes[1]!}│one\n-   │two` };
+		expect(() => applyTool(toolEdit, hashes)).toThrow(/\[E_BAD_ANCHOR\]/);
+		expect(() => applyTool(toolEdit, hashes)).toThrow(/replacement_text line 1, replacement_text line 2/);
 	});
 
 	it("leaves numbered deletion rows as literal content without warning", async () => {
@@ -246,25 +227,21 @@ describe("diff-prefix false-positive guards (tightened shapes)", () => {
 		expect(result.warnings ?? []).toEqual([]);
 	});
 
-	it("still strips exact +HASH│ rows without a space", async () => {
+	it("rejects exact +HASH│ rows without a space", async () => {
 		const hashes = await lineHashes(file, home.testPath);
 		const anchor = hashes[0]!;
-		const result = applyTool(
-      { remove_from: anchor,
-      remove_to: anchor, replacement_text: `+${hashes[1]!}│one` },
-    hashes);
-		expect(result.content).toBe("one\nbeta\ngamma\ndelta");
-		expect(result.warnings?.[0]).toMatch(/stripped diff-preview marker/);
+		const toolEdit: HTEdit = { remove_from: anchor,
+			remove_to: anchor, replacement_text: `+${hashes[1]!}│one` };
+		expect(() => applyTool(toolEdit, hashes)).toThrow(/\[E_BAD_ANCHOR\]/);
+		expect(() => applyTool(toolEdit, hashes)).toThrow(/stripped diff-preview marker/);
 	});
 
-	it("still strips exact -HASH│ and -   │ rows", async () => {
+	it("rejects exact -HASH│ and -   │ rows", async () => {
 		const hashes = await lineHashes(file, home.testPath);
 		const anchor = hashes[0]!;
-		const result = applyTool(
-      { remove_from: anchor,
-      remove_to: anchor, replacement_text: `-${hashes[1]!}│one\n-   │two` },
-    hashes);
-		expect(result.content).toBe("one\ntwo\nbeta\ngamma\ndelta");
-		expect(result.warnings?.[0]).toMatch(/stripped diff-preview marker/);
+		const toolEdit: HTEdit = { remove_from: anchor,
+			remove_to: anchor, replacement_text: `-${hashes[1]!}│one\n-   │two` };
+		expect(() => applyTool(toolEdit, hashes)).toThrow(/\[E_BAD_ANCHOR\]/);
+		expect(() => applyTool(toolEdit, hashes)).toThrow(/stripped diff-preview marker/);
 	});
 });

--- a/test/core/hashline.apply.test.ts
+++ b/test/core/hashline.apply.test.ts
@@ -146,7 +146,7 @@ describe("applyEdit — noop detection", () => {
 			],
 			content_lines: [],
 		};
-		expect(() => applyEdit(content, edit)).toThrow(/^\[E_WOULD_EMPTY\]/);
+		expect(() => applyEdit(content, edit)).toThrow(/\[E_EMPTY_RANGE\]/);
 	});
 
 	it("allows whole-file rewrite when the final content is non-empty", async () => {
@@ -313,7 +313,7 @@ describe("applyEdit — edge cases (empty, single-line, no trailing newline)", (
 			],
 			content_lines: [],
 		};
-		expect(() => applyEdit(content, edit)).toThrow(/^\[E_WOULD_EMPTY\]/);
+		expect(() => applyEdit(content, edit)).toThrow(/\[E_EMPTY_RANGE\]/);
 	});
 
 	it("edits a line in a file with no trailing newline", async () => {

--- a/test/core/hashline.hash.test.ts
+++ b/test/core/hashline.hash.test.ts
@@ -95,7 +95,7 @@ describe("perfect hashing", () => {
 		expect(caught!.message).toContain("Re-read for fresh anchors");
 	});
 
-	it("rejects an ambiguous hash with [E_AMBIGUOUS_ANCHOR] (synthetic collision)", async () => {
+	it("rejects an ambiguous hash with [E_STALE_ANCHOR] (synthetic collision)", async () => {
 		const file = "alpha\nbeta\ngamma\ndelta";
 		const realHashes = await lineHashes(file, home.testPath);
 		const forgedHashes = [...realHashes];
@@ -115,7 +115,7 @@ describe("perfect hashing", () => {
 			caught = error as Error;
 		}
 		expect(caught).toBeDefined();
-		expect(caught!.message).toMatch(/E_AMBIGUOUS_ANCHOR/);
+		expect(caught!.message).toMatch(/E_STALE_ANCHOR/);
 		expect(caught!.message).toMatch(/matches lines 1, 3/);
 		expect(caught!.message).toContain(`${realHashes[0]!}│alpha`);
 		expect(caught!.message).toContain(`${realHashes[0]!}│gamma`);

--- a/test/core/hashline.parse.test.ts
+++ b/test/core/hashline.parse.test.ts
@@ -19,30 +19,30 @@ describe("parseHashRef", () => {
 		);
 	});
 	it("rejects leading >>> markers (strict mode: no marker stripping)", () => {
-		expect(() => parseHashRef(">>> aB3")).toThrow(/E_BAD_REF/);
+		expect(() => parseHashRef(">>> aB3")).toThrow(/E_BAD_ANCHOR/);
 	});
 
 	it("rejects + and - diff markers (strict mode: anchor only)", () => {
-		expect(() => parseHashRef("+aB3")).toThrow(/E_BAD_REF/);
-		expect(() => parseHashRef("-aB3")).toThrow(/E_BAD_REF/);
-		expect(() => parseHashRef("-#aB3")).toThrow(/E_BAD_REF/);
+		expect(() => parseHashRef("+aB3")).toThrow(/E_BAD_ANCHOR/);
+		expect(() => parseHashRef("-aB3")).toThrow(/E_BAD_ANCHOR/);
+		expect(() => parseHashRef("-#aB3")).toThrow(/E_BAD_ANCHOR/);
 	});
 
 	it("rejects - and _ anywhere in the anchor (not in the alphabet)", () => {
-		expect(() => parseHashRef("-qk")).toThrow(/E_BAD_REF/);
-		expect(() => parseHashRef("-_-")).toThrow(/E_BAD_REF/);
-		expect(() => parseHashRef("---")).toThrow(/E_BAD_REF/);
-		expect(() => parseHashRef("aB_")).toThrow(/E_BAD_REF/);
-		expect(() => parseHashRef("aB-")).toThrow(/E_BAD_REF/);
+		expect(() => parseHashRef("-qk")).toThrow(/E_BAD_ANCHOR/);
+		expect(() => parseHashRef("-_-")).toThrow(/E_BAD_ANCHOR/);
+		expect(() => parseHashRef("---")).toThrow(/E_BAD_ANCHOR/);
+		expect(() => parseHashRef("aB_")).toThrow(/E_BAD_ANCHOR/);
+		expect(() => parseHashRef("aB-")).toThrow(/E_BAD_ANCHOR/);
 	});
 
 	it("rejects + as a hash body character (not in alphabet)", () => {
-		expect(() => parseHashRef("+qk")).toThrow(/E_BAD_REF/);
-		expect(() => parseHashRef("#+qk")).toThrow(/E_BAD_REF/);
+		expect(() => parseHashRef("+qk")).toThrow(/E_BAD_ANCHOR/);
+		expect(() => parseHashRef("#+qk")).toThrow(/E_BAD_ANCHOR/);
 	});
 
-	it("rejects malformed anchors with E_BAD_REF", () => {
-		expect(() => parseHashRef("invalid")).toThrow(/^\[E_BAD_REF\]/);
+	it("rejects malformed anchors with E_BAD_ANCHOR", () => {
+		expect(() => parseHashRef("invalid")).toThrow(/\[E_BAD_ANCHOR\]/);
 	});
 
 	it("rejects legacy LINE#HASH format", () => {
@@ -52,19 +52,19 @@ describe("parseHashRef", () => {
 	});
 
 	it("rejects wrong-length anchors", () => {
-		expect(() => parseHashRef("aB")).toThrow(/E_BAD_REF/);
-		expect(() => parseHashRef("aB3x")).toThrow(/E_BAD_REF/);
-		expect(() => parseHashRef("#aB3x")).toThrow(/E_BAD_REF/);
+		expect(() => parseHashRef("aB")).toThrow(/E_BAD_ANCHOR/);
+		expect(() => parseHashRef("aB3x")).toThrow(/E_BAD_ANCHOR/);
+		expect(() => parseHashRef("#aB3x")).toThrow(/E_BAD_ANCHOR/);
 	});
 
 	it("rejects anchors with invalid alphabet", () => {
-		expect(() => parseHashRef("!@#")).toThrow(/^\[E_BAD_REF\]/);
+		expect(() => parseHashRef("!@#")).toThrow(/\[E_BAD_ANCHOR\]/);
 	});
 });
 
 describe("parseText", () => {
 	it("rejects null with a clear error", () => {
-		expect(() => parseText(null as unknown as string)).toThrow(/^\[E_BAD_SHAPE\].*must be a string with \\n line separators/);
+		expect(() => parseText(null as unknown as string)).toThrow(/\[E_BAD_PAYLOAD\].*must be a string with \\n line separators/);
 	});
 
 	it("rejects array input with clear error (must use string)", () => {

--- a/test/core/hashline.recovery.test.ts
+++ b/test/core/hashline.recovery.test.ts
@@ -92,7 +92,7 @@ describe("applyEdit — recovery scenarios", () => {
         { remove_from: hashes[0]!,
         remove_to: hashes[0]!, replacement_text: "X" },
       ), undefined, forgedHashes)
-    ).toThrow(/E_AMBIGUOUS_ANCHOR/);
+    ).toThrow(/E_STALE_ANCHOR/);
   });
 
   it("rejects unknown fields in edit items", () => {
@@ -131,27 +131,31 @@ describe("applyEdit — recovery scenarios", () => {
     expect(() => resEdit(edit)).toThrow(/Invalid anchor/);
   });
 
-  it("strips bare hash prefix in content_lines", async () => {
-    const content = "a\nb\nc\nd\ne";
-    const hashes = await lineHashes(content, home.testPath);
-    const result = applyEdit(content, resEdit(
-      { remove_from: hashes[1]!,
-      remove_to: hashes[2]!, replacement_text: `${hashes[1]!}│b\nX` },
-    ));
-    expect(result.content).toBe("a\nb\nX\nd\ne");
-    expect(result.warnings?.[0]).toMatch(/stripped "HASH│" prefix/);
-  });
+	it("rejects bare hash prefix in content_lines with E_BAD_ANCHOR", async () => {
+		const content = "a\nb\nc\nd\ne";
+		const hashes = await lineHashes(content, home.testPath);
+		expect(() => applyEdit(content, resEdit(
+			{ remove_from: hashes[1]!,
+			remove_to: hashes[2]!, replacement_text: `${hashes[1]!}│b\nX` },
+		))).toThrow(/\[E_BAD_ANCHOR\]/);
+		expect(() => applyEdit(content, resEdit(
+			{ remove_from: hashes[1]!,
+			remove_to: hashes[2]!, replacement_text: `${hashes[1]!}│b\nX` },
+		))).toThrow(/stripped "HASH│" prefix/);
+	});
 
-  it("strips diff preview rows in content_lines", async () => {
-    const content = "a\nb\nc";
-    const hashes = await lineHashes(content, home.testPath);
-    const result = applyEdit(content, resEdit(
-      { remove_from: hashes[1]!,
-      remove_to: hashes[1]!, replacement_text: `+${hashes[1]!}│B` },
-    ));
-    expect(result.content).toBe("a\nB\nc");
-    expect(result.warnings?.[0]).toMatch(/stripped diff-preview marker/);
-  });
+	it("rejects diff preview rows in content_lines with E_BAD_ANCHOR", async () => {
+		const content = "a\nb\nc";
+		const hashes = await lineHashes(content, home.testPath);
+		expect(() => applyEdit(content, resEdit(
+			{ remove_from: hashes[1]!,
+			remove_to: hashes[1]!, replacement_text: `+${hashes[1]!}│B` },
+		))).toThrow(/\[E_BAD_ANCHOR\]/);
+		expect(() => applyEdit(content, resEdit(
+			{ remove_from: hashes[1]!,
+			remove_to: hashes[1]!, replacement_text: `+${hashes[1]!}│B` },
+		))).toThrow(/stripped diff-preview marker/);
+	});
 
   it("warns on unicode escape sequences in content", async () => {
     const content = "a\nb\nc";

--- a/test/core/hashline.resolve.test.ts
+++ b/test/core/hashline.resolve.test.ts
@@ -24,9 +24,9 @@ describe("resEdit", () => {
 		expect(r.hash_bounds[1].hash).toBe("MQX");
 	});
 
-	it("throws on replace with no remove_from/remove_to (E_BAD_SHAPE)", () => {
+	it("throws on replace with no remove_from/remove_to (E_BAD_PAYLOAD)", () => {
     const edit = { replacement_text: "new" } as any;
-		expect(() => resEdit(edit)).toThrow(/^\[E_BAD_SHAPE\]/);
+		expect(() => resEdit(edit)).toThrow(/\[E_BAD_PAYLOAD\]/);
 	});
 
 	it("throws on malformed remove_from/remove_to", () => {
@@ -86,28 +86,23 @@ describe("resEdit", () => {
 		);
 	});
 
-	it("strips a HASH│content row pasted into remove_from/remove_to with a warning", () => {
+	it("rejects a HASH│content row pasted into remove_from/remove_to with E_BAD_ANCHOR", () => {
 		const edit: HTEdit = { remove_from: "MQX│const x = 1;", remove_to: "MQX│const x = 1;", replacement_text: "new" };
 		const warnings: string[] = [];
-		const resolved = resEdit(edit, warnings);
-		expect(resolved.hash_bounds[0].hash).toBe("MQX");
-		expect(resolved.hash_bounds[1].hash).toBe("MQX");
-		expect(warnings).toHaveLength(2);
-		expect(warnings[0]).toMatch(/^\[E_BAD_REF\]/);
-		expect(warnings[0]).toContain('stripped "HASH│" prefix');
-		expect(warnings[0]).toContain("from remove_from/remove_to");
+		expect(() => resEdit(edit, warnings)).toThrow(/\[E_BAD_ANCHOR\]/);
+		expect(() => resEdit(edit, warnings)).toThrow('stripped "HASH│" prefix');
+		expect(() => resEdit(edit, warnings)).toThrow("from remove_from/remove_to");
+		expect(warnings).toEqual([]);
 	});
 
-	it("strips diff-preview rows pasted into remove_from/remove_to with a warning", () => {
+	it("rejects diff-preview rows pasted into remove_from/remove_to with E_BAD_ANCHOR", () => {
 		const edit: HTEdit = { remove_from: "+MQX│const x = 1;", remove_to: "-MQX│const x = 1;", replacement_text: "new" };
 		const warnings: string[] = [];
-		const resolved = resEdit(edit, warnings);
-		expect(resolved.hash_bounds[0].hash).toBe("MQX");
-		expect(resolved.hash_bounds[1].hash).toBe("MQX");
-		expect(warnings).toHaveLength(2);
-		expect(warnings[0]).toContain("diff-preview marker");
-		expect(warnings[0]).toContain("stripped diff-preview marker");
-		expect(warnings[1]).toContain('leading "-" marker');
+		expect(() => resEdit(edit, warnings)).toThrow(/\[E_BAD_ANCHOR\]/);
+		expect(() => resEdit(edit, warnings)).toThrow("stripped diff-preview marker");
+		const edit2: HTEdit = { remove_from: "-MQX│const x = 1;", remove_to: "MQX", replacement_text: "new" };
+		expect(() => resEdit(edit2, warnings)).toThrow('leading "-" marker');
+		expect(warnings).toEqual([]);
 	});
 
 	it("leaves bare anchors untouched and emits no warning", () => {
@@ -120,6 +115,6 @@ describe("resEdit", () => {
 
 	it("still rejects rows without a leading hash", () => {
 		const edit: HTEdit = { remove_from: "│const x = 1;", remove_to: "MQX", replacement_text: "new" };
-		expect(() => resEdit(edit)).toThrow(/^\[E_BAD_REF\]/);
+		expect(() => resEdit(edit)).toThrow(/\[E_BAD_ANCHOR\]/);
 	});
 });

--- a/test/core/read-tool.encoding.test.ts
+++ b/test/core/read-tool.encoding.test.ts
@@ -89,7 +89,7 @@ describe("read tool — encoding integration (replaces manual dsh paste)", () =>
 		// localIO with autoGuess off falls back to readFile utf-8 → contains U+FFFD, no warning
 		expect(r.text).toContain("\uFFFD");
 		expect(r.warning).toBeUndefined();
-		// Top-3 via E_NOT_TEXT is the ctxFsIO (DSH web) path; localIO never throws E_NOT_TEXT for this case
+		// Top-3 via E_UNSUPPORTED_FILE is the ctxFsIO (DSH web) path; localIO never throws E_UNSUPPORTED_FILE for this case
 	});
 
 	it("autoGuess=true: gbk without encoding decodes and warning second block", async () => {

--- a/test/core/reject-and-serve-seam.test.ts
+++ b/test/core/reject-and-serve-seam.test.ts
@@ -43,7 +43,7 @@ describe("recordEchoServes — serve-record policy", () => {
 });
 
 describe("applyEdit — stale range beats would-empty", () => {
-	it("rejects E_RANGE_STALE before E_WOULD_EMPTY when both apply", () => {
+	it("rejects E_STALE_RANGE before E_EMPTY_RANGE when both apply", () => {
 		const content = "aaa\nbbb\nccc";
 		const hashes = lineHashesPure(content);
 		const served = [hashes[0]!, "S1", hashes[2]!];
@@ -64,7 +64,7 @@ describe("applyEdit — stale range beats would-empty", () => {
 			error = caught;
 		}
 		expect(error).toBeInstanceOf(ServedRejectionError);
-		expect((error as ServedRejectionError).code).toBe("E_RANGE_STALE");
+		expect((error as ServedRejectionError).code).toBe("E_STALE_RANGE");
 	});
 });
 describe("finalizeToolResult", () => {

--- a/test/core/served-store.test.ts
+++ b/test/core/served-store.test.ts
@@ -146,7 +146,7 @@ describe("served state — merge helper (stale-tail invariant)", () => {
 			// The file shrank to 1 line; the new serve must not keep the old
 			// tail — a hash held at a position beyond the line count is a
 			// stale claim that later makes boundary anchors look ambiguous
-			// (E_RANGE_UNVERIFIED, "served at N positions").
+			// (E_UNSERVED_RANGE, "served at N positions").
 			await recordServed("sessionA", "/p.ts", [{ position: 0, hash: "abc" }], 1);
 			expect(await loadServed("sessionA", "/p.ts")).toEqual(["abc"]);
 			expect(

--- a/test/core/utils.test.ts
+++ b/test/core/utils.test.ts
@@ -95,11 +95,11 @@ describe("rejectUnknownFields", () => {
     expect(() => rejectUnknownFields(obj, allowed, "Request")).not.toThrow();
   });
 
-  it("throws [E_BAD_SHAPE] for a single unknown field", () => {
+  it("throws [E_BAD_PAYLOAD] for a single unknown field", () => {
     const obj = { path: "test.txt", unknown_field: "value" };
     const allowed = new Set(["path"]);
     expect(() => rejectUnknownFields(obj, allowed, "Request")).toThrow(
-      /^\[E_BAD_SHAPE\]/,
+      /\[E_BAD_PAYLOAD\]/,
     );
   });
 

--- a/test/core/validation.test.ts
+++ b/test/core/validation.test.ts
@@ -24,17 +24,17 @@ describe("errCode", () => {
 describe("valKind", () => {
 	it("throws for directory", () => {
 		expect(() => valKind({ kind: "directory" }, "test.txt"))
-			.toThrow("[E_NOT_TEXT] Path is a directory: test.txt. Use ls to inspect directories.");
+			.toThrow("[E_UNSUPPORTED_FILE] Path is a directory: test.txt.");
 	});
 
 	it("throws for binary file", () => {
 		expect(() => valKind({ kind: "binary", description: "application/octet-stream" }, "test.bin"))
-			.toThrow("[E_NOT_TEXT] Path is a binary file: test.bin (application/octet-stream). Hashline edit only supports text files.");
+			.toThrow("[E_UNSUPPORTED_FILE] Path is a binary file: test.bin (application/octet-stream). Hashline edit only supports text files.");
 	});
 
 	it("throws for image file", () => {
 		expect(() => valKind({ kind: "image", mimeType: "image/png" }, "test.png"))
-			.toThrow("[E_NOT_TEXT] Path is an image file: test.png. Hashline edit only supports text files.");
+			.toThrow("[E_UNSUPPORTED_FILE] Path is an image file: test.png. Hashline edit only supports text files.");
 	});
 
 	it("does not throw for text file", () => {

--- a/test/core/workspace-store.test.ts
+++ b/test/core/workspace-store.test.ts
@@ -154,7 +154,7 @@ describe("stale served tail (regression)", () => {
 			// write auto-read). Before the fix the second serve left the stale
 			// positions 2..7 in the array, so the surviving "c" line's hash
 			// appeared at BOTH its old position 2 and its new position 1 —
-			// and any edit targeting it failed E_RANGE_UNVERIFIED.
+			// and any edit targeting it failed E_UNSERVED_RANGE.
 			await withWorkspace(ws, async () => {
 				const big = "a\nb\nc\nd\ne\nf\ng\nh\n";
 				writeFileSync(path, big);

--- a/test/core/write-hook.hash-echo.test.ts
+++ b/test/core/write-hook.hash-echo.test.ts
@@ -99,7 +99,7 @@ describe("write hash-echo guard", () => {
 			expect(decision).toMatchObject({ kind: "deny" });
 			expect(
 				(decision as { reason?: string }).reason,
-			).toContain("[E_WRITE_HASH_ECHO]");
+			).toContain("[E_SERVED_ECHO]");
 			expect(next).not.toHaveBeenCalled();
 			expect(await readFile(path)).toEqual(beforeBytes);
 

--- a/test/support/fixtures.ts
+++ b/test/support/fixtures.ts
@@ -251,12 +251,12 @@ export function setupIntegrationTest(cwd: string, io: FileIO = localIO()) {
 			async execute(_callId: string, params: unknown) {
 				const rec = params as { edits?: Array<{ path?: string; file_path?: string; remove_from: string; remove_to: string; replacement_text: string }> };
 				const edits = rec.edits ?? [];
-				if (edits.length === 0) throw new Error("[E_BAD_SHAPE] batch_edit shim: edits empty");
+				if (edits.length === 0) throw new Error("[E_BAD_PAYLOAD] batch_edit shim: edits empty");
 				const path = (edits[0] as any).path ?? (edits[0] as any).file_path ?? null;
 				// verify all same file (new edit is single-file)
 				for (const e of edits) {
 					const ep = (e as any).path ?? (e as any).file_path ?? path;
-					if (ep !== path) throw new Error("[E_BAD_SHAPE] batch_edit shim: cross-file batches removed — use one edit call per file");
+					if (ep !== path) throw new Error("[E_BAD_PAYLOAD] batch_edit shim: cross-file batches removed — use one edit call per file");
 				}
 				const tuples = edits.map(e => [e.remove_from, e.remove_to, e.replacement_text] as [string,string,string]);
 				const text = await editTool.execute({ path, edits: tuples } as unknown as never, { signal: new AbortController().signal, agent: { id: sessionKey, session: { id: sessionKey, header: { cwd } } } } as unknown as never);


### PR DESCRIPTION
Port of upstream pi-better-edit ADR-0014 (dd1a779, v1.6.0) adapted to our seams. Closes #45.

What: full E_* code family rename (adj+noun, no aliases), [MODEL]/[USER] display-layer audience split, heal-to-throw for anchor/content prefix strips (healed-reversed kept), E_UNSERVED_RANGE merge with unservedKind, CONTEXT glossary realignment, README table, new docs/adr/0014-user-model-audience.md.

Deferred to T3: prompt/guidance channel wording rides the EDIT_DESCRIPTION rewrite (#47).

Gates: npm run typecheck pass, npm test 1229/1229 pass, npm run build pass, biome check pass.
Scope note: behavior port only, no structural flattening toward upstream modules (per absorption plan Q5).