### PR TITLE
fix(edit): Gemma-4 tool-call bleed hardening + prompt channel wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,12 @@
 
 ### Features
 
-- **session-view:** canon-deficit drift instead of hash rotation (Closes #46)
+- **session-view:** canon-deficit drift instead of hash rotation (Closes #46) (#50)
 - user/model audience split + glossary error codes (#49) (BREAKING CHANGE)
+
+### Fixed
+
+- **edit:** Gemma-4 tool-call bleed hardening + prompt channel wording (Closes #47)
 
 ### Documentation
 

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -83,7 +83,15 @@ export function editRequestFrom(input: unknown): NormalizedEditRequest | undefin
     // but handle here for direct calls
   }
   const { path, edits } = rec as { path?: unknown; edits?: unknown };
-  if (path !== null && (typeof path !== "string" || (path as string).length === 0)) return undefined;
+  // Gemma-4 tool-call bleed (#55): the model may wrap the path in <|>, │, |,
+  // quotes, or backticks after seeing │ separators. Strip wrappers iteratively.
+  let effectivePath = path;
+  if (typeof effectivePath === "string") {
+    const sanitized = sanitizePath(effectivePath);
+    if (sanitized === null) return undefined;
+    effectivePath = sanitized;
+  }
+  if (effectivePath !== null && (typeof effectivePath !== "string" || (effectivePath as string).length === 0)) return undefined;
   if (!Array.isArray(edits) || edits.length === 0) return undefined;
   const items: EditItem[] = [];
   for (const item of edits) {
@@ -91,7 +99,50 @@ export function editRequestFrom(input: unknown): NormalizedEditRequest | undefin
     if (!normalized) return undefined;
     items.push(normalized);
   }
-  return { path: path as string | null, edits: items };
+  return { path: effectivePath as string | null, edits: items };
+}
+
+/**
+ * Strip Gemma-4 tool-call bleed wrappers from a path string: `<|>`, `\u2502`, `|`
+ * pairs plus surrounding quotes/backticks, applied iteratively. Returns the
+ * cleaned path, or null when nothing usable remains (caller rejects).
+ */
+export function sanitizePath(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  let s = value.trim();
+  let changed = true;
+  while (changed) {
+    changed = false;
+    if (s.startsWith("<|>") && s.endsWith("<|>") && s.length > 6) {
+      s = s.slice(3, -3).trim();
+      changed = true;
+    }
+    if (s.startsWith("\u2502") && s.endsWith("\u2502") && s.length > 2) {
+      s = s.slice(1, -1).trim();
+      changed = true;
+    }
+    if (s.startsWith("|") && s.endsWith("|") && s.length > 2) {
+      s = s.slice(1, -1).trim();
+      changed = true;
+    }
+    if (
+      (s.startsWith('"') && s.endsWith('"')) ||
+      (s.startsWith("'") && s.endsWith("'")) ||
+      (s.startsWith("`") && s.endsWith("`"))
+    ) {
+      s = s.slice(1, -1).trim();
+      changed = true;
+    }
+    if (s.startsWith("<|>")) {
+      s = s.slice(3).trim();
+      changed = true;
+    }
+    if (s.endsWith("<|>")) {
+      s = s.slice(0, -3).trim();
+      changed = true;
+    }
+  }
+  return s.length > 0 ? s : null;
 }
 
 export const EDIT_TUPLE_HINT =

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -14,12 +14,10 @@ export interface ToolGuidance {
 
 export const EDIT_DESCRIPTION =
   "Edit a range of lines in a text file with `{ \"path\": path, \"edits\": [[remove_from, remove_to, replacement_text], ...] }`. " +
-  "`path` is the file path or `null`. `read` returns `HASH\u2502content` (e.g. `wUp\u2502    \"site\": {`) \u2014 for `edit`, " +
-  "`remove_from`/`remove_to` are HASH anchors (bare 3-char value before `\u2502`, e.g. \"wUp\", \"AU6\"), never `HASH\u2502content` or line content. " +
-  "`replacement_text` is bare content without `HASH\u2502`, lines joined by \\n (e.g. \"    \\\"site\\\": {\\n        \\\"class\\\": SiteScraper,\"); use \"\" to delete. " +
-  "Example: read shows `wUp\u2502    \"site\": {` + `AU6\u2502        \"name\": \"old\",` \u2192 edit " +
-  "`{\"path\":\"scrape.py\",\"edits\":[[\"wUp\",\"AU6\",\"    \\\"site\\\": {\\n        \\\"class\\\": SiteScraper,\"]]}`. " +
-  "Edits in one call apply atomically; after success reuse `HASH\u2502content` from the returned diff for the next edit (no re-read needed). On failure follow the error hint.";
+  "`path` is file path or null. `read` shows `HASH\u2502content` (e.g. `wUp\u2502  \"site\": {`) \u2014 use bare 3-char HASH anchors for " +
+  "`remove_from`/`remove_to` (e.g. \"wUp\"), never `HASH\u2502content`. `replacement_text` is bare content, \\n joins lines, \"\" deletes. " +
+  "Example: `{\"path\":\"a.py\",\"edits\":[[\"wUp\",\"AU6\",\"new\"]]}`. Edits are atomic; reuse `HASH\u2502content` from the diff after success. " +
+  "On failure follow the error hint: `[MODEL]` errors need a retry with fresh anchors, `[USER]` notices are human-only.";
 
 export const EDIT_GUIDANCE: ToolGuidance = {
   intro: "Edit a range of lines via a bare 3-char HASH anchor \u2014 payload is { path, edits: [[hash,hash,text]] } (single-file atomic, null path infers).",
@@ -30,6 +28,8 @@ export const EDIT_GUIDANCE: ToolGuidance = {
     "`edit`: every `\\n` in `replacement_text` separates lines; mirror trailing blank lines explicitly (use \"\" to delete a range).",
     "`edit`: after a successful edit the returned diff shows fresh anchors (`HASH\u2502content`) \u2014 copy new `HASH` values from there for the next edit; no need to re-read.",
     "`edit`: `remove_from`/`remove_to` are inclusive; batch multiple edits to the same file only when independent \u2014 they apply atomically (fail \u2192 nothing written).",
+    "`edit`: `[MODEL]` errors (e.g. `E_STALE_*`, `E_UNSERVED_*`, `E_BAD_PAYLOAD`, `E_SERVED_ECHO`) need a retry \u2014 `[USER]` warnings/`drift:` notices are human-only.",
+    "`edit`: on `E_STALE_RANGE`/`E_UNSERVED_RANGE` retry from the echoed fresh anchors (no re-read needed); on `E_STALE_ANCHOR` re-read.",
   ],
 };
 

--- a/test/core/path-sanitize.test.ts
+++ b/test/core/path-sanitize.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { editRequestFrom, sanitizePath } from "../../src/contract.js";
+import { EDIT_DESCRIPTION } from "../../src/prompts.js";
+
+describe("gemma-4 tool-call bleed hardening (#55)", () => {
+	it("keeps EDIT_DESCRIPTION under 800 chars with canonical shape", () => {
+		expect(EDIT_DESCRIPTION.length).toBeLessThan(800);
+		expect(EDIT_DESCRIPTION).toContain('{ "path": path, "edits":');
+		expect(EDIT_DESCRIPTION).toContain("[MODEL]");
+		expect(EDIT_DESCRIPTION).toContain("[USER]");
+	});
+
+	it("leaves clean paths untouched", () => {
+		expect(sanitizePath("a.py")).toBe("a.py");
+		expect(sanitizePath("dir/sub/file.ts")).toBe("dir/sub/file.ts");
+		expect(sanitizePath(null)).toBeNull();
+		expect(sanitizePath(123)).toBeNull();
+	});
+
+	it("strips <|> wrappers", () => {
+		expect(sanitizePath("<|>a.py<|>")).toBe("a.py");
+		expect(sanitizePath("<|>a.py")).toBe("a.py");
+		expect(sanitizePath("a.py<|>")).toBe("a.py");
+	});
+
+	it("strips separator and pipe wrappers", () => {
+		expect(sanitizePath("│a.py│")).toBe("a.py");
+		expect(sanitizePath("|a.py|")).toBe("a.py");
+	});
+
+	it("strips quote and backtick wrappers, iteratively", () => {
+		expect(sanitizePath('"a.py"')).toBe("a.py");
+		expect(sanitizePath("'a.py'")).toBe("a.py");
+		expect(sanitizePath("`a.py`")).toBe("a.py");
+		expect(sanitizePath('"<|>a.py<|>"')).toBe("a.py");
+	});
+
+	it("rejects empty remainders", () => {
+		expect(sanitizePath("")).toBeNull();
+		expect(sanitizePath("   ")).toBeNull();
+		expect(sanitizePath('""')).toBeNull();
+		expect(sanitizePath("<|>")).toBeNull();
+	});
+
+	it("normalizes wrapped paths in editRequestFrom", () => {
+		const req = editRequestFrom({ path: "<|>a.py<|>", edits: [["a", "b", "c"]] });
+		expect(req?.path).toBe("a.py");
+		expect(editRequestFrom({ path: "a.py", edits: [["a", "b", "c"]] })?.path).toBe("a.py");
+		expect(editRequestFrom({ path: null, edits: [["a", "b", "c"]] })?.path).toBeNull();
+	});
+
+	it("rejects emptied paths in editRequestFrom", () => {
+		expect(editRequestFrom({ path: '""', edits: [["a", "b", "c"]] })).toBeUndefined();
+		expect(editRequestFrom({ path: "", edits: [["a", "b", "c"]] })).toBeUndefined();
+	});
+});


### PR DESCRIPTION
Port of upstream pi-better-edit e67f493 (v1.4.3, closes pi-better-edit#55) adapted to our seams. Closes #47.

What: EDIT_DESCRIPTION 851->607 chars with canonical shape + [MODEL]/[USER] channel note; EDIT_GUIDANCE channel + staleness-retry lines; contract.ts sanitizePath with editRequestFrom wiring; 8 regression tests.

Gates: typecheck pass, full suite pass, biome pass.