### PR TITLE
feat(edit): accept object-form edits entries ({remove_from, remove_to, replacement_text}), closes #64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Features
+
+- **edit:** accept object-form edits entries, closes #64
+
 ### Fixed
 
 - **script:** correct repo inference and headless dispatch for gh-release

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -74,6 +74,23 @@ export function itemFromTuple(value: unknown): EditItem | undefined {
   return { remove_from, remove_to, replacement_text };
 }
 
+/**
+ * Accept both the tuple form (["a", "b", "c"]) and the object form
+ * ({ remove_from, remove_to, replacement_text }) per edits entry (#64).
+ * Missing/mistyped fields and unknown fields still return undefined so the
+ * caller rejects with E_BAD_PAYLOAD.
+ */
+export function itemFromEntry(value: unknown): EditItem | undefined {
+  if (Array.isArray(value)) return itemFromTuple(value);
+  if (isRec(value)) {
+    const { remove_from, remove_to, replacement_text } = value as Record<string, unknown>;
+    if (typeof remove_from !== "string" || typeof remove_to !== "string" || typeof replacement_text !== "string") return undefined;
+    if (Object.keys(value).some((k) => !["remove_from", "remove_to", "replacement_text"].includes(k))) return undefined;
+    return { remove_from, remove_to, replacement_text };
+  }
+  return undefined;
+}
+
 export function editRequestFrom(input: unknown): NormalizedEditRequest | undefined {
   if (!isRec(input) || !("path" in input) || !("edits" in input)) return undefined;
   const rec = input as Record<string, unknown>;
@@ -95,7 +112,7 @@ export function editRequestFrom(input: unknown): NormalizedEditRequest | undefin
   if (!Array.isArray(edits) || edits.length === 0) return undefined;
   const items: EditItem[] = [];
   for (const item of edits) {
-    const normalized = itemFromTuple(item);
+    const normalized = itemFromEntry(item);
     if (!normalized) return undefined;
     items.push(normalized);
   }

--- a/test/core/coverage-agent-c-contract.test.ts
+++ b/test/core/coverage-agent-c-contract.test.ts
@@ -136,3 +136,39 @@ describe("coverage: contract.ts", () => {
     expect(() => assertUndoRequest({} as any)).toThrow();
   });
 });
+
+describe("object-form edits entries (#64)", () => {
+  it("accepts object entries", () => {
+    const req = editRequestFrom({
+      path: "file.txt",
+      edits: [{ remove_from: "a", remove_to: "b", replacement_text: "c" }],
+    });
+    expect(req?.edits).toEqual([{ remove_from: "a", remove_to: "b", replacement_text: "c" }]);
+  });
+
+  it("accepts mixed tuple/object batches", () => {
+    const req = editRequestFrom({
+      path: "file.txt",
+      edits: [
+        ["a", "a", "x"],
+        { remove_from: "b", remove_to: "b", replacement_text: "y" },
+      ],
+    });
+    expect(req?.edits).toHaveLength(2);
+    expect(req?.edits[1]).toEqual({ remove_from: "b", remove_to: "b", replacement_text: "y" });
+  });
+
+  it("still rejects invalid objects (missing/unknown fields)", () => {
+    expect(editRequestFrom({ path: "file.txt", edits: [{ remove_from: "a" }] })).toBeUndefined();
+    expect(
+      editRequestFrom({
+        path: "file.txt",
+        edits: [{ remove_from: "a", remove_to: "b", replacement_text: "c", path: "z" }],
+      }),
+    ).toBeUndefined();
+    expect(
+      editRequestFrom({ path: "file.txt", edits: [{ remove_from: 1 as unknown as string, remove_to: "b", replacement_text: "c" }] }),
+    ).toBeUndefined();
+    expect(editRequestFrom({ path: "file.txt", edits: ["not-an-entry" as unknown as [string, string, string]] })).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Fixes #64

---

## 摘要 / Summary

### 中文

`edit` 的 `edits` 条目现在同时接受两种格式：

- 元组（现有）：`["a", "b", "c"]`
- 对象（新增）：`{ "remove_from": "a", "remove_to": "b", "replacement_text": "c" }`

同一 batch 内可混用（每条目独立归一化）。对象条目仍执行完整校验：缺字段、字段类型错误、或含未知字段（如混入 `path`）一律按 `E_BAD_PAYLOAD` 拒绝，文件不产生任何改动。

### English

`edit` entries now accept both forms:

- tuple (existing): `["a", "b", "c"]`
- object (new): `{ "remove_from": "a", "remove_to": "b", "replacement_text": "c" }`

Mixed batches are allowed (each entry normalizes independently). Object entries are still fully validated: missing fields, wrong field types, or unknown fields (e.g. a stray `path`) are rejected with `E_BAD_PAYLOAD` — nothing is written.

---

## 改动 / Changes

### 中文

- `src/contract.ts`
  - 新增 `itemFromEntry`：数组 → 复用 `itemFromTuple`；对象 → 校验 `remove_from` / `remove_to` / `replacement_text` 三字段并拒绝未知字段后归一化
  - `editRequestFrom` 的条目循环改调 `itemFromEntry`
  - 下游管线零改动（内部本就以归一化对象传递）
- `test/core/coverage-agent-c-contract.test.ts`
  - 新增 3 条用例：纯对象条目 / 混合 batch（元组 + 对象）/ 非法对象拒绝（缺字段、未知字段、类型错误、非条目）

### English

- `src/contract.ts`
  - adds `itemFromEntry`: arrays reuse `itemFromTuple`; objects are validated for the three fields (`remove_from` / `remove_to` / `replacement_text`), reject unknown fields, then normalize
  - the entry loop in `editRequestFrom` now calls `itemFromEntry`
  - zero downstream changes (the pipeline already carries normalized objects)
- `test/core/coverage-agent-c-contract.test.ts`
  - adds 3 cases: pure-object entries / mixed batch (tuple + object) / invalid-object rejection (missing field, unknown field, wrong type, non-entry)

---

## 验证 / Verification

### 中文

- `tsc --noEmit`（`tsconfig.json`） ✅
- `tsc --noEmit -p tsconfig.test.json` ✅
- `vitest run test/core/coverage-agent-c-contract.test.ts` → **13/13 通过**（含新增 3 条） ✅

### English

- `tsc --noEmit` (`tsconfig.json`) ✅
- `tsc --noEmit -p tsconfig.test.json` ✅
- `vitest run test/core/coverage-agent-c-contract.test.ts` → **13/13 passed** (including the 3 new cases) ✅

---

## 验收点 / Acceptance

### 中文

- [ ] 纯对象 batch 可解析执行
- [ ] 混合 batch（元组 + 对象）可解析执行
- [ ] 缺字段 / 未知字段 / 类型错误的对象仍被 `E_BAD_PAYLOAD` 拒绝
- [ ] 现有元组格式行为不变（全部既有测试通过）

### English

- [ ] pure-object batches parse and execute
- [ ] mixed batches (tuple + object) parse and execute
- [ ] objects with missing / unknown / mistyped fields are still rejected with `E_BAD_PAYLOAD`
- [ ] existing tuple behavior unchanged (all existing tests pass)