### PR TITLE
feat(session-view): canon-deficit drift instead of hash rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ### Features
 
-- user/model audience split + glossary error codes (Closes #45) (BREAKING CHANGE)
+- **session-view:** canon-deficit drift instead of hash rotation (Closes #46)
+- user/model audience split + glossary error codes (#49) (BREAKING CHANGE)
 
 ### Documentation
 
-- **absorb:** record v1.2.1→v1.6.0 audit triage (T1–T4, issues #45–#48)
 - migrate CLAUDE.md to AGENTS.md with symlink
 
 ## [0.6.3](https://github.com/Rianico/dsh-better-edit/compare/v0.6.2...v0.6.3) (2026-09-05)

--- a/src/session-view.ts
+++ b/src/session-view.ts
@@ -22,7 +22,7 @@
  * @module dsh-better-edit/session-view
  */
 
-import { HASH_RE } from "./hashline/hash-assign.js";
+import { HASH_RE, canon } from "./hashline/hash-assign.js";
 import {
 	loadHashStore,
 	loadServedStore,
@@ -346,6 +346,9 @@ export interface ComputeDriftInput {
 	range: ResolvedRange;
 	reported: Set<string>;
 	cap?: number;
+	/** WHY (#68): parallel to `served`, whitespace-stripped form at serve time.
+	 * Absent/empty preserves legacy hash-equality (old DBs, unit callers). */
+	servedCanons?: (string | null)[];
 }
 
 export interface DriftNoticeResult {
@@ -353,6 +356,61 @@ export interface DriftNoticeResult {
 	rows: DriftRow[];
 	total: number;
 	allAlreadyReported: boolean;
+}
+
+type RotatedSurvivorCheck = (servedPos: number) => boolean;
+
+/**
+ * WHY (#68 hash-rotation vs content loss): probing + tombstone growth reassign
+ * distinct hashes to identical duplicate lines across sequential edits, so a
+ * served hash missing from the result set may still survive under a fresh hash.
+ * Suppress those by consuming one matching canon outside the edited span;
+ * report only true canon deficit. Whitespace-only reformats stay silent
+ * (canon strips ASCII whitespace, ADR-0002). Absent/empty servedCanons keeps
+ * legacy hash-equality.
+ */
+function buildRotatedSurvivorCheck(
+	input: ComputeDriftInput,
+	rangeFrom: number,
+	rangeTo: number,
+	delta: number,
+): RotatedSurvivorCheck {
+	const canons = input.servedCanons;
+	if (!canons || !canons.some((c) => c !== null)) return () => false;
+	// Edited served interval mapped to result coordinates (single range).
+	const spanFrom = Math.max(0, rangeFrom);
+	const spanTo = Math.max(spanFrom - 1, rangeTo + delta);
+	const remaining = new Map<string, number>();
+	for (let i = 0; i < input.resultLines.length; i++) {
+		if (i >= spanFrom && i <= spanTo) continue;
+		const c = canon(input.resultLines[i] ?? "");
+		remaining.set(c, (remaining.get(c) ?? 0) + 1);
+	}
+	const take = (c: string): boolean => {
+		const left = remaining.get(c) ?? 0;
+		if (left <= 0) return false;
+		remaining.set(c, left - 1);
+		return true;
+	};
+	// Pre-consume: served lines that survived under their own hash already
+	// account for their result content, so a deleted duplicate is not masked
+	// by a surviving twin (multiset difference, not per-hash presence).
+	const currentPosOfHash = new Map<string, number>();
+	for (let i = 0; i < input.resultHashes.length; i++) {
+		currentPosOfHash.set(input.resultHashes[i]!, i);
+	}
+	for (let p = 0; p < input.served.length; p++) {
+		const h = input.served[p];
+		if (h === null || (p >= rangeFrom && p <= rangeTo)) continue;
+		const currentPos = currentPosOfHash.get(h);
+		if (currentPos === undefined) continue;
+		take(canon(input.resultLines[currentPos] ?? ""));
+	}
+	return (servedPos) => {
+		const c = canons[servedPos] ?? null;
+		if (c === null) return false;
+		return take(c);
+	};
 }
 
 export function computeDrift(input: ComputeDriftInput): DriftNoticeResult | undefined {
@@ -375,6 +433,7 @@ export function computeDrift(input: ComputeDriftInput): DriftNoticeResult | unde
 	}
 	const rangeFrom = Math.min(servedStartIdx, servedEndIdx);
 	const rangeTo = Math.max(servedStartIdx, servedEndIdx);
+	const isRotatedSurvivor = buildRotatedSurvivorCheck(input, rangeFrom, rangeTo, range.delta);
 	let total = 0;
 	let unshown = 0;
 	let anyNotReported = false;
@@ -384,6 +443,7 @@ export function computeDrift(input: ComputeDriftInput): DriftNoticeResult | unde
 		if (servedHash === null) continue;
 		if (p >= rangeFrom && p <= rangeTo) continue;
 		if (resultHashSet.has(servedHash)) continue;
+		if (isRotatedSurvivor(p)) continue;
 		total++;
 		if (!reported.has(servedHash)) anyNotReported = true;
 		const currentPos = currentPositionOfDrifted(served, currentPosOfHash, resultHashSet, p, range.delta);
@@ -431,7 +491,8 @@ export function computeDrift(input: ComputeDriftInput): DriftNoticeResult | unde
 
 export async function scanDrift(input: { sessionKey: string; served: (string | null)[]; resultHashes: string[]; resultLines: string[]; range: ResolvedRange; path: string }): Promise<string | undefined> {
 	const reported = await driftReported(input.sessionKey, input.path);
-	const result = computeDrift({ ...input, reported });
+	const servedCanons = await loadServedCanons(input.sessionKey, input.path);
+	const result = computeDrift({ ...input, reported, servedCanons });
 	if (!result || result.allAlreadyReported) return result?.text;
 	await recordServed(input.sessionKey, input.path, result.rows.map((row) => ({ position: row.position, hash: row.hash })), input.resultLines.length);
 	await markDriftReported(input.sessionKey, input.path, result.rows.filter((row) => row.drifted).map((row) => row.hash));

--- a/test/core/drift.test.ts
+++ b/test/core/drift.test.ts
@@ -350,3 +350,77 @@ describe("computeDrift", () => {
 		]);
 	});
 });
+
+describe("computeDrift rotated survivors (#68 canon deficit)", () => {
+	const range121 = {
+		startLine: 1,
+		endLine: 1,
+		startHash: "h00",
+		endHash: "h00",
+		delta: 0,
+	};
+
+	it("reports hash rotation as drift without servedCanons (legacy)", () => {
+		const result = computeDrift({
+			served: ["h00", "h01", "h02", "h03"],
+			resultHashes: ["n00", "n01", "h02", "h03"],
+			resultLines: ["dup", "dup", "dup", "unique"],
+			range: range121,
+			reported: new Set(),
+		});
+		expect(result).toBeDefined();
+		// h00 is inside the edited range (skipped); only h01 counts.
+		expect(result!.total).toBe(1);
+	});
+
+	it("stays silent when rotated duplicates survive under fresh hashes", () => {
+		const result = computeDrift({
+			served: ["h00", "h01", "h02", "h03"],
+			servedCanons: ["dup", "dup", "dup", "unique"],
+			resultHashes: ["n00", "n01", "h02", "h03"],
+			resultLines: ["dup", "dup", "dup", "unique"],
+			range: range121,
+			reported: new Set(),
+		});
+		expect(result).toBeUndefined();
+	});
+
+	it("reports true canon deficit when a duplicate is really gone", () => {
+		const result = computeDrift({
+			served: ["h00", "h01", "h02", "h03"],
+			servedCanons: ["dup", "dup", "dup", "unique"],
+			resultHashes: ["h00", "h02", "h03"],
+			resultLines: ["dup", "dup", "unique"],
+			range: range121,
+			reported: new Set(),
+		});
+		expect(result).toBeDefined();
+		expect(result!.total).toBe(1);
+	});
+
+	it("stays silent on whitespace-only reformat with rotated hash", () => {
+		const result = computeDrift({
+			served: ["h00", "h01"],
+			servedCanons: ["code", "tail"],
+			resultHashes: ["n00", "h01"],
+			resultLines: ["  code  ", "tail"],
+			range: range121,
+			reported: new Set(),
+		});
+		expect(result).toBeUndefined();
+	});
+
+	it("still reports content loss outside the range with canons present", () => {
+		const result = computeDrift({
+			served: ["h00", "h01", "h02"],
+			servedCanons: ["a", "b", "c"],
+			resultHashes: ["h00", "X"],
+			resultLines: ["a", "x"],
+			range: range121,
+			reported: new Set(),
+		});
+		expect(result).toBeDefined();
+		// h00 is inside the edited range (skipped); h01+h02 truly lost.
+		expect(result!.total).toBe(2);
+	});
+});


### PR DESCRIPTION
Port of upstream pi-better-edit 95c4703 (v1.6.0, refs pi-better-edit#68) adapted to SessionView. Closes #46.

What: computeDrift consumes matching canons outside the edited span (multiset difference with pre-consume for hash-surviving lines) and reports only true deficit. scanDrift threads stored servedCanons. 5 regression tests.

Gates: typecheck pass, 1234/1234 pass, biome pass. Behavior port only (no structural change).