### PR TITLE
feat(edit): accept object-form edits entries ({remove_from, remove_to, replacement_text}), closes #64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Features
+
+- **edit:** accept object-form edits entries, closes #64
+
 ### Fixed
 
 - **script:** correct repo inference and headless dispatch for gh-release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 
+- **edit:** advertise object-form edits in hint, schema and guidance, polish itemFromEntry
 - **script:** correct repo inference and headless dispatch for gh-release
 
 ### Documentation

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -4,8 +4,8 @@
  * declared once here; every tool validates through these asserts, and the
  * [E_BAD_PAYLOAD] vocabulary is shared instead of re-implemented per tool.
  *
- * Contract now mirrors upstream ADR-0007: {path: string|null, edits: [[remove_from,remove_to,replacement_text],...]} tuple payload,
- * single-file, atomic. batch_edit is removed.
+ * Contract now mirrors upstream ADR-0007: {path: string|null, edits: [[remove_from,remove_to,replacement_text],...]} tuple payload
+ * (plus object-form {remove_from, remove_to, replacement_text} per #64), single-file, atomic. batch_edit is removed.
  * @module dsh-better-edit/contract
  */
 
@@ -83,9 +83,10 @@ export function itemFromTuple(value: unknown): EditItem | undefined {
 export function itemFromEntry(value: unknown): EditItem | undefined {
   if (Array.isArray(value)) return itemFromTuple(value);
   if (isRec(value)) {
-    const { remove_from, remove_to, replacement_text } = value as Record<string, unknown>;
+    const rec = value as Record<string, unknown>;
+    const { remove_from, remove_to, replacement_text } = rec;
     if (typeof remove_from !== "string" || typeof remove_to !== "string" || typeof replacement_text !== "string") return undefined;
-    if (Object.keys(value).some((k) => !["remove_from", "remove_to", "replacement_text"].includes(k))) return undefined;
+    if (Object.keys(rec).some((k) => !EDIT_ITEM_KS.has(k))) return undefined;
     return { remove_from, remove_to, replacement_text };
   }
   return undefined;
@@ -167,8 +168,10 @@ export function sanitizePath(value: unknown): string | null {
 export const EDIT_TUPLE_HINT =
   "Edit must be called with exactly one payload. Use the canonical payload " +
   '{"path": path, "edits": [[remove_from, remove_to, replacement_text], ...]}: ' +
-  "path is a non-empty string (or null to infer from anchors), each item is a " +
-  "fixed 3-position array of two inclusive bare-3-char anchors and the full " +
+  "path is a non-empty string (or null to infer from anchors), each item is " +
+  "either a fixed 3-position array [remove_from, remove_to, replacement_text] " +
+  "or an object {remove_from, remove_to, replacement_text} (mixed batches allowed) " +
+  "of two inclusive bare-3-char anchors and the full " +
   "replacement (an empty string deletes the range).";
 
 function describeReceived(input: unknown): string {
@@ -184,6 +187,7 @@ function describeReceived(input: unknown): string {
 
 const EDIT_KS = new Set(["path", "edits", "sandbox_permissions", "justification"]);
 const READ_KS = new Set(["path", "offset", "limit", "encoding"]);
+const EDIT_ITEM_KS = new Set(["remove_from", "remove_to", "replacement_text"]);
 
 // ---- normalization -----------------------------------------------------------
 
@@ -226,7 +230,7 @@ export function prepareEditArguments(args: unknown): Record<string, unknown> {
 
 export function assertEditRequest(request: unknown): asserts request is NormalizedEditRequest {
   if (!isNormalizedEdit(request)) {
-    throw new CodedError("E_BAD_PAYLOAD", "[MODEL] [E_BAD_PAYLOAD] Edit request must be exactly { path, edits: [[remove_from, remove_to, replacement_text], ...] }.");
+    throw new CodedError("E_BAD_PAYLOAD", "[MODEL] [E_BAD_PAYLOAD] Edit request must be exactly { path, edits: [[remove_from, remove_to, replacement_text], ...] } or { path, edits: [{remove_from, remove_to, replacement_text}, ...] } (mixed batches allowed).");
   }
   rejectUnknownFields(request as Record<string, unknown>, EDIT_KS, "Edit request");
   const req = request as NormalizedEditRequest;
@@ -242,7 +246,7 @@ export function assertEditRequest(request: unknown): asserts request is Normaliz
   for (let index = 0; index < req.edits.length; index++) {
     const item = req.edits[index]!;
     if (typeof item.remove_from !== "string" || typeof item.remove_to !== "string" || typeof item.replacement_text !== "string") {
-      throw new CodedError("E_BAD_PAYLOAD",`[MODEL] [E_BAD_PAYLOAD] Edit request edits[${index}] must be a three-position array [remove_from, remove_to, replacement_text].`);
+      throw new CodedError("E_BAD_PAYLOAD",`[MODEL] [E_BAD_PAYLOAD] Edit request edits[${index}] must be a three-position array [remove_from, remove_to, replacement_text] or an object {remove_from, remove_to, replacement_text}.`);
     }
   }
 }
@@ -305,6 +309,23 @@ export const editTupleSchema = {
   description: "[remove_from, remove_to, replacement_text]",
 } as const
 
+export const editObjectSchema = {
+  type: 'object',
+  additionalProperties: false,
+  required: ["remove_from", "remove_to", "replacement_text"] as const,
+  properties: {
+    remove_from: removeFromSchema,
+    remove_to: removeToSchema,
+    replacement_text: replacementTextSchema,
+  },
+  description: "{remove_from, remove_to, replacement_text}",
+} as const
+
+export const editItemSchema = {
+  anyOf: [editTupleSchema, editObjectSchema],
+  description: "Edit entry — either tuple or object form (mixed batches allowed)",
+} as const
+
 export const editToolSchema = {
   type: 'object',
   additionalProperties: false,
@@ -313,10 +334,10 @@ export const editToolSchema = {
     path: editPathSchema,
     edits: {
       type: 'array',
-      description: "Ordered list of edit tuples",
+      description: "Ordered list of edit entries — each entry is either a tuple [remove_from, remove_to, replacement_text] or an object {remove_from, remove_to, replacement_text} (mixed batches allowed)",
       minItems: 1,
       maxItems: EDITS_MAX_ITEMS,
-      items: editTupleSchema,
+      items: editItemSchema,
     },
   },
 } as const

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -74,6 +74,23 @@ export function itemFromTuple(value: unknown): EditItem | undefined {
   return { remove_from, remove_to, replacement_text };
 }
 
+/**
+ * Accept both the tuple form (["a", "b", "c"]) and the object form
+ * ({ remove_from, remove_to, replacement_text }) per edits entry (#64).
+ * Missing/mistyped fields and unknown fields still return undefined so the
+ * caller rejects with E_BAD_PAYLOAD.
+ */
+export function itemFromEntry(value: unknown): EditItem | undefined {
+  if (Array.isArray(value)) return itemFromTuple(value);
+  if (isRec(value)) {
+    const { remove_from, remove_to, replacement_text } = value as Record<string, unknown>;
+    if (typeof remove_from !== "string" || typeof remove_to !== "string" || typeof replacement_text !== "string") return undefined;
+    if (Object.keys(value).some((k) => !["remove_from", "remove_to", "replacement_text"].includes(k))) return undefined;
+    return { remove_from, remove_to, replacement_text };
+  }
+  return undefined;
+}
+
 export function editRequestFrom(input: unknown): NormalizedEditRequest | undefined {
   if (!isRec(input) || !("path" in input) || !("edits" in input)) return undefined;
   const rec = input as Record<string, unknown>;
@@ -95,7 +112,7 @@ export function editRequestFrom(input: unknown): NormalizedEditRequest | undefin
   if (!Array.isArray(edits) || edits.length === 0) return undefined;
   const items: EditItem[] = [];
   for (const item of edits) {
-    const normalized = itemFromTuple(item);
+    const normalized = itemFromEntry(item);
     if (!normalized) return undefined;
     items.push(normalized);
   }

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -13,19 +13,20 @@ export interface ToolGuidance {
 }
 
 export const EDIT_DESCRIPTION =
-  "Edit a range of lines in a text file with `{ \"path\": path, \"edits\": [[remove_from, remove_to, replacement_text], ...] }`. " +
+  "Edit a range of lines in a text file with `{ \"path\": path, \"edits\": [[remove_from, remove_to, replacement_text], ...] }` (tuple) or object `{remove_from, remove_to, replacement_text}` entries \u2014 mixed batches allowed. " +
   "`path` is file path or null. `read` shows `HASH\u2502content` (e.g. `wUp\u2502  \"site\": {`) \u2014 use bare 3-char HASH anchors for " +
   "`remove_from`/`remove_to` (e.g. \"wUp\"), never `HASH\u2502content`. `replacement_text` is bare content, \\n joins lines, \"\" deletes. " +
-  "Example: `{\"path\":\"a.py\",\"edits\":[[\"wUp\",\"AU6\",\"new\"]]}`. Edits are atomic; reuse `HASH\u2502content` from the diff after success. " +
+  "Example: `{\"path\":\"a.py\",\"edits\":[[\"wUp\",\"AU6\",\"new\"]]}` (object form `{remove_from:\"wUp\",remove_to:\"AU6\",replacement_text:\"new\"}` equivalent). Edits are atomic; reuse `HASH\u2502content` from the diff after success. " +
   "On failure follow the error hint: `[MODEL]` errors need a retry with fresh anchors, `[USER]` notices are human-only.";
 
 export const EDIT_GUIDANCE: ToolGuidance = {
-  intro: "Edit a range of lines via a bare 3-char HASH anchor \u2014 payload is { path, edits: [[hash,hash,text]] } (single-file atomic, null path infers).",
+  intro: "Edit a range of lines via a bare 3-char HASH anchor \u2014 payload is { path, edits: [[hash,hash,text]] } or { path, edits: [{remove_from, remove_to, replacement_text}] } (single-file atomic, null path infers; tuple and object forms are equivalent, mixed batches allowed).",
   lines: [
     "`edit`: `HASH` vs `HASH\u2502content` \u2014 `HASH` is the bare 3-char (e.g. \"wUp\"), `HASH\u2502content` is the full line from `read`/`diff` (e.g. `wUp\u2502    \"site\": {`); never mix them.",
     "`edit`: get `remove_from`/`remove_to` by copying only the 3 chars before `\u2502` from `read` output \u2014 never include `\u2502` or content after it.",
     "`edit`: `replacement_text` is plain file content without `HASH\u2502` \u2014 e.g. \"    \\\"site\\\": {\\n        \\\"class\\\": SiteScraper,\" \u2014 never prefix lines with `HASH\u2502`.",
     "`edit`: every `\\n` in `replacement_text` separates lines; mirror trailing blank lines explicitly (use \"\" to delete a range).",
+    "`edit`: `edits` entries accept either tuple `[remove_from, remove_to, replacement_text]` or object `{remove_from, remove_to, replacement_text}` \u2014 mixed batches allowed, each entry normalizes independently; unknown fields (e.g. stray `path`) are rejected.",
     "`edit`: after a successful edit the returned diff shows fresh anchors (`HASH\u2502content`) \u2014 copy new `HASH` values from there for the next edit; no need to re-read.",
     "`edit`: `remove_from`/`remove_to` are inclusive; batch multiple edits to the same file only when independent \u2014 they apply atomically (fail \u2192 nothing written).",
     "`edit`: `[MODEL]` errors (e.g. `E_STALE_*`, `E_UNSERVED_*`, `E_BAD_PAYLOAD`, `E_SERVED_ECHO`) need a retry \u2014 `[USER]` warnings/`drift:` notices are human-only.",

--- a/test/core/coverage-agent-c-contract.test.ts
+++ b/test/core/coverage-agent-c-contract.test.ts
@@ -136,3 +136,39 @@ describe("coverage: contract.ts", () => {
     expect(() => assertUndoRequest({} as any)).toThrow();
   });
 });
+
+describe("object-form edits entries (#64)", () => {
+  it("accepts object entries", () => {
+    const req = editRequestFrom({
+      path: "file.txt",
+      edits: [{ remove_from: "a", remove_to: "b", replacement_text: "c" }],
+    });
+    expect(req?.edits).toEqual([{ remove_from: "a", remove_to: "b", replacement_text: "c" }]);
+  });
+
+  it("accepts mixed tuple/object batches", () => {
+    const req = editRequestFrom({
+      path: "file.txt",
+      edits: [
+        ["a", "a", "x"],
+        { remove_from: "b", remove_to: "b", replacement_text: "y" },
+      ],
+    });
+    expect(req?.edits).toHaveLength(2);
+    expect(req?.edits[1]).toEqual({ remove_from: "b", remove_to: "b", replacement_text: "y" });
+  });
+
+  it("still rejects invalid objects (missing/unknown fields)", () => {
+    expect(editRequestFrom({ path: "file.txt", edits: [{ remove_from: "a" }] })).toBeUndefined();
+    expect(
+      editRequestFrom({
+        path: "file.txt",
+        edits: [{ remove_from: "a", remove_to: "b", replacement_text: "c", path: "z" }],
+      }),
+    ).toBeUndefined();
+    expect(
+      editRequestFrom({ path: "file.txt", edits: [{ remove_from: 1 as unknown as string, remove_to: "b", replacement_text: "c" }] }),
+    ).toBeUndefined();
+    expect(editRequestFrom({ path: "file.txt", edits: ["not-an-entry" as unknown as [string, string, string]] })).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Merges `feat/edits-object-form` (#65, closes #64) on top of `origin/main@9af0535` and applies the review patch for discoverability/polish. `edit` now accepts both tuple `["a","b","c"]` and object `{remove_from, remove_to, replacement_text}` entries (mixed batches allowed), with full validation and `E_BAD_PAYLOAD` on missing/unknown/mistyped fields.

**Impact**: 4 files (91 +, 12 -) · **Risk**: Low — parse-layer normalization only, downstream pipeline unchanged

Closes #64. Supersedes #65 (same feature, correct base + review feedback addressed).

## What Changed

- **`src/contract.ts`**
  - `itemFromEntry`: new normalizer — `Array.isArray` → `itemFromTuple`, `isRec` → validate 3 string fields + reject unknown keys via `EDIT_ITEM_KS` Set; `editRequestFrom` now calls `itemFromEntry`
  - `EDIT_ITEM_KS` constant extracted (mirrors `EDIT_KS`/`READ_KS`)
  - `EDIT_TUPLE_HINT` extended to document both forms (`either tuple … or object {…} (mixed batches allowed)`)
  - `assertEditRequest` messages updated for both forms
  - Schema: new `editObjectSchema` + `editItemSchema = {anyOf: [editTupleSchema, editObjectSchema]}`; `editToolSchema.edits.items` → `editItemSchema` with mixed-batch description
- **`src/prompts.ts`**
  - `EDIT_DESCRIPTION` (788 chars, <800): tuple + object forms, compact equivalent example
  - `EDIT_GUIDANCE`: intro mentions both payload shapes; new bullet documenting tuple/object equivalence and unknown-field rejection
- **`test/core/coverage-agent-c-contract.test.ts`**
  - 3 cases: pure-object, mixed tuple/object, invalid-object rejection (missing/unknown/type/non-entry)
- **`CHANGELOG.md`**: `### Features — edit: accept object-form edits entries, closes #64` under `[Unreleased]`

## Architecture

No structural shift — single parse-layer seam (`contract.ts`) normalizes to `EditItem`, downstream (`mutation.ts`, `assertEditRequest`) unchanged.

## Verification

- `pnpm run typecheck` (`tsc --noEmit` + `tsc -p tsconfig.test.json`) ✅
- `pnpm test` — 116 files / 1270 tests passed (base `origin/main@9af0535` has 116 files; `8b52eb2` str-replace tests intentionally excluded) ✅
- `EDIT_DESCRIPTION.length === 788` (<800 invariant from `path-sanitize.test.ts`) ✅

## Checklist

- [x] Forked from `origin/main@9af0535` (branch does **not** contain `8b52eb2 feat(str-replace)`)
- [x] Merged `MrWeiCodes/dsh-better-edit:feat/edits-object-form@e664bd7` (`git merge --no-ff`)
- [x] Applied review patch: hint + JSON Schema + guidance + `EDIT_ITEM_KS` polish
- [x] `src/contract.ts` `editRequestFrom` still atomic — invalid object entries reject whole batch
- [x] `editToolSchema` advertises both forms (`anyOf`) so structured tool-calling discovers object form
- [x] Branch pushed as `fix/pr65-object-form-patch`, ready for review
