### PR TITLE
fix: review follow-ups from 1.6.0 absorb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 
+- review follow-ups from 1.6.0 absorb (Closes #55)
 - **served:** epoch lifecycle belongs to full reads (Closes #48) (#54)
 - **edit:** Gemma-4 tool-call bleed hardening + prompt channel wording (Closes #47) (#52)
 

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -10,7 +10,7 @@
  */
 
 import { EDITS_MAX_ITEMS } from "./constants.js";
-import { isRec, normalizeFilePath, rejectUnknownFields } from "./utils.js";
+import { isRec, normalizeFilePath, rejectUnknownFields, CodedError } from "./utils.js";
 
 // ---- request shapes --------------------------------------------------------
 
@@ -107,42 +107,44 @@ export function editRequestFrom(input: unknown): NormalizedEditRequest | undefin
  * pairs plus surrounding quotes/backticks, applied iteratively. Returns the
  * cleaned path, or null when nothing usable remains (caller rejects).
  */
+/** Paired/single bleed wrappers, longest-token first. Each entry strips one layer. */
+const PATH_WRAPPERS: ReadonlyArray<{
+	open: string;
+	close: string;
+	/** Minimum surviving length guard (keeps `"<|>"` alone from vanishing mid-loop). */
+	minLen: number;
+	pairOnly: boolean;
+}> = [
+	{ open: "<|>", close: "<|>", minLen: 6, pairOnly: false },
+	{ open: "\u2502", close: "\u2502", minLen: 2, pairOnly: true },
+	{ open: "|", close: "|", minLen: 2, pairOnly: true },
+	{ open: '"', close: '"', minLen: 0, pairOnly: true },
+	{ open: "'", close: "'", minLen: 0, pairOnly: true },
+	{ open: "`", close: "`", minLen: 0, pairOnly: true },
+];
+
 export function sanitizePath(value: unknown): string | null {
-  if (typeof value !== "string") return null;
-  let s = value.trim();
-  let changed = true;
-  while (changed) {
-    changed = false;
-    if (s.startsWith("<|>") && s.endsWith("<|>") && s.length > 6) {
-      s = s.slice(3, -3).trim();
-      changed = true;
-    }
-    if (s.startsWith("\u2502") && s.endsWith("\u2502") && s.length > 2) {
-      s = s.slice(1, -1).trim();
-      changed = true;
-    }
-    if (s.startsWith("|") && s.endsWith("|") && s.length > 2) {
-      s = s.slice(1, -1).trim();
-      changed = true;
-    }
-    if (
-      (s.startsWith('"') && s.endsWith('"')) ||
-      (s.startsWith("'") && s.endsWith("'")) ||
-      (s.startsWith("`") && s.endsWith("`"))
-    ) {
-      s = s.slice(1, -1).trim();
-      changed = true;
-    }
-    if (s.startsWith("<|>")) {
-      s = s.slice(3).trim();
-      changed = true;
-    }
-    if (s.endsWith("<|>")) {
-      s = s.slice(0, -3).trim();
-      changed = true;
-    }
-  }
-  return s.length > 0 ? s : null;
+	if (typeof value !== "string") return null;
+	let cleaned = value.trim();
+	let changed = true;
+	while (changed) {
+		changed = false;
+		for (const w of PATH_WRAPPERS) {
+			if (cleaned.length > w.minLen && cleaned.startsWith(w.open) && cleaned.endsWith(w.close)) {
+				cleaned = cleaned.slice(w.open.length, -w.close.length).trim();
+				changed = true;
+			} else if (!w.pairOnly) {
+				if (cleaned.startsWith(w.open)) {
+					cleaned = cleaned.slice(w.open.length).trim();
+					changed = true;
+				} else if (cleaned.endsWith(w.close)) {
+					cleaned = cleaned.slice(0, -w.close.length).trim();
+					changed = true;
+				}
+			}
+		}
+	}
+	return cleaned.length > 0 ? cleaned : null;
 }
 
 export const EDIT_TUPLE_HINT =
@@ -200,52 +202,52 @@ export function prepareEditArguments(args: unknown): Record<string, unknown> {
   if (valid) {
     return { path: valid.path, edits: (args as Record<string, unknown>).edits };
   }
-  throw new Error(`[MODEL] [E_BAD_PAYLOAD] ${EDIT_TUPLE_HINT} ${describeReceived(args)}`);
+  throw new CodedError("E_BAD_PAYLOAD",`[MODEL] [E_BAD_PAYLOAD] ${EDIT_TUPLE_HINT} ${describeReceived(args)}`);
 }
 
 // ---- assertions ---------------------------------------------------------------
 
 export function assertEditRequest(request: unknown): asserts request is NormalizedEditRequest {
   if (!isNormalizedEdit(request)) {
-    throw new Error("[MODEL] [E_BAD_PAYLOAD] Edit request must be exactly { path, edits: [[remove_from, remove_to, replacement_text], ...] }.");
+    throw new CodedError("E_BAD_PAYLOAD", "[MODEL] [E_BAD_PAYLOAD] Edit request must be exactly { path, edits: [[remove_from, remove_to, replacement_text], ...] }.");
   }
   rejectUnknownFields(request as Record<string, unknown>, EDIT_KS, "Edit request");
   const req = request as NormalizedEditRequest;
   if (req.path !== null && (typeof req.path !== "string" || req.path.length === 0)) {
-    throw new Error('[MODEL] [E_BAD_PAYLOAD] Edit request path must be a non-empty string or null.');
+    throw new CodedError("E_BAD_PAYLOAD", '[MODEL] [E_BAD_PAYLOAD] Edit request path must be a non-empty string or null.');
   }
   if (!Array.isArray(req.edits) || req.edits.length === 0) {
-    throw new Error('[MODEL] [E_BAD_PAYLOAD] Edit request requires a non-empty "edits" array.');
+    throw new CodedError("E_BAD_PAYLOAD", '[MODEL] [E_BAD_PAYLOAD] Edit request requires a non-empty "edits" array.');
   }
   if (req.edits.length > EDITS_MAX_ITEMS) {
-    throw new Error(`[MODEL] [E_BAD_PAYLOAD] edit accepts at most ${EDITS_MAX_ITEMS} edits; got ${req.edits.length}. Split the batch.`);
+    throw new CodedError("E_BAD_PAYLOAD",`[MODEL] [E_BAD_PAYLOAD] edit accepts at most ${EDITS_MAX_ITEMS} edits; got ${req.edits.length}. Split the batch.`);
   }
   for (let index = 0; index < req.edits.length; index++) {
     const item = req.edits[index]!;
     if (typeof item.remove_from !== "string" || typeof item.remove_to !== "string" || typeof item.replacement_text !== "string") {
-      throw new Error(`[MODEL] [E_BAD_PAYLOAD] Edit request edits[${index}] must be a three-position array [remove_from, remove_to, replacement_text].`);
+      throw new CodedError("E_BAD_PAYLOAD",`[MODEL] [E_BAD_PAYLOAD] Edit request edits[${index}] must be a three-position array [remove_from, remove_to, replacement_text].`);
     }
   }
 }
 
 // legacy — now always fails with new shape message (batch_edit removed)
 export function assertBatchEditRequest(_request: unknown): asserts _request is BatchEditParams {
-  throw new Error("[MODEL] [E_BAD_PAYLOAD] batch_edit has been removed. Use edit with { path, edits: [[remove_from, remove_to, replacement_text], ...] }.");
+  throw new CodedError("E_BAD_PAYLOAD", "[MODEL] [E_BAD_PAYLOAD] batch_edit has been removed. Use edit with { path, edits: [[remove_from, remove_to, replacement_text], ...] }.");
 }
 
 export function assertReadRequest(request: unknown): asserts request is ReadParams {
-  if (!isRec(request)) throw new Error("[MODEL] [E_BAD_PAYLOAD] Read request must be an object.");
+  if (!isRec(request)) throw new CodedError("E_BAD_PAYLOAD", "[MODEL] [E_BAD_PAYLOAD] Read request must be an object.");
   rejectUnknownFields(request, READ_KS, "Read request");
   if (typeof request.path !== "string" || request.path.length === 0) {
-    throw new Error('[MODEL] [E_BAD_PAYLOAD] Read request requires a non-empty "path" string.');
+    throw new CodedError("E_BAD_PAYLOAD", '[MODEL] [E_BAD_PAYLOAD] Read request requires a non-empty "path" string.');
   }
 }
 
 export function assertUndoRequest(request: unknown): asserts request is UndoParams {
-  if (!isRec(request)) throw new Error("[MODEL] [E_BAD_PAYLOAD] undo_last_edit request must be an object.");
+  if (!isRec(request)) throw new CodedError("E_BAD_PAYLOAD", "[MODEL] [E_BAD_PAYLOAD] undo_last_edit request must be an object.");
   normalizeFilePath(request);
   if (typeof request.path !== "string" || request.path.length === 0) {
-    throw new Error('[MODEL] [E_BAD_PAYLOAD] undo_last_edit request requires a non-empty "path" string.');
+    throw new CodedError("E_BAD_PAYLOAD", '[MODEL] [E_BAD_PAYLOAD] undo_last_edit request requires a non-empty "path" string.');
   }
 }
 

--- a/src/edit-response.ts
+++ b/src/edit-response.ts
@@ -5,6 +5,10 @@ import { visLines, clipLine } from "./utils.js";
 
 export type EditDetails = {
 	diff: string;
+	/** Bare `E_*` code for the primary error signal, if any (no `[MODEL]` prefix). Structured counterpart to message-string codes. */
+	errCode?: string;
+	/** Disambiguator for `E_UNSERVED_RANGE`: boundary miss vs interior hole. */
+	unservedKind?: "boundary" | "interior";
 	firstChangedLine?: number;
 	snapshotId?: string;
 	classification?: "noop";
@@ -103,10 +107,7 @@ export interface FinalizeInput {
 }
 
 export function finalizeResult(input: FinalizeInput): string {
-	const modelWarnings = input.warnings?.filter(
-		(w) => !w.startsWith("Batch drift note:"),
-	);
-	const base = input.diff + warnBlock(modelWarnings);
+	const base = input.diff + warnBlock(input.warnings);
 	return base;
 }
 
@@ -154,10 +155,7 @@ export function buildNoop(input: NoopInput): TResult {
 	const noopDetailsText = noopEdit
 		? `Edit for ${noopEdit.loc} is identical to current content:\n  ${noopEdit.loc}: ${clipLine(noopEdit.currentContent)}`
 		: "The edit produced identical content.";
-	const modelWarnings = warnings?.filter(
-		(w) => !w.startsWith("Batch drift note:"),
-	);
-	const text = `No changes made to ${path}\nClassification: noop\n${noopDetailsText}${warnBlock(modelWarnings)}`;
+	const text = `No changes made to ${path}\nClassification: noop\n${noopDetailsText}${warnBlock(warnings)}`;
 
 	const metrics = buildMetrics({
 		classification: "noop",
@@ -202,10 +200,7 @@ export function buildChanged(input: SuccessInput): TResult {
 	);
 	const addedLines = editMeta.addedLines;
 	const removedLines = editMeta.removedLines;
-	const modelWarnings = warnings?.filter(
-		(w) => !w.startsWith("Batch drift note:"),
-	);
-	const warningsBlock = warnBlock(modelWarnings);
+	const warningsBlock = warnBlock(warnings);
 	const successPrefix = `Successfully edited in ${path}.`;
 	const lineSummary =
 		addedLines > 0 || removedLines > 0
@@ -283,10 +278,7 @@ export function buildBatchResult(sections: BatchSection[]): TResult {
 		.join("\n\n");
 
 	if (allNoop) {
-		const modelWarnings = warnings.filter(
-			(w) => !w.startsWith("Batch drift note:"),
-		);
-		const text = `No changes made. All ${totalEdits} edit(s) in the batch produced identical content.\nClassification: noop${warnBlock(modelWarnings)}`;
+			const text = `No changes made. All ${totalEdits} edit(s) in the batch produced identical content.\nClassification: noop${warnBlock(warnings)}`;
 		return {
 			content: [{ type: "text", text }],
 			details: {
@@ -330,10 +322,7 @@ export function buildBatchResult(sections: BatchSection[]): TResult {
 			? ` Added ${addedLines} line(s), removed ${removedLines} line(s).`
 			: "";
 	const summary = `Successfully edited ${appliedFiles.length} file(s) — ${appliedTotal} of ${totalEdits} edit(s) applied${noopTotal > 0 ? ` (${noopTotal} noop)` : ""}.${lineSummary}`;
-	const modelWarnings = warnings.filter(
-		(w) => !w.startsWith("Batch drift note:"),
-	);
-	const baseText = `${summary}${warnBlock(modelWarnings)}`;
+	const baseText = `${summary}${warnBlock(warnings)}`;
 	const diffSection = formatDiffCard(diff);
 	const text = `${baseText}${diffSection}`;
 

--- a/src/fs-bridge.ts
+++ b/src/fs-bridge.ts
@@ -38,6 +38,7 @@ import {
   prepareForSave,
 } from "./file-encoding-state.js";
 import type { FileEncodingState } from "./file-encoding-state.js";
+import { codeOf } from "./utils.js";
 
 // Re-export file encoding state seam for backward compat (file-view, read-and-serve, tests)
 export type { FileEncodingState } from "./file-encoding-state.js";
@@ -370,7 +371,7 @@ export function localIO(): FileIO {
         return decoded.text;
       } catch (error) {
         // Local fallback: when autoGuess off, E_UNSUPPORTED_FILE should fall back to raw UTF-8 with � (no throw)
-        if (error instanceof Error && error.message.includes("[E_UNSUPPORTED_FILE]")) {
+        if (codeOf(error) === "E_UNSUPPORTED_FILE") {
           return readFile(absolutePath, "utf-8");
         }
         throw error;

--- a/src/hashline/anchor-pipeline.ts
+++ b/src/hashline/anchor-pipeline.ts
@@ -17,7 +17,7 @@
  * @module dsh-better-edit/hashline/anchor-pipeline
  */
 
-import { abortIf, splitLines, rejectUnknownFields, clipLine } from "../utils.js";
+import { abortIf, splitLines, rejectUnknownFields, clipLine, CodedError } from "../utils.js";
 import { HASH_CLASS, HL_BARE_PREFIX_RE, HL_PREFIX_PLUS_RE, HL_PREFIX_MINUS_RE, HASH_SEP, ANCHOR_LEN, ALPH_RE, canon, lineHashesPure, getCanonForHash, rememberHashCanon } from "./hash-assign.js";
 import { recordServed, servedPositionsOf } from "../session-view.js";
 import { SERVED_ECHO_CAP } from "../constants.js";
@@ -65,7 +65,7 @@ function parseRef(ref: string): Anchor {
 		return { hash: trimmed };
 	}
 
-	throw new Error(diagRef(ref));
+	throw new CodedError("E_BAD_ANCHOR", diagRef(ref));
 }
 
 export const parseHashRef = parseRef;
@@ -223,28 +223,28 @@ function assertItem(edit: Record<string, unknown>): void {
 	);
 
 	if ("remove_from" in edit && typeof edit.remove_from !== "string") {
-		throw new Error(
+		throw new CodedError("E_BAD_PAYLOAD",
 			`[MODEL] [E_BAD_PAYLOAD] Field "remove_from" must be an anchor string (3-char hash).`,
 		);
 	}
 	if ("remove_to" in edit && typeof edit.remove_to !== "string") {
-		throw new Error(
+		throw new CodedError("E_BAD_PAYLOAD",
 			`[MODEL] [E_BAD_PAYLOAD] Field "remove_to" must be an anchor string (3-char hash).`,
 		);
 	}
 	if (!("replacement_text" in edit)) {
-		throw new Error(
+		throw new CodedError("E_BAD_PAYLOAD",
 			`[MODEL] [E_BAD_PAYLOAD] The edit requires a "replacement_text" field. Provide the replacement text (use "" to delete).`,
 		);
 	}
 	if (typeof edit.replacement_text !== "string") {
-		throw new Error(NEW_CONTENT_NOT_STRING_MSG);
+		throw new CodedError("E_BAD_PAYLOAD", NEW_CONTENT_NOT_STRING_MSG);
 	}
 	if (
 		typeof edit.remove_from !== "string" ||
 		typeof edit.remove_to !== "string"
 	) {
-		throw new Error(
+		throw new CodedError("E_BAD_PAYLOAD",
 			`[MODEL] [E_BAD_PAYLOAD] The edit requires "remove_from" and "remove_to" anchor strings (3-char hashes from read output).`,
 		);
 	}
@@ -271,7 +271,7 @@ export function resEdit(edit: HTEdit, _warnings?: string[]): HEdit {
 			const hash = firstHashFromBlock(trimmed);
 			if (hash) {
 				const lines = trimmed.split("\n").length;
-				throw new Error(`[MODEL] [E_BAD_ANCHOR] extracted first hash "${hash}" from ${lines}-line block — use bare "${hash}" next time`);
+				throw new CodedError("E_BAD_ANCHOR",`[MODEL] [E_BAD_ANCHOR] extracted first hash "${hash}" from ${lines}-line block — use bare "${hash}" next time`);
 			}
 		}
 		const match = trimmed.match(ANCHOR_ROW_RE);
@@ -284,7 +284,7 @@ export function resEdit(edit: HTEdit, _warnings?: string[]): HEdit {
 			} else {
 				message = `[E_BAD_ANCHOR] stripped "HASH│" prefix from remove_from/remove_to "${trimmed}".`;
 			}
-			throw new Error(`[MODEL] ${message}`);
+			throw new CodedError("E_BAD_ANCHOR", `[MODEL] ${message}`);
 		}
 		return ref;
 	}) as [string, string];
@@ -428,7 +428,7 @@ function valEdit(
 		return { resolved: undefined, mismatches };
 	}
 	if (startResolved.line > endResolved.line) {
-		throw new Error(
+		throw new CodedError("E_REVERSED_ANCHORS",
 			`[MODEL] [E_REVERSED_ANCHORS] Range start line ${startResolved.line} must be <= end line ${endResolved.line} (anchors ${edit.hash_bounds[0].hash} and ${edit.hash_bounds[1].hash}).`,
 		);
 	}
@@ -456,7 +456,7 @@ export interface ServedRow {
 	hash: string;
 }
 
-export class ServedRejectionError extends Error {
+export class ServedRejectionError extends CodedError {
 	readonly code: ServedCode;
 	readonly unservedKind: "boundary" | "interior" | undefined;
 	readonly firstOffendingLine: number | undefined;
@@ -469,7 +469,7 @@ export class ServedRejectionError extends Error {
 		firstOffendingLine?: number;
 		servedRows: ServedRow[];
 	}) {
-		super(opts.message);
+		super(opts.code, opts.message);
 		this.name = "ServedRejectionError";
 		this.code = opts.code;
 		this.unservedKind = opts.unservedKind;
@@ -484,11 +484,11 @@ export function isServedRejection(
 	return error instanceof ServedRejectionError;
 }
 
-export class AnchorMismatchError extends Error {
+export class AnchorMismatchError extends CodedError {
 	readonly servedRows: ServedRow[];
 
 	constructor(message: string, servedRows: ServedRow[]) {
-		super(message);
+		super("E_STALE_ANCHOR", message);
 		this.name = "AnchorMismatchError";
 		this.servedRows = servedRows;
 	}
@@ -497,10 +497,10 @@ export class AnchorMismatchError extends Error {
 /** Thrown when replacement_text carries anchor-syntax garbage (HASH│/diff-preview prefixes).
  * Carries the stripped edit so applyEdit can distinguish served-echo (→ E_SERVED_ECHO
  * denial downstream) from garbage (→ E_BAD_ANCHOR stands). */
-export class BadAnchorError extends Error {
+export class BadAnchorError extends CodedError {
 	readonly stripped: HEdit;
 	constructor(message: string, stripped: HEdit) {
-		super(message);
+		super("E_BAD_ANCHOR", message);
 		this.name = "BadAnchorError";
 		this.stripped = stripped;
 	}

--- a/src/read-and-serve.ts
+++ b/src/read-and-serve.ts
@@ -91,15 +91,11 @@ export async function readAndServe(
 		for (let i = 0; i < view.hashes.length; i++) {
 			fullCanons.push(canons[i] ?? null);
 		}
-		await recordServed(
-			sessionKey,
-			view.absolutePath,
-			view.served,
-			view.hashes.length,
-			view.hashes,
-			fullCanons,
+		await recordServed(sessionKey, view.absolutePath, view.served, view.hashes.length, {
+			hashes: view.hashes,
+			canons: fullCanons,
 			snapshotId,
-		);
+		});
 	}
 	// #69: epoch lifecycle belongs to full reads — a partial (paged or
 	// truncated) read merges window rows only and must not clear the

--- a/src/session-view.ts
+++ b/src/session-view.ts
@@ -171,24 +171,29 @@ export async function retireAnchors(
 	});
 }
 
+/** Full-file context for a complete read — when present and matching `rows`, the call is a full read. */
+export interface FullReadContext {
+	hashes: readonly string[];
+	canons?: readonly (string | null)[];
+	snapshotId?: string;
+}
+
 export async function recordServed(
 	sessionKey: string,
 	path: string,
 	rows: ServedEntry[],
 	lineCount?: number,
-	fullReadHashes?: readonly string[],
-	fullReadCanons?: readonly (string | null)[],
-	fullReadSnapshotId?: string,
+	full?: FullReadContext,
 ): Promise<void> {
 	if (rows.length === 0) return;
 	try {
 		const store = await loadServedStore();
 		const isFullRead =
-			fullReadHashes !== undefined &&
-			rows.length === fullReadHashes.length &&
+			full !== undefined &&
+			rows.length === full.hashes.length &&
 			rows.every(
 				(row, index) =>
-					row.position === index && row.hash === fullReadHashes[index],
+					row.position === index && row.hash === full.hashes[index],
 			);
 		withStore(() => {
 			const current = store.getServed(sessionKey, path);
@@ -198,16 +203,16 @@ export async function recordServed(
 			}
 			if (isFullRead) {
 				store.clearRetiredAnchors(sessionKey, path);
-				if (fullReadCanons) store.upsertServedCanons(sessionKey, path, JSON.stringify(fullReadCanons));
-				if (fullReadSnapshotId) store.upsertEpochSnapshotId(sessionKey, path, fullReadSnapshotId);
+				if (full?.canons) store.upsertServedCanons(sessionKey, path, JSON.stringify(full.canons));
+				if (full?.snapshotId) store.upsertEpochSnapshotId(sessionKey, path, full.snapshotId);
 			} else {
 			// For partial reads, update canons for the served rows via hash-to-canon map (robust for partial views)
-				if (fullReadCanons && fullReadHashes) {
+				if (full?.canons && full.hashes) {
 					const canonByHash = new Map<string, string | null>();
-					for (let i = 0; i < fullReadHashes.length; i++) {
-						const h = fullReadHashes[i]!;
-						const c = fullReadCanons[i] ?? null;
-						if (h) canonByHash.set(h, c);
+					for (let i = 0; i < full.hashes.length; i++) {
+						const lineHash = full.hashes[i]!;
+						const lineCanon = full.canons[i] ?? null;
+						if (lineHash) canonByHash.set(lineHash, lineCanon);
 					}
 					const currentCanons = store.getServedCanons(sessionKey, path);
 					const updatedCanons = currentCanons.slice();

--- a/src/tool-edit.ts
+++ b/src/tool-edit.ts
@@ -15,6 +15,7 @@ import {
 import { abortIf } from "./utils.js";
 import { execute } from "./mutation.js";
 import { EDIT_DESCRIPTION } from "./prompts.js";
+import { codeOf } from "./utils.js";
 import type { FileIO } from "./fs-bridge.js";
 import { execCwd, execSessionKey } from "./workspace-context.js";
 import type { FsSandboxController, FsEscalationArgs } from "./sandbox.js";
@@ -40,7 +41,7 @@ async function resolveNullPath(edits: Array<{ remove_from: string; remove_to: st
       throw new Error(`[MODEL] [E_BAD_PAYLOAD] Edit request requires a non-empty "path" string; the anchors match multiple known files: ${matches.join(", ")}. Include the intended path.`);
     }
   } catch (e) {
-    if (e instanceof Error && e.message.includes("[E_BAD_PAYLOAD]")) throw e;
+    if (codeOf(e) === "E_BAD_PAYLOAD") throw e;
     return undefined;
   }
   return undefined;

--- a/src/tool-undo.ts
+++ b/src/tool-undo.ts
@@ -8,7 +8,7 @@
 import type { Context } from "@deepseek-ai/cordis";
 import { defineTool } from "@deepseek-ai/dsh-tools";
 import { toLF, stripBOM, genDiff, restoreEndings } from "./edit-diff.js";
-import { cntDiff, splitLines } from "./utils.js";
+import { cntDiff, splitLines, codeOf } from "./utils.js";
 import { assertUndoRequest } from "./contract.js";
 import { normalizeRequest as normReq } from "./contract.js";
 import { upsertSnapshotFor } from "./hash-store.js";
@@ -77,7 +77,7 @@ export function buildUndoTool(io: FileIO, sandbox: FsSandboxController) {
 					currentRaw = await io.readText(absolutePath, signal);
 				} catch (error) {
 					const message = error instanceof Error ? error.message : String(error);
-					if (message.includes("[E_NOT_FOUND]")) {
+					if (codeOf(error) === "E_NOT_FOUND") {
 						await clearUndo(absolutePath);
 						return `[E_UNDO_STALE] cannot undo on ${path}: file no longer exists.`;
 					}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -90,3 +90,25 @@ export function clipLine(line: string, maxLen = 200): string {
 	const flat = line.replace(/\n/g, "\\n");
 	return flat.length > maxLen ? `${flat.slice(0, maxLen)}...` : flat;
 }
+
+/** Machine-readable error-code carrier — bare `E_*` code alongside the human message. */
+export class CodedError extends Error {
+	readonly code: string;
+	constructor(code: string, message: string) {
+		super(message);
+		this.name = "CodedError";
+		this.code = code;
+	}
+}
+
+const CODED_RE = /\[(E_[A-Z_]+)\]/;
+
+/** Structured bare-code read for any tool error: carrier first, `[E_*]` message convention as fallback. */
+export function codeOf(error: unknown): string | undefined {
+	if (error instanceof CodedError) return error.code;
+	if (error instanceof Error) {
+		const m = error.message.match(CODED_RE);
+		if (m) return m[1]!;
+	}
+	return undefined;
+}

--- a/test/core/epoch-lifecycle.test.ts
+++ b/test/core/epoch-lifecycle.test.ts
@@ -54,30 +54,19 @@ describe("epoch lifecycle belongs to full reads (#69)", () => {
 		try {
 			const sessionKey = sessionKeyFor("t4-epoch");
 			const path = join(home, "e.txt");
-			await recordServed(
-				sessionKey,
-				path,
-				[
-					{ position: 0, hash: "aaa" },
-					{ position: 1, hash: "bbb" },
-				],
-				2,
-				["aaa", "bbb"],
-				["a", "b"],
-				"snap-full",
-			);
+			await recordServed(sessionKey, path, [{ position: 0, hash: "aaa" }, { position: 1, hash: "bbb" }], 2, {
+				hashes: ["aaa", "bbb"],
+				canons: ["a", "b"],
+				snapshotId: "snap-full",
+			});
 			expect(await loadEpochSnapshotId(sessionKey, path)).toBe("snap-full");
 
 			await markDriftReported(sessionKey, path, ["bbb"]);
-			await recordServed(
-				sessionKey,
-				path,
-				[{ position: 1, hash: "BBB" }],
-				2,
-				["aaa", "BBB"],
-				["a", "b"],
-				"snap-partial",
-			);
+			await recordServed(sessionKey, path, [{ position: 1, hash: "BBB" }], 2, {
+				hashes: ["aaa", "BBB"],
+				canons: ["a", "b"],
+				snapshotId: "snap-partial",
+			});
 			const stored = await loadServed(sessionKey, path);
 			expect(stored).toEqual(["aaa", "BBB"]);
 			expect(await loadEpochSnapshotId(sessionKey, path)).toBe("snap-full");

--- a/test/core/error-codes.test.ts
+++ b/test/core/error-codes.test.ts
@@ -1,39 +1,126 @@
-import { readFileSync, readdirSync } from "node:fs";
-import { join, dirname } from "node:path";
-import { fileURLToPath } from "url";
 import { describe, expect, it } from "vitest";
+import { assertEditRequest } from "../../src/contract.js";
+import { CodedError, codeOf } from "../../src/utils.js";
+import {
+	resEdit,
+	verifyServedRange,
+	AnchorMismatchError,
+	ServedRejectionError,
+	lineHashesPure,
+} from "../../src/hashline/index.js";
+import { finalizeResult, type EditDetails } from "../../src/edit-response.js";
 
-const root = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
-const codeRe = /\[E_[A-Z0-9_]+\]/g;
-
-function collectCodes(dir: string): Set<string> {
-  const codes = new Set<string>();
-  for (const entry of readdirSync(dir, { withFileTypes: true })) {
-    const full = join(dir, entry.name);
-    if (entry.isDirectory()) {
-      for (const code of collectCodes(full)) codes.add(code);
-    } else if (entry.name.endsWith(".ts")) {
-      for (const match of readFileSync(full, "utf-8").matchAll(codeRe)) {
-        codes.add(match[0]);
-      }
-    }
-  }
-  return codes;
+function codeOfThrow(fn: () => unknown): string | undefined {
+	try {
+		fn();
+	} catch (error) {
+		return codeOf(error);
+	}
+	throw new Error("expected throw");
 }
 
-const readmeCodes = new Set([
-  ...readFileSync(join(root, "README.md"), "utf-8").matchAll(codeRe),
-].map((match) => match[0]));
-const srcCodes = collectCodes(join(root, "src"));
+describe("structured error codes (#55 S1)", () => {
+	it("contract rejects carry bare E_BAD_PAYLOAD", () => {
+		try {
+			assertEditRequest({ path: 123, edits: [] });
+			expect.unreachable();
+		} catch (error) {
+			expect(error).toBeInstanceOf(CodedError);
+			expect((error as CodedError).code).toBe("E_BAD_PAYLOAD");
+			expect(codeOf(error)).toBe("E_BAD_PAYLOAD");
+		}
+	});
 
-describe("error code contract", () => {
-  it("documents every error code emitted by src in the README", () => {
-    const undocumented = [...srcCodes].filter((code) => !readmeCodes.has(code)).sort();
-    expect(undocumented).toEqual([]);
-  });
+	it("anchor-syntax throws carry bare E_BAD_ANCHOR", () => {
+		expect(codeOfThrow(() => resEdit({ remove_from: "MQX│x", remove_to: "MQX", replacement_text: "y" } as any))).toBe(
+			"E_BAD_ANCHOR",
+		);
+	});
 
-  it("emits every error code documented in the README", () => {
-    const phantom = [...readmeCodes].filter((code) => !srcCodes.has(code)).sort();
-    expect(phantom).toEqual([]);
-  });
+	it("tombstoned anchor with changed canon carries E_STALE_RANGE", () => {
+		const hashes = lineHashesPure("a\nb\nc");
+		try {
+			verifyServedRange({
+				served: [...hashes],
+				servedCanons: ["zzz", "b", "c"],
+				tombstone: new Set([hashes[0]!]),
+				startHash: hashes[0]!,
+				endHash: hashes[1]!,
+				startLine: 1,
+				endLine: 2,
+				fileHashes: hashes,
+				fileLines: ["a", "b", "c"],
+			});
+			expect.unreachable();
+		} catch (error) {
+			expect(error).toBeInstanceOf(ServedRejectionError);
+			expect((error as ServedRejectionError).code).toBe("E_STALE_RANGE");
+			expect(codeOf(error)).toBe("E_STALE_RANGE");
+		}
+	});
+
+	it("interior hole carries E_UNSERVED_RANGE with kind", () => {
+		const hashes = lineHashesPure("a\nb\nc");
+		try {
+			verifyServedRange({
+				served: [hashes[0]!, null, hashes[2]!],
+				startHash: hashes[0]!,
+				endHash: hashes[2]!,
+				startLine: 1,
+				endLine: 3,
+				fileHashes: hashes,
+				fileLines: ["a", "b", "c"],
+			});
+			expect.unreachable();
+		} catch (error) {
+			expect(error).toBeInstanceOf(ServedRejectionError);
+			expect((error as ServedRejectionError).code).toBe("E_UNSERVED_RANGE");
+			expect((error as ServedRejectionError).unservedKind).toBe("interior");
+		}
+	});
+
+	it("ambiguous served anchor carries E_UNSERVED_RANGE with boundary kind", () => {
+		const hashes = lineHashesPure("a\nb\nc");
+		try {
+			verifyServedRange({
+				served: [hashes[0]!, hashes[0]!, hashes[2]!],
+				startHash: hashes[0]!,
+				endHash: hashes[1]!,
+				startLine: 1,
+				endLine: 2,
+				fileHashes: hashes,
+				fileLines: ["a", "b", "c"],
+			});
+			expect.unreachable();
+		} catch (error) {
+			expect(error).toBeInstanceOf(ServedRejectionError);
+			expect((error as ServedRejectionError).code).toBe("E_UNSERVED_RANGE");
+			expect((error as ServedRejectionError).unservedKind).toBe("boundary");
+		}
+	});
+
+	it("anchor mismatch carries E_STALE_ANCHOR", () => {
+		const error = new AnchorMismatchError("m", []);
+		expect(error.code).toBe("E_STALE_ANCHOR");
+		expect(codeOf(error)).toBe("E_STALE_ANCHOR");
+	});
+
+	it("codeOf falls back to message convention, else undefined", () => {
+		expect(codeOf(new Error("[MODEL] [E_EMPTY_RANGE] x"))).toBe("E_EMPTY_RANGE");
+		expect(codeOf(new Error("plain failure"))).toBeUndefined();
+		expect(codeOf("nope")).toBeUndefined();
+	});
+
+	it("EditDetails accepts structured errCode/unservedKind", () => {
+		const details: EditDetails = { diff: "", errCode: "E_BAD_PAYLOAD", unservedKind: "boundary" };
+		expect(details.errCode).toBe("E_BAD_PAYLOAD");
+	});
+});
+
+describe("batch drift note retired (#55 S2)", () => {
+	it("passes warnings through with no special-casing", () => {
+		const text = finalizeResult({ diff: "d", warnings: ["Batch drift note: x", "other"] });
+		expect(text).toContain("Batch drift note: x");
+		expect(text).toContain("other");
+	});
 });


### PR DESCRIPTION
Closes #55. Follow-ups from the two-axis review of the v1.6.0 absorb.

S1: structured error codes in tool details (CodedError carrier + codeOf reader; EditDetails gains errCode/unservedKind; messages byte-identical). S2: batch drift note retired (no producer existed; dead content filters removed). R1/R3/R4 smell refactors, behavior-preserving (R2 skipped: pointwise verify-compares vs multiset accounting resist sharing).

Gates: typecheck pass, 1253/1253 pass, build pass, biome pass.