### PR TITLE
fix(served): epoch lifecycle belongs to full reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 
 ### Fixed
 
-- **edit:** Gemma-4 tool-call bleed hardening + prompt channel wording (Closes #47)
+- **served:** epoch lifecycle belongs to full reads (Closes #48)
+- **edit:** Gemma-4 tool-call bleed hardening + prompt channel wording (Closes #47) (#52)
 
 ### Documentation
 

--- a/src/read-and-serve.ts
+++ b/src/read-and-serve.ts
@@ -101,7 +101,14 @@ export async function readAndServe(
 			snapshotId,
 		);
 	}
-	await clearDriftReported(sessionKey, view.absolutePath);
+	// #69: epoch lifecycle belongs to full reads — a partial (paged or
+	// truncated) read merges window rows only and must not clear the
+	// drift-reported marks; only a full read resets them.
+	const isFullRead =
+		options.offset === undefined &&
+		options.limit === undefined &&
+		!view.truncation?.truncated;
+	if (isFullRead) await clearDriftReported(sessionKey, view.absolutePath);
 	const autoFooter = getAutoGuessFooter(view.absolutePath) ?? getAutoGuessFooter(rawPath) ?? getAutoGuessFooter(view.absolutePath.replace(/\\/g, "/")) ?? "";
 	const warning = autoFooter || undefined;
 	const text = view.hadUtf8DecodeErrors

--- a/src/session-view.ts
+++ b/src/session-view.ts
@@ -220,7 +220,8 @@ export async function recordServed(
 					while (updatedCanons.length > 0 && updatedCanons[updatedCanons.length - 1] === null) updatedCanons.pop();
 					store.upsertServedCanons(sessionKey, path, JSON.stringify(updatedCanons));
 				}
-				if (fullReadSnapshotId) store.upsertEpochSnapshotId(sessionKey, path, fullReadSnapshotId);
+				// #69: partial reads merge window rows + canons only — the epoch
+				// snapshotId advances on full reads alone (see isFullRead above).
 				addRetiredAnchors(
 					store,
 					sessionKey,

--- a/test/core/epoch-lifecycle.test.ts
+++ b/test/core/epoch-lifecycle.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, beforeAll } from "vitest";
+import { join } from "node:path";
+import { readAndServe } from "../../src/read-and-serve.js";
+import { localIO } from "../../src/fs-bridge.js";
+import { execPipeline } from "../../src/mutation.js";
+import { shutdownHashStore } from "../../src/hash-store.js";
+import {
+	loadServed,
+	loadEpochSnapshotId,
+	recordServed,
+	markDriftReported,
+	driftReported,
+} from "../../src/session-view.js";
+import { sessionKeyFor } from "../../src/workspace-context.js";
+import { withTempFile, withHome, getWritableTempRoot } from "../support/fixtures.js";
+import { initHasher } from "../../src/hashline/hasher.js";
+import { mkdtemp } from "fs/promises";
+import { rm } from "fs/promises";
+
+beforeAll(async () => {
+	await initHasher();
+});
+
+describe("epoch lifecycle belongs to full reads (#69)", () => {
+	it("partial read merges window rows but preserves drift-reported", async () => {
+		await withTempFile("p.txt", "one\ntwo\nthree\nfour\n", async ({ cwd, path }) => {
+			const sessionKey = sessionKeyFor("t4-partial");
+			await markDriftReported(sessionKey, path, ["abc"]);
+
+			await readAndServe(localIO(), "p.txt", cwd, {
+				sessionKey,
+				offset: 2,
+				limit: 2,
+			});
+
+			expect(await driftReported(sessionKey, path)).toEqual(new Set(["abc"]));
+		});
+	});
+
+	it("full read clears drift-reported", async () => {
+		await withTempFile("f.txt", "one\ntwo\nthree\n", async ({ cwd, path }) => {
+			const sessionKey = sessionKeyFor("t4-full");
+			await markDriftReported(sessionKey, path, ["abc"]);
+
+			await readAndServe(localIO(), "f.txt", cwd, { sessionKey });
+
+			expect(await driftReported(sessionKey, path)).toEqual(new Set());
+		});
+	});
+
+	it("recordServed advances epoch snapshotId on full reads only", async () => {
+		const home = await mkdtemp(join(await getWritableTempRoot(), "t4-epoch-"));
+		const restore = withHome(home);
+		try {
+			const sessionKey = sessionKeyFor("t4-epoch");
+			const path = join(home, "e.txt");
+			await recordServed(
+				sessionKey,
+				path,
+				[
+					{ position: 0, hash: "aaa" },
+					{ position: 1, hash: "bbb" },
+				],
+				2,
+				["aaa", "bbb"],
+				["a", "b"],
+				"snap-full",
+			);
+			expect(await loadEpochSnapshotId(sessionKey, path)).toBe("snap-full");
+
+			await markDriftReported(sessionKey, path, ["bbb"]);
+			await recordServed(
+				sessionKey,
+				path,
+				[{ position: 1, hash: "BBB" }],
+				2,
+				["aaa", "BBB"],
+				["a", "b"],
+				"snap-partial",
+			);
+			const stored = await loadServed(sessionKey, path);
+			expect(stored).toEqual(["aaa", "BBB"]);
+			expect(await loadEpochSnapshotId(sessionKey, path)).toBe("snap-full");
+			expect(await driftReported(sessionKey, path)).toEqual(new Set(["bbb"]));
+		} finally {
+			shutdownHashStore();
+			await rm(home, { recursive: true, force: true });
+			restore();
+		}
+	});
+
+	it("malformed-anchor edit throws before any serve write", async () => {
+		const home = await mkdtemp(join(await getWritableTempRoot(), "t4-preload-"));
+		const restore = withHome(home);
+		try {
+			const sessionKey = sessionKeyFor("t4-preload");
+			await expect(
+				execPipeline(
+					localIO(),
+					{
+						path: "nope.txt",
+						remove_from: "MQX│const x = 1;",
+						remove_to: "MQX",
+						replacement_text: "y",
+					} as any,
+					home,
+					{ sessionKey },
+				),
+			).rejects.toThrow(/\[E_BAD_ANCHOR\]/);
+			expect(await loadServed(sessionKey, join(home, "nope.txt"))).toEqual([]);
+		} finally {
+			shutdownHashStore();
+			await rm(home, { recursive: true, force: true });
+			restore();
+		}
+	});
+});


### PR DESCRIPTION
Port of upstream pi-better-edit 3918292 (v1.6.0, refs pi-better-edit#69) adapted to our seams. Closes #48.

What: clearDriftReported gated on full reads in read-and-serve; recordServed partial no longer advances epoch snapshotId; verified pre-load malformed-anchor edits write zero serves. 4 regression tests.

Gates: typecheck pass, 1246/1246 pass, build pass, biome pass.