### PR TITLE
fix(served): refresh canons on truncated serve records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 
 ### Fixed
 
-- review follow-ups from 1.6.0 absorb (Closes #55)
+- **served:** refresh canons on truncated serve records (Closes #53)
+- review follow-ups from 1.6.0 absorb (Closes #55) (#56)
 - **served:** epoch lifecycle belongs to full reads (Closes #48) (#54)
 - **edit:** Gemma-4 tool-call bleed hardening + prompt channel wording (Closes #47) (#52)
 

--- a/src/mutation.ts
+++ b/src/mutation.ts
@@ -410,6 +410,7 @@ export async function execute(opts: {
           entry.servedRows,
           splitLines(fileResult.result).length,
           fileResult.range.startLine - 1,
+          splitLines(fileResult.result).map((l) => canon(l)),
         );
       }
     }

--- a/src/session-view.ts
+++ b/src/session-view.ts
@@ -240,7 +240,7 @@ export async function recordServed(
 	}
 }
 
-export async function recordServedTruncated(sessionKey: string, path: string, rows: ServedEntry[], lineCount: number, clearFrom = 0): Promise<void> {
+export async function recordServedTruncated(sessionKey: string, path: string, rows: ServedEntry[], lineCount: number, clearFrom = 0, fullCanons?: readonly (string | null)[]): Promise<void> {
 	if (rows.length === 0) return;
 	try {
 		const store = await loadServedStore();
@@ -249,6 +249,22 @@ export async function recordServedTruncated(sessionKey: string, path: string, ro
 			const updated = _mergeServedRows(current, rows, { truncateTo: lineCount, clearFrom });
 			if (current.length !== updated.length || current.some((v, i) => v !== updated[i])) {
 				store.upsertServed(sessionKey, path, JSON.stringify(updated));
+			}
+			if (fullCanons) {
+				// #53: hashes without fresh canons leave the verify collision-guard
+				// comparing live content against stale metadata (false E_STALE_RANGE).
+				// Refresh canons for recorded rows; null where served is null so the
+				// parallel arrays stay consistent (canon null <=> served null).
+				const currentCanons = store.getServedCanons(sessionKey, path);
+				const rowCanon = new Map<number, string | null>();
+				for (const row of rows) rowCanon.set(row.position, fullCanons[row.position] ?? null);
+				const updatedCanons: (string | null)[] = [];
+				for (let i = 0; i < updated.length; i++) {
+					updatedCanons.push(
+						updated[i] === null ? null : rowCanon.has(i) ? rowCanon.get(i)! : (currentCanons[i] ?? null),
+					);
+				}
+				store.upsertServedCanons(sessionKey, path, JSON.stringify(updatedCanons));
 			}
 			addRetiredAnchors(
 				store,

--- a/src/tool-undo.ts
+++ b/src/tool-undo.ts
@@ -12,7 +12,7 @@ import { cntDiff, splitLines, codeOf } from "./utils.js";
 import { assertUndoRequest } from "./contract.js";
 import { normalizeRequest as normReq } from "./contract.js";
 import { upsertSnapshotFor } from "./hash-store.js";
-import { contentChecksum } from "./hashline/hash-assign.js";
+import { canon, contentChecksum } from "./hashline/hash-assign.js";
 import { lineHashes } from "./hashline/hash.js";
 import { changedRange } from "./hashline/anchor-pipeline.js";
 import { getUndo, clearUndo } from "./undo-edit.js";
@@ -193,6 +193,7 @@ export function buildUndoTool(io: FileIO, sandbox: FsSandboxController) {
 						undoDenseRows,
 						splitLines(undo.content).length,
 						restoredRange?.firstChangedLine ?? undoDiffResult.firstChangedLine ?? 0,
+						splitLines(undo.content).map((l) => canon(l)),
 					);
 				}
 

--- a/test/core/batch-canon-refresh.test.ts
+++ b/test/core/batch-canon-refresh.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, beforeAll } from "vitest";
+import { readFile } from "node:fs/promises";
+import {
+	withTempFile,
+	setupIntegrationTest,
+	getText,
+} from "../support/fixtures.js";
+import { initHasher } from "../../src/hashline/hasher.js";
+
+beforeAll(async () => {
+	await initHasher();
+});
+
+/** Hashes served by a read/diff, keyed by line content (the model's view). */
+function servedByContent(text: string): Map<string, string> {
+	const map = new Map<string, string>();
+	for (const line of text.split("\n")) {
+		const m = line.match(/^([ +]?)([A-Za-z0-9]{3})│(.*)$/);
+		if (m) map.set(m[3]!, m[2]!);
+	}
+	return map;
+}
+
+describe("batch edit serves stay fresh for immediate retry (#53)", () => {
+	it("write → batch → retry on diff anchors without re-read", async () => {
+		await withTempFile("g.txt", "1\n2\n3\n", async ({ cwd, path }) => {
+			const harness = setupIntegrationTest(cwd);
+			const readText = getText(await harness.readTool.execute("read", { path: "g.txt" }));
+			const served1 = servedByContent(readText);
+			const h2 = served1.get("2")!;
+			const h3 = served1.get("3")!;
+			expect(h2).toMatch(/^[A-Za-z0-9]{3}$/);
+			expect(h3).toMatch(/^[A-Za-z0-9]{3}$/);
+
+			const out1 = getText(
+				(await harness.editTool.execute("edit", {
+					path: "g.txt",
+					edits: [
+						[h2, h2, "b"],
+						[h3, h3, "C"],
+					],
+				}) as any),
+			);
+			expect(out1).toContain("Successfully");
+			expect(await readFile(path, "utf-8")).toBe("1\nb\nC\n");
+
+			// Fresh anchors straight from the diff — no re-read.
+			const served2 = servedByContent(out1);
+			const retry = await harness.editTool.execute("edit", {
+				path: "g.txt",
+				edits: [[served2.get("1")!, served2.get("b")!, "a\nB"]],
+			} as any);
+			expect(getText(retry)).toContain("Successfully");
+			expect(await readFile(path, "utf-8")).toBe("a\nB\nC\n");
+		});
+	});
+});


### PR DESCRIPTION
Closes #53. recordServedTruncated updated hashes but never canons, so the verify collision-guard compared live content against stale metadata and threw false E_STALE_RANGE on the first retry after any batch edit or undo.

Fix threads full-file canons from the batch result (mutation.ts) and restored content (tool-undo.ts); null where served is null to keep the parallel arrays consistent. Red-green: new session-shape test (write/batch/retry on diff anchors with no re-read) failed with the exact reported error before, passes after.

Gates: typecheck pass, 1254/1254 pass, build pass, biome pass.