### PR TITLE
feat(str-replace): add governed editor shadow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ### Features
 
-- **edit:** accept object-form edits entries, closes #64
+- **str-replace:** add governed editor shadow
+- **edit:** accept object-form edits entries ({remove_from, remove_to, replacement_text}), closes #64 (#66)
 
 ### Fixed
 
-- **edit:** advertise object-form edits in hint, schema and guidance, polish itemFromEntry
 - **script:** correct repo inference and headless dispatch for gh-release
 
 ### Documentation

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -76,6 +76,18 @@ _Avoid_: manual migration
 The status-bar-equivalent escape hatch: `read({encoding})` re-interprets bytes on disk (`Reopen with Encoding`) and `write({encoding})` transcodes the buffer on save (`Save with Encoding`). The agent-facing surface for correcting a `detection error` without corrupting disk.
 _Avoid_: force encoding
 
+**encoding governance**:
+The invariant that every agent-issued file mutation passes through `file encoding state` (recorded at open, inverted at save): BOM sniff → strict UTF-8 → `autoGuessEncoding` gate → Top-3 always surfaced. A mutation without prior observation fails loud instead of guessing bytes.
+_Avoid_: encoding handling (implies best-effort, not a gate)
+
+**governed edit path**:
+Any tool path that enforces `encoding governance`: `read`/`edit`/`undo_last_edit` and the `str_replace_editor` shadow (`view` → `str_replace`/`insert`/`create`). The `str_replace_editor` shadow records `file encoding state` but never `served state` — it can feed `write` round-trips but cannot authorize hashline `edit` anchors.
+_Avoid_: native edit path (implies the built-in tools own the semantics; here the plugin does)
+
+**ungoverned edit path**:
+A file mutation that bypasses `encoding governance` — the built-in `write`/`edit`/`str_replace_editor` on layers the plugin does not shadow, or any shell redirection. Ungoverned writes can silently normalize or mojibake non-UTF-8 bytes; the plugin heals by discarding stale `file encoding state` on version drift and re-running deterministic detection.
+_Avoid_: native edit path
+
 **reject-and-serve**:
 The staleness policy: reject the edit and return the current range as fresh `HASH│content` rows, which themselves count as serves, so the retry needs no read.
 _Avoid_: reject-then-reread (the retry must not require a read)

--- a/docs/adr/0015-shadow-str-replace-editor.md
+++ b/docs/adr/0015-shadow-str-replace-editor.md
@@ -1,0 +1,73 @@
+# ADR-0015 — Shadow `str_replace_editor` on the Agent Layer
+
+Date: 2026-09-08
+Status: accepted
+Related: ADR-0012 (VS Code encoding model), CONTEXT.md `File Encoding`
+(`encoding governance`, `governed edit path`, `ungoverned edit path`)
+
+## Context
+
+Deployments compose the preset's built-in `str_replace_editor`
+(`@deepseek-ai/dsh-tool-str-replace-editor`: `view` / `str_replace` /
+`insert` / `create` / `undo_edit`) alongside this plugin's hashline
+`read`/`edit`. The built-in is an **ungoverned edit path**: it reads and
+writes through `ctx.fs` without `file encoding state`, so GBK/Big5/Shift-JIS
+files are mojibaked or rejected as `FS_NOT_TEXT`, and UTF-8-BOM files lose
+their BOM — silently, mid-task, after the model already saw content.
+
+## Decision
+
+Shadow the built-in at the **agent layer** (`src/index.ts`
+`installAgentTools` via `agent.ctx.tools.register`, mirroring `read`/`edit`):
+nearest-layer-wins routes the agent's `str_replace_editor` calls to
+`src/tool-str-replace-editor.ts`, which keeps **contract parity** (same
+commands, same params, no new `encoding` param; read-first invariant holds)
+while enforcing **encoding governance**:
+
+- `view` is observation: BOM → strict UTF-8 → `autoGuessEncoding` gate →
+  Top-3 via `decodeForOpen`; records `file encoding state`, emits
+  `fs/observed`, never records `served state`.
+- `str_replace`/`insert` without prior `view`/`read` fail loud with
+  `E_BLIND_REPLACE` — no disk write. Undecodable bytes fail loud with
+  `E_UNSUPPORTED_FILE` + Top-3.
+- `create` defaults to UTF-8 without BOM. `undo_edit` is out of scope →
+  `E_UNSUPPORTED` (use `undo_last_edit`).
+
+The self-heal watcher also covers the shadow: an external preset takeover of
+`str_replace_editor` is restored like `read`/`edit`.
+
+## Why hard to reverse
+
+Shadowing replaces a built-in the model already knows. Rolling back changes
+agent-visible behavior (BOM loss returns, GBK breaks again) and invalidates
+the `E_BLIND_REPLACE` retry vocabulary the model learned. The shadow's
+identity check in self-heal pins the exact def reference — a silent upstream
+contract change (new command/param) would surface as drift, not compat.
+
+## Why surprising
+
+A tool named exactly like the built-in that rejects calls the built-in would
+accept (blind `str_replace`, `undo_edit`). The surprise is deliberate and
+loud (`E_BLIND_REPLACE` / `E_UNSUPPORTED` carry the retry instruction), never
+a silent behavior change: every accepted call does what the built-in promises.
+
+## Trade-off: agent layer vs upstream
+
+- Agent-layer shadow (chosen): zero upstream coordination, per-agent unwind
+  on dispose, preset guidance untouched. Cost: we own contract parity — every
+  upstream command/param addition must be ported (see `tests/contract/`).
+- Upstream fix (rejected for now): enriching `FS_NOT_TEXT` / teaching the
+  built-in governance helps every consumer, but `dsh-fs` is `0.1.0-rc`
+  (breaking changes allowed) and the harness team has not committed to the
+  VS Code model. Proposed upstream as complementary (ADR-0012 references).
+
+## Consequences
+
+- `src/tool-str-replace-editor.ts` (new, isolated): reuses `ctxFsIO` +
+  `file-encoding-state.ts` (`decodeForOpen` via `io.readText`,
+  `recordOpenState`, `prepareForSave` via `io.writeText`,
+  `invalidateIfStale`, `getEncodingState`).
+- `src/index.ts` + `src/self-heal.ts`: register and watch the third shadow.
+- Contract tests (`tests/tool-str-replace-editor.test.ts`,
+  `tests/contract/str-replace-editor.test.ts`) pin parity: name, params, no
+  `encoding` param, range slicing, `E_BLIND_REPLACE`, BOM round-trip.

--- a/src/file-encoding-state.ts
+++ b/src/file-encoding-state.ts
@@ -17,7 +17,7 @@
 
 import { detectBom, isValidUtf8, decodeBytes, normalizeEncoding, top3Candidates, chardetTop3Candidates } from "./encoding.js";
 import type { CandidatePreview } from "./encoding.js";
-import { detectEnding, type LineEnding } from "./edit-diff.js";
+import { detectEnding, restoreEndings, toLF, type LineEnding } from "./edit-diff.js";
 
 // ---------------------------------------------------------------------------
 // State — per-targetKey, session-TTL, version-invalidated
@@ -302,6 +302,10 @@ export interface EncodeForSaveOptions {
   currentVersion?: string | undefined;
 }
 
+/** Shared UTF-8 BOM marker — single source for the BOM round-trip seam.
+ * Prefer `prepareForSave` / `stripBOM` over re-implementing this check. */
+export const UTF8_BOM = "\uFEFF";
+
 /**
  * Decide what bytes (as text, since provider expects string) to write and
  * what new state to record. BOM and lineEnding are restored here when a
@@ -332,6 +336,16 @@ export function prepareForSave(
     return { textToWrite: content };
   }
 
-  // Default: UTF-8 without BOM, preserve lineEnding if known
-  return { textToWrite: content };
+  // Default: restore recorded BOM + lineEnding via the shared seam so
+  // governed writers (e.g. the str_replace_editor shadow) don't re-implement
+  // the round-trip locally and diverge on future utf16le/lineEnding evolution.
+  // Only add, never strip: a missing memo means UTF-8 without BOM + LF.
+  let textToWrite = content;
+  if (existingState?.lineEnding) {
+    textToWrite = restoreEndings(toLF(textToWrite), existingState.lineEnding);
+  }
+  if (existingState?.hasBOM && !textToWrite.startsWith(UTF8_BOM)) {
+    textToWrite = `${UTF8_BOM}${textToWrite}`;
+  }
+  return { textToWrite };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import { ctxFsIO } from "./fs-bridge.js";
 import { FsSandboxController } from "./sandbox.js";
 import { buildReadTool } from "./tool-read.js";
 import { buildEditTool } from "./tool-edit.js";
+import { buildStrReplaceEditorTool } from "./tool-str-replace-editor.js";
 import { registerUndoTool } from "./tool-undo.js";
 import { registerWriteHook } from "./write-hook.js";
 import { createSelfHealWatcher } from "./self-heal.js";
@@ -121,6 +122,10 @@ function installAgentTools(rootCtx: Context, agent: Agent): void {
 		disposers.push(agent.ctx.tools.register(hashReadDef));
 		const hashEditDef = buildEditTool(io, sandbox);
 		disposers.push(agent.ctx.tools.register(hashEditDef));
+		// Governed shadow of the preset's built-in str_replace_editor
+		// (ADR-0015): identical contract, encoding-governed mutations.
+		const hashStrReplaceDef = buildStrReplaceEditorTool(io);
+		disposers.push(agent.ctx.tools.register(hashStrReplaceDef));
 		disposers.push(registerUndoTool(rootCtx, agent.ctx, io, sandbox));
 		disposers.push(registerWriteHook(rootCtx, agent.ctx, io));
 
@@ -134,6 +139,7 @@ function installAgentTools(rootCtx: Context, agent: Agent): void {
 				toolsSvc,
 				hashReadDef,
 				hashEditDef,
+				hashStrReplaceDef,
 			}),
 		);
 		// Shadow the preset's built-in tool guidance with the hashline

--- a/src/render-text-warning.ts
+++ b/src/render-text-warning.ts
@@ -1,0 +1,24 @@
+/**
+ * Shared output-render seam for the `{ text, warning? }` tool payload.
+ *
+ * `read` (tool-read.ts) and `str_replace_editor` view (tool-str-replace-editor.ts)
+ * previously carried verbatim copies of this render closure, so a warning-format
+ * change had to be made in two places (report #7). Both now delegate here.
+ * @module dsh-better-edit/render-text-warning
+ */
+
+export type TextWarningValue = { text: string; warning?: string } | string;
+
+export type TextBlock = { type: "text"; text: string };
+
+/**
+ * Render a `{ text, warning? }` payload (or bare string) as content blocks:
+ * string input yields a single text block, object input yields the text block
+ * plus a second block when `warning` is present.
+ */
+export function renderTextWarning(value: TextWarningValue): TextBlock[] {
+	if (typeof value === "string") return [{ type: "text", text: value }];
+	const blocks: TextBlock[] = [{ type: "text", text: value.text }];
+	if (value.warning) blocks.push({ type: "text", text: value.warning });
+	return blocks;
+}

--- a/src/self-heal.ts
+++ b/src/self-heal.ts
@@ -15,6 +15,8 @@ export interface SelfHealOptions {
 	toolsSvc: unknown;
 	hashReadDef: unknown;
 	hashEditDef: unknown;
+	/** ADR-0015 shadow def; when present the watcher also heals `str_replace_editor`. */
+	hashStrReplaceDef?: unknown;
 	healMinIntervalMs?: number;
 }
 
@@ -27,12 +29,19 @@ export function createSelfHealWatcher(options: SelfHealOptions): () => void {
 		toolsSvc,
 		hashReadDef,
 		hashEditDef,
+		hashStrReplaceDef,
 		healMinIntervalMs = 1000,
 	} = options;
+	const watchStrReplace = hashStrReplaceDef !== undefined;
 
 	let lastHealAt = 0;
 	let healCount = 0;
 	let selfHealDisabled = false;
+
+	const formatFailMsg = (error: unknown): string =>
+		`dsh-better-edit: self-heal failed for agent ${agentId}: ${error instanceof Error ? error.message : String(error)} \u2014 see Rianico/dsh-better-edit#43`;
+	const formatRestoredMsg = (toolLabel: string, attempt: number): string =>
+		`dsh-better-edit: restored ${toolLabel} after external takeover \u2014 agent ${agentId} (${attempt}/2) \u2014 see Rianico/dsh-better-edit#43`;
 
 	const stop = agentCtx.on("tools/change", () => {
 		try {
@@ -47,7 +56,11 @@ export function createSelfHealWatcher(options: SelfHealOptions): () => void {
 			const currentEdit = layer?.get?.("edit") ?? layer?.data?.get?.("edit");
 			const readOk = currentRead === hashReadDef;
 			const editOk = currentEdit === hashEditDef;
-			if (readOk && editOk) return;
+			const currentStrReplace = watchStrReplace
+				? (layer?.get?.("str_replace_editor") ?? layer?.data?.get?.("str_replace_editor"))
+				: hashStrReplaceDef;
+			const strReplaceOk = !watchStrReplace || currentStrReplace === hashStrReplaceDef;
+			if (readOk && editOk && strReplaceOk) return;
 			const now = Date.now();
 			if (now - lastHealAt < healMinIntervalMs) return;
 			if (healCount >= 2) {
@@ -65,6 +78,7 @@ export function createSelfHealWatcher(options: SelfHealOptions): () => void {
 			lastHealAt = now;
 			const restoreRead = !readOk;
 			const restoreEdit = !editOk;
+			const restoreStrReplace = watchStrReplace && !strReplaceOk;
 			const restoreCount = healCount;
 			queueMicrotask(() => {
 				try {
@@ -74,53 +88,37 @@ export function createSelfHealWatcher(options: SelfHealOptions): () => void {
 						| { get?: (name: string) => unknown; data?: Map<string, unknown> }
 						| undefined;
 					if (!currentLayer) return;
-					if (restoreEdit) {
+					const restoreTool = (name: string, def: unknown, toolLabel: string): boolean => {
 						try {
-							currentLayer?.data?.delete?.("edit");
+							(currentLayer as { data?: Map<string, unknown> })?.data?.delete?.(name);
 						} catch {
 							// ignore — best-effort delete of intruding entry
 						}
 						try {
-							agentCtx.tools.register(hashEditDef);
+							agentCtx.tools.register(def);
 						} catch (e) {
-							rootCtx.logger.warn(
-								`dsh-better-edit: self-heal failed for agent ${agentId}: ${e instanceof Error ? e.message : String(e)} \u2014 see Rianico/dsh-better-edit#43`,
-							);
-							return;
+							rootCtx.logger.warn(formatFailMsg(e));
+							return false;
 						}
-						rootCtx.logger.warn(
-							`dsh-better-edit: restored hash-anchored edit after external takeover \u2014 agent ${agentId} (${restoreCount}/2) \u2014 see Rianico/dsh-better-edit#43`,
-						);
+						rootCtx.logger.warn(formatRestoredMsg(toolLabel, restoreCount));
+						return true;
+					};
+					if (restoreEdit) {
+						if (!restoreTool("edit", hashEditDef, "hash-anchored edit")) return;
+					}
+					if (restoreStrReplace) {
+						if (!restoreTool("str_replace_editor", hashStrReplaceDef, "governed str_replace_editor")) return;
 					}
 					if (restoreRead) {
-						try {
-							currentLayer?.data?.delete?.("read");
-						} catch {
-							// ignore — best-effort delete of intruding entry
-						}
-						try {
-							agentCtx.tools.register(hashReadDef);
-						} catch (e) {
-							rootCtx.logger.warn(
-								`dsh-better-edit: self-heal failed for agent ${agentId}: ${e instanceof Error ? e.message : String(e)} \u2014 see Rianico/dsh-better-edit#43`,
-							);
-							return;
-						}
-						rootCtx.logger.warn(
-							`dsh-better-edit: restored hash-anchored read after external takeover \u2014 agent ${agentId} (${restoreCount}/2) \u2014 see Rianico/dsh-better-edit#43`,
-						);
+						if (!restoreTool("read", hashReadDef, "hash-anchored read")) return;
 					}
 				} catch (error) {
-					rootCtx.logger.warn(
-						`dsh-better-edit: self-heal failed for agent ${agentId}: ${error instanceof Error ? error.message : String(error)} \u2014 see Rianico/dsh-better-edit#43`,
-					);
+					rootCtx.logger.warn(formatFailMsg(error));
 				}
 			});
 		} catch (error) {
 			try {
-				rootCtx.logger.warn(
-					`dsh-better-edit: self-heal failed for agent ${agentId}: ${error instanceof Error ? error.message : String(error)} \u2014 see Rianico/dsh-better-edit#43`,
-				);
+				rootCtx.logger.warn(formatFailMsg(error));
 			} catch {
 				// ignore — logger may throw in mock
 			}

--- a/src/tool-read.ts
+++ b/src/tool-read.ts
@@ -15,6 +15,7 @@ import { READ_DESCRIPTION } from "./prompts.js";
 import { normalizeEncoding } from "./encoding.js";
 
 import type { FileIO } from "./fs-bridge.js";
+import { renderTextWarning } from "./render-text-warning.js";
 import { execCwd, execSessionKey } from "./workspace-context.js";
 import { withWorkspace } from "./workspace-context.js";
 
@@ -46,13 +47,7 @@ export function buildReadTool(io: FileIO) {
 		},
 		output: {
 			schema: { type: "object", properties: { text: { type: "string", required: true }, warning: { type: "string" } }, additionalProperties: false },
-			render: (_args, value) => {
-				const v = value as { text: string; warning?: string } | string;
-				if (typeof v === "string") return [{ type: "text", text: v }];
-				const blocks: Array<{ type: "text"; text: string }> = [{ type: "text", text: v.text }];
-				if (v.warning) blocks.push({ type: "text", text: v.warning });
-				return blocks;
-			},
+			render: (_args, value) => renderTextWarning(value as { text: string; warning?: string } | string),
 		},
 		async execute(args, exec) {
 			return withWorkspace(execCwd(exec), async () => {

--- a/src/tool-str-replace-editor.ts
+++ b/src/tool-str-replace-editor.ts
@@ -1,0 +1,328 @@
+/**
+ * The dsh `str_replace_editor` shadow: a governed agent-layer replacement for
+ * the built-in `@deepseek-ai/dsh-tool-str-replace-editor` with identical
+ * contract (`view` / `str_replace` / `insert` / `create`, no new `encoding`
+ * param) but routed through the file-encoding-state seam.
+ *
+ * - `view` is observation: decode via the `ctxFsIO` path (`decodeForOpen`
+ *   inside `io.readText`), records file encoding state, emits `fs/observed`,
+ *   and never records served state (so it can feed `write` round-trips but
+ *   cannot authorize hashline `edit` anchors).
+ * - `str_replace` / `insert` without a prior `view`/`read` fail loud with
+ *   `E_BLIND_REPLACE` — no disk write.
+ * - `create` defaults to UTF-8 without BOM.
+ * - `undo_edit` is out of scope → `E_UNSUPPORTED` (use `undo_last_edit`).
+ *
+ * See ADR-0015.
+ * @module dsh-better-edit/tool-str-replace-editor
+ */
+
+import { defineTool } from "@deepseek-ai/dsh-tools";
+import type { FileIO } from "./fs-bridge.js";
+import { getAutoGuessFooter } from "./fs-bridge.js";
+import { getEncodingState, invalidateIfStale, prepareForSave, recordOpenState } from "./file-encoding-state.js";
+import { stripBOM } from "./edit-diff.js";
+import { renderTextWarning } from "./render-text-warning.js";
+import { execCwd, withWorkspace } from "./workspace-context.js";
+import { abortIf, splitLines } from "./utils.js";
+
+export const STR_REPLACE_EDITOR_DESCRIPTION =
+  "View, create, and edit text files by exact string match. Commands: " +
+  "`view` {path, view_range?} shows 1-indexed lines; `str_replace` {path, old_str, new_str} " +
+  "replaces the unique occurrence of old_str; `insert` {path, insert_line, new_str} inserts " +
+  "new line(s) before insert_line (1-indexed, lines+1 appends); `create` {path, file_text} " +
+  "creates a new file (fails if it exists). str_replace/insert require a prior view of the " +
+  "file in this session (E_BLIND_REPLACE otherwise). Encoding is governed: non-UTF-8 files " +
+  "decode via auto-guess when enabled, otherwise fail loud with Top-3 candidates.";
+
+type StrReplaceCommand = "view" | "str_replace" | "insert" | "create" | "undo_edit";
+
+const KNOWN_COMMANDS: ReadonlySet<string> = new Set([
+  "view",
+  "str_replace",
+  "insert",
+  "create",
+  "undo_edit",
+]);
+
+function argError(code: string, message: string): Error {
+  return new Error(`[MODEL] [${code}] ${message}`);
+}
+
+function requireString(args: Record<string, unknown>, name: string): string {
+  const value = args[name];
+  if (typeof value !== "string" || value.length === 0) {
+    throw argError("E_BAD_PAYLOAD", `str_replace_editor: "${name}" must be a non-empty string.`);
+  }
+  return value;
+}
+
+function requireViewRange(args: Record<string, unknown>): [number, number] | undefined {
+  const value = args["view_range"];
+  if (value === undefined) return undefined;
+  if (
+    !Array.isArray(value) ||
+    value.length !== 2 ||
+    !Number.isInteger(value[0]) ||
+    !Number.isInteger(value[1]) ||
+    (value[0] as number) < 1 ||
+    (value[1] as number) < 1 ||
+    (value[0] as number) > (value[1] as number)
+  ) {
+    throw argError(
+      "E_BAD_PAYLOAD",
+      'str_replace_editor: "view_range" must be [start, end] with 1-indexed positive integers and start <= end.',
+    );
+  }
+  return [value[0] as number, value[1] as number];
+}
+
+/**
+ * Strict read-first gate: the file must carry file encoding state recorded by
+ * a prior `view`/`read` at the current version. Stale memos are invalidated
+ * first, so drifted files fail loud instead of editing blind. Never writes.
+ */
+async function requireObserved(
+  io: FileIO,
+  absolutePath: string,
+  displayPath: string,
+  signal?: AbortSignal,
+): Promise<void> {
+  const version = await io.statVersion(absolutePath, signal);
+  invalidateIfStale(absolutePath, version);
+  if (!getEncodingState(absolutePath)) {
+    throw argError(
+      "E_BLIND_REPLACE",
+      `str_replace_editor: ${displayPath} has not been viewed in this session (no file encoding state at the current version). Call view first, then retry. Nothing was written.`,
+    );
+  }
+}
+
+function countOccurrences(haystack: string, needle: string): number {
+  if (needle.length === 0) return 0;
+  let count = 0;
+  let from = 0;
+  while (true) {
+    const at = haystack.indexOf(needle, from);
+    if (at === -1) return count;
+    count += 1;
+    from = at + needle.length;
+  }
+}
+
+/** Shared-seam save restoration: BOM + lineEnding via `prepareForSave`.
+ * Replaces the former local `restoreBom` so the shadow can't diverge from
+ * the file-encoding-state round-trip (report #2). */
+function restoreForSave(content: string, absolutePath: string): string {
+  return prepareForSave(content, getEncodingState(absolutePath)).textToWrite;
+}
+
+function autoGuessWarning(absolutePath: string, rawPath: string): string | undefined {
+  return getAutoGuessFooter(absolutePath) ?? getAutoGuessFooter(rawPath) ?? getAutoGuessFooter(absolutePath.replace(/\\/g, "/")) ?? undefined;
+}
+
+export function buildStrReplaceEditorTool(io: FileIO) {
+  return defineTool({
+    name: "str_replace_editor",
+    description: STR_REPLACE_EDITOR_DESCRIPTION,
+    parameters: {
+      command: {
+        type: "string",
+        required: true,
+        description: "One of: view, str_replace, insert, create, undo_edit",
+      },
+      path: {
+        type: "string",
+        required: true,
+        description: "File path",
+      },
+      view_range: {
+        type: "json",
+        description: "[start, end] 1-indexed inclusive line range for view",
+      } as unknown as import("@deepseek-ai/dsh-tools").ValueSchemaSpec,
+      old_str: {
+        type: "string",
+        description: "Exact string to replace (must occur exactly once) for str_replace",
+      },
+      new_str: {
+        type: "string",
+        description: "Replacement text for str_replace, or line(s) to insert for insert",
+      },
+      insert_line: {
+        type: "number",
+        description: "1-indexed line to insert before (lines+1 appends) for insert",
+      },
+      file_text: {
+        type: "string",
+        description: "Full content for create",
+      },
+    },
+    output: {
+      schema: {
+        type: "object",
+        properties: { text: { type: "string", required: true }, warning: { type: "string" } },
+        additionalProperties: false,
+      },
+      render: (_args, value) =>
+        renderTextWarning(value as { text: string; warning?: string } | string),
+    },
+    async execute(args, exec) {
+      return withWorkspace(execCwd(exec), async () => {
+        const cwd = execCwd(exec);
+        const signal = exec.signal;
+        const rec = (args ?? {}) as Record<string, unknown>;
+        const command = rec["command"];
+        if (typeof command !== "string" || !KNOWN_COMMANDS.has(command)) {
+          throw argError(
+            "E_BAD_COMMAND",
+            `str_replace_editor: unknown command ${JSON.stringify(command)} — expected one of view, str_replace, insert, create, undo_edit.`,
+          );
+        }
+        const cmd = command as StrReplaceCommand;
+        if (cmd === "undo_edit") {
+          throw new Error(
+            "[MODEL] [E_UNSUPPORTED] str_replace_editor undo_edit is not implemented — use undo_last_edit.",
+          );
+        }
+        const rawPath = requireString(rec, "path");
+        abortIf(signal);
+        const absolutePath = await io.resolve(rawPath, cwd, signal);
+
+        if (cmd === "view") {
+          const text = await io.readText(absolutePath, signal);
+          // Observation only: encoding state is recorded by readText;
+          // served state is never touched here.
+          // NOTE (report #10): the readText + emitObserved pair costs two
+          // RPCs by design — readText decodes + records encoding state with
+          // no session, while emitObserved emits fs/observed with exec + a
+          // fresh stat version. Piggy-backing would need readText to take
+          // exec / return a version (FileIO contract break); same pattern
+          // as tool-read.ts, so documented, not collapsed.
+          await io.emitObserved(absolutePath, exec, signal);
+          const display = stripBOM(text).text;
+          const range = requireViewRange(rec);
+          let out = display;
+          if (range) {
+            const lines = splitLines(display);
+            const total = lines.length === 1 && lines[0] === "" ? 0 : lines.length;
+            const [start, end] = range;
+            if (total === 0) {
+              out = "[File is empty.]";
+            } else if (start > total) {
+              out = `View range [${start}, ${end}] is beyond end of file (${total} lines total).`;
+            } else {
+              out = lines.slice(start - 1, Math.min(end, total)).join("\n");
+              if (end < total) {
+                out += `\n\n[Showing lines ${start}-${Math.min(end, total)} of ${total}. Use view_range to continue.]`;
+              }
+            }
+          }
+          const warning = autoGuessWarning(absolutePath, rawPath);
+          return warning ? { text: out, warning } : { text: out };
+        }
+
+        if (cmd === "create") {
+          const fileText = requireString(rec, "file_text");
+          const ver = await io.statVersion(absolutePath, signal);
+          const exists = ver !== undefined;
+          if (exists) {
+            throw argError(
+              "E_FILE_EXISTS",
+              `str_replace_editor: cannot create ${rawPath} — file already exists.`,
+            );
+          }
+          // Governed default: UTF-8 without BOM (no memo → no BOM).
+          await io.writeText(absolutePath, fileText, signal, exec);
+          try {
+            const version = await io.statVersion(absolutePath, signal);
+            recordOpenState(absolutePath, fileText, "utf8", false, version);
+          } catch {
+            // best-effort: the write succeeded; state is a hint.
+          }
+          return { text: `Created ${rawPath}.` };
+        }
+
+        // str_replace / insert — strict read-first gate, no disk write on failure.
+        // NOTE (report #9): requireObserved's statVersion + the readText below
+        // cost two RPCs by design — the stat invalidates stale encoding memos
+        // BEFORE the read so a drifted file fails loud with E_BLIND_REPLACE
+        // without paying for the read, and collapsing them (Promise.all or
+        // skipping the stat) reintroduces TOCTOU: a stale memo could authorize
+        // an edit on drifted bytes. Returning the version from readText would
+        // need a FileIO contract break for an unmeasured hot-path nit; same
+        // pattern as the view double-RPC above, so documented, not collapsed.
+        await requireObserved(io, absolutePath, rawPath, signal);
+        const current = await io.readText(absolutePath, signal);
+
+        if (cmd === "str_replace") {
+          const oldStr = requireString(rec, "old_str");
+          if (!("new_str" in rec) || typeof rec["new_str"] !== "string") {
+            throw argError(
+              "E_BAD_PAYLOAD",
+              'str_replace_editor: "new_str" must be a string for str_replace.',
+            );
+          }
+          const newStr = rec["new_str"] as string;
+          const matches = countOccurrences(current, oldStr);
+          if (matches === 0) {
+            throw argError(
+              "E_NO_MATCH",
+              `str_replace_editor: old_str not found in ${rawPath}. Nothing was written.`,
+            );
+          }
+          if (matches > 1) {
+            throw argError(
+              "E_AMBIGUOUS_MATCH",
+              `str_replace_editor: old_str has multiple matches (${matches}) in ${rawPath} — must match exactly once. Narrow old_str with more context. Nothing was written.`,
+            );
+          }
+          const next = restoreForSave(current.replace(oldStr, newStr), absolutePath);
+          await io.writeText(absolutePath, next, signal, exec);
+          return { text: `Replaced 1 occurrence in ${rawPath}.` };
+        }
+
+        // insert
+        const line = rec["insert_line"];
+        if (!Number.isInteger(line) || (line as number) < 1) {
+          throw argError(
+            "E_BAD_PAYLOAD",
+            'str_replace_editor: "insert_line" must be a positive integer for insert.',
+          );
+        }
+        if (!("new_str" in rec) || typeof rec["new_str"] !== "string") {
+          throw argError(
+            "E_BAD_PAYLOAD",
+            'str_replace_editor: "new_str" must be a string for insert.',
+          );
+        }
+        const insertText = rec["new_str"] as string;
+        const insertAt = line as number;
+        const stripped = stripBOM(current).text;
+        const endsWithNL = stripped.endsWith("\n");
+        const body = endsWithNL ? stripped.slice(0, -1) : stripped;
+        const lines = stripped.length === 0 ? [] : body.split("\n");
+        if (insertAt > lines.length + 1) {
+          throw argError(
+            "E_BAD_PAYLOAD",
+            `str_replace_editor: insert_line ${insertAt} is beyond end of file (${lines.length} lines). Nothing was written.`,
+          );
+        }
+        const added = insertText.split("\n");
+        lines.splice(insertAt - 1, 0, ...added);
+        let out2 = lines.join("\n");
+        if (endsWithNL && out2.length > 0) out2 += "\n";
+        const next = restoreForSave(out2, absolutePath);
+        await io.writeText(absolutePath, next, signal, exec);
+        return { text: `Inserted ${added.length} line(s) at line ${insertAt} in ${rawPath}.` };
+      });
+    },
+  });
+}
+
+/** Register the shadow `str_replace_editor` on the calling agent's scope (own layer). */
+export function registerStrReplaceEditorTool(
+  agentCtx: { tools: { register(def: unknown): () => void } },
+  io: FileIO,
+): () => void {
+  return agentCtx.tools.register(buildStrReplaceEditorTool(io));
+}

--- a/test/core/render-text-warning.test.ts
+++ b/test/core/render-text-warning.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { renderTextWarning } from "../../src/render-text-warning.js";
+import { buildReadTool } from "../../src/tool-read.js";
+import { buildStrReplaceEditorTool } from "../../src/tool-str-replace-editor.js";
+import { localIO } from "../../src/fs-bridge.js";
+
+describe("renderTextWarning shared render (report #7)", () => {
+	it("renders a bare string as one block", () => {
+		expect(renderTextWarning("hello")).toEqual([{ type: "text", text: "hello" }]);
+	});
+
+	it("renders {text} as one block and {text,warning} as two blocks", () => {
+		expect(renderTextWarning({ text: "body" })).toEqual([{ type: "text", text: "body" }]);
+		expect(renderTextWarning({ text: "body", warning: "warn" })).toEqual([
+			{ type: "text", text: "body" },
+			{ type: "text", text: "warn" },
+		]);
+	});
+
+	it("read and str_replace_editor output.render agree (read-vs-view parity)", () => {
+		const io = localIO();
+		const read = buildReadTool(io) as unknown as {
+			output: { render: (a: unknown, v: unknown) => unknown };
+		};
+		const editor = buildStrReplaceEditorTool(io) as unknown as {
+			output: { render: (a: unknown, v: unknown) => unknown };
+		};
+		for (const value of [
+			"bare",
+			{ text: "body" },
+			{ text: "body", warning: "warn" },
+		] as const) {
+			const expected = renderTextWarning(value);
+			expect(read.output.render({}, value)).toEqual(expected);
+			expect(editor.output.render({}, value)).toEqual(expected);
+		}
+	});
+});

--- a/tests/contract/str-replace-editor.test.ts
+++ b/tests/contract/str-replace-editor.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { localIO, clearEncodingState, clearAutoGuessFooter } from "../../src/fs-bridge.js";
+import { buildStrReplaceEditorTool } from "../../src/tool-str-replace-editor.js";
+
+function fakeExec(cwd: string, session = "sre-contract") {
+  return {
+    signal: new AbortController().signal,
+    agent: { id: session, session: { id: session, header: { cwd } } },
+  } as never;
+}
+
+describe("str_replace_editor contract parity", () => {
+  function paramsOf(tool: unknown): Record<string, unknown> {
+    const p = (tool as { parameters: unknown }).parameters as Record<string, unknown>;
+    // defineTool compiles ValueSchemaSpec into JSON Schema: {type:'object', properties:{...}}
+    if (p && typeof p === "object" && "properties" in p)
+      return p["properties"] as Record<string, unknown>;
+    return p;
+  }
+  it("tool name is str_replace_editor with built-in command params and no encoding param", () => {
+    const tool = buildStrReplaceEditorTool(localIO()) as unknown as {
+      name: string;
+      parameters: Record<string, unknown>;
+    };
+    const params = paramsOf(tool);
+    expect(tool.name).toBe("str_replace_editor");
+    for (const key of [
+      "command",
+      "path",
+      "view_range",
+      "old_str",
+      "new_str",
+      "insert_line",
+      "file_text",
+    ]) {
+      expect(params, `missing param ${key}`).toHaveProperty(key);
+    }
+    expect(params).not.toHaveProperty("encoding");
+  });
+
+  it("view_range slices 1-indexed inclusive", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "sre-c-"));
+    try {
+      clearEncodingState();
+      clearAutoGuessFooter();
+      const p = join(dir, "f.txt");
+      await writeFile(p, "l1\nl2\nl3\nl4\n", "utf-8");
+      const tool = buildStrReplaceEditorTool(localIO());
+      const exec = fakeExec(dir);
+      const res = (await tool.execute(
+        { command: "view", path: p, view_range: [2, 3] },
+        exec,
+      )) as unknown as { text: string };
+      expect(res.text).toContain("l2");
+      expect(res.text).toContain("l3");
+      expect(res.text).not.toContain("l1\n");
+      expect(res.text).not.toContain("l4");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("insert + create round-trip; create fails when file exists; undo_edit unsupported", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "sre-c2-"));
+    try {
+      clearEncodingState();
+      clearAutoGuessFooter();
+      const io = localIO();
+      const tool = buildStrReplaceEditorTool(io);
+      const exec = fakeExec(dir);
+      const created = join(dir, "new.txt");
+      const c = (await tool.execute(
+        { command: "create", path: created, file_text: "a\nb\n" },
+        exec,
+      )) as unknown as { text: string };
+      expect(c.text).toContain("new.txt");
+      await expect(
+        tool.execute({ command: "create", path: created, file_text: "x" }, exec),
+      ).rejects.toThrow(/already exists/);
+      await tool.execute({ command: "view", path: created }, exec);
+      await tool.execute(
+        { command: "insert", path: created, insert_line: 1, new_str: "top" },
+        exec,
+      );
+      const v = (await tool.execute({ command: "view", path: created }, exec)) as unknown as {
+        text: string;
+      };
+      expect(v.text.split("\n")[0]).toContain("top");
+      await expect(tool.execute({ command: "undo_edit", path: created }, exec)).rejects.toThrow(
+        /E_UNSUPPORTED/,
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("unknown command rejected", async () => {
+    const tool = buildStrReplaceEditorTool(localIO());
+    await expect(
+      tool.execute({ command: "delete", path: "x" }, fakeExec(tmpdir())),
+    ).rejects.toThrow(/E_BAD_COMMAND|unknown command/i);
+  });
+});

--- a/tests/tool-str-replace-editor.test.ts
+++ b/tests/tool-str-replace-editor.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { writeFile, readFile, rm, mkdtemp } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import iconv from "iconv-lite";
+import { localIO, clearEncodingState, clearAutoGuessFooter } from "../src/fs-bridge.js";
+import { _resetConfigCache } from "../src/store-config.js";
+import { buildStrReplaceEditorTool } from "../src/tool-str-replace-editor.js";
+
+function fakeExec(cwd: string, session = "sre-test") {
+  return {
+    signal: new AbortController().signal,
+    agent: { id: session, session: { id: session, header: { cwd } } },
+  } as never;
+}
+
+describe("str_replace_editor shadow tool (TDD red)", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "sre-"));
+    clearEncodingState();
+    clearAutoGuessFooter();
+    _resetConfigCache();
+    delete process.env.DSH_BETTER_EDIT_AUTO_GUESS_ENCODING;
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+    clearEncodingState();
+    clearAutoGuessFooter();
+    delete process.env.DSH_BETTER_EDIT_AUTO_GUESS_ENCODING;
+    _resetConfigCache();
+  });
+
+  it("BOM round-trip: view -> str_replace preserves EF BB BF", async () => {
+    const p = join(dir, "bom.txt");
+    await writeFile(
+      p,
+      Buffer.concat([Buffer.from([0xef, 0xbb, 0xbf]), Buffer.from("hello\nworld\n", "utf-8")]),
+    );
+    const io = localIO();
+    const tool = buildStrReplaceEditorTool(io);
+    const exec = fakeExec(dir);
+    await tool.execute({ command: "view", path: p }, exec);
+    const res = (await tool.execute(
+      { command: "str_replace", path: p, old_str: "world", new_str: "there" },
+      exec,
+    )) as unknown as { text: string };
+    expect(res.text).toMatch(/Replaced 1 occurrence/);
+    const raw = await readFile(p);
+    expect(raw[0]).toBe(0xef);
+    expect(raw[1]).toBe(0xbb);
+    expect(raw[2]).toBe(0xbf);
+    expect(raw.toString("utf-8")).toContain("there");
+  });
+
+  it("GBK file view decodes via autoGuess", async () => {
+    const p = join(dir, "gbk.txt");
+    // Longer body: short GBK byte runs are valid Big5 too (detection-error
+    // territory) — a paragraph lets the guesser settle on gbk.
+    const body =
+      "你好世界，这是一个用于编码检测的长段落。\n第二行内容也是中文。\n第三行继续添加更多中文字符以提高置信度。";
+    await writeFile(p, iconv.encode(body, "gbk"));
+    process.env.DSH_BETTER_EDIT_AUTO_GUESS_ENCODING = "true";
+    _resetConfigCache();
+    const io = localIO();
+    const tool = buildStrReplaceEditorTool(io);
+    const res = (await tool.execute({ command: "view", path: p }, fakeExec(dir))) as unknown as {
+      text: string;
+      warning?: string;
+    };
+    expect(res.text).toContain("你好世界");
+    // Decisive guess → no footer; mid-confidence guess → Auto-guessed footer (readAndServe parity).
+    expect(res.warning === undefined || (res.warning ?? "").includes("Auto-guessed")).toBe(true);
+  });
+
+  it("ambiguous bytes surface the autoGuess footer as warning (second block)", async () => {
+    const p = join(dir, "gbk-short.txt");
+    await writeFile(p, iconv.encode("你好世界", "gbk"));
+    process.env.DSH_BETTER_EDIT_AUTO_GUESS_ENCODING = "true";
+    _resetConfigCache();
+    const tool = buildStrReplaceEditorTool(localIO());
+    const res = (await tool.execute({ command: "view", path: p }, fakeExec(dir))) as unknown as {
+      text: string;
+      warning?: string;
+    };
+    // Short GBK runs are valid Big5 too — the guesser stays uncertain and must say so.
+    expect(res.warning ?? "").toContain("Auto-guessed");
+    const blocks = (
+      tool as unknown as { output: { render(a: unknown, v: unknown): Array<{ text: string }> } }
+    ).output.render({ path: p }, res);
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]!.text).toBe(res.text);
+    expect(blocks[1]!.text).toBe(res.warning);
+  });
+
+  it("undecodable view fails loud with Top-3 (E_UNSUPPORTED_FILE)", async () => {
+    const throwingIO = {
+      ...localIO(),
+      readText: async () => {
+        throw new Error(
+          `[MODEL] [E_UNSUPPORTED_FILE] Path is not a readable UTF-8 text file: x. Top-3 guesses: gbk("a"), big5("b"), shift_jis("c"). Try read({encoding: "<encoding>"})`,
+        );
+      },
+    } as unknown as ReturnType<typeof localIO>;
+    const tool = buildStrReplaceEditorTool(throwingIO);
+    await expect(
+      tool.execute({ command: "view", path: join(dir, "x.bin") }, fakeExec(dir)),
+    ).rejects.toThrow(/E_UNSUPPORTED_FILE/);
+  });
+
+  it("blind str_replace without prior view -> E_BLIND_REPLACE, no disk write", async () => {
+    const p = join(dir, "blind.txt");
+    await writeFile(p, "alpha\nbeta\n", "utf-8");
+    const io = localIO();
+    const tool = buildStrReplaceEditorTool(io);
+    await expect(
+      tool.execute(
+        { command: "str_replace", path: p, old_str: "beta", new_str: "BETA" },
+        fakeExec(dir),
+      ),
+    ).rejects.toThrow(/E_BLIND_REPLACE/);
+    expect(await readFile(p, "utf-8")).toBe("alpha\nbeta\n");
+  });
+
+  it("blind insert without prior view -> E_BLIND_REPLACE", async () => {
+    const p = join(dir, "blind2.txt");
+    await writeFile(p, "a\nb\n", "utf-8");
+    const tool = buildStrReplaceEditorTool(localIO());
+    await expect(
+      tool.execute({ command: "insert", path: p, insert_line: 1, new_str: "x" }, fakeExec(dir)),
+    ).rejects.toThrow(/E_BLIND_REPLACE/);
+  });
+
+  it("old_str must match exactly once", async () => {
+    const p = join(dir, "dup.txt");
+    await writeFile(p, "same\nsame\n", "utf-8");
+    const tool = buildStrReplaceEditorTool(localIO());
+    const exec = fakeExec(dir);
+    await tool.execute({ command: "view", path: p }, exec);
+    await expect(
+      tool.execute({ command: "str_replace", path: p, old_str: "missing", new_str: "x" }, exec),
+    ).rejects.toThrow(/not found/);
+    await expect(
+      tool.execute({ command: "str_replace", path: p, old_str: "same", new_str: "x" }, exec),
+    ).rejects.toThrow(/multiple/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #60 

Shadows the preset's built-in `str_replace_editor` on the **agent layer** with a governed, encoding-aware implementation (`view`/`str_replace`/`insert`/`create` parity, no new `encoding` param). Every mutation now passes through `file encoding state` (BOM → strict UTF-8 → `autoGuessEncoding` → Top-3), failing loud with `E_BLIND_REPLACE` / `E_UNSUPPORTED_FILE` instead of mojibaking GBK/Big5/Shift-JIS or losing BOM.

**Impact**: 12 files (788 +, 45 -) · **Risk**: Medium (shadows a built-in tool name; contract parity must track upstream)

## What Changed

**Docs / Domain (ADR-0015):**
- `CONTEXT.md`: adds `encoding governance` / `governed edit path` / `ungoverned edit path` glossary (ADR-0012 VS Code model)
- `docs/adr/0015-shadow-str-replace-editor.md`: accepted — agent-layer shadow vs upstream fix trade-off, self-heal identity pinning, rollback surprise
- `CHANGELOG.md`: Unreleased updated (`str-replace: add governed editor shadow`) via `scripts/changelog-unreleased.py`

**Source — Shadow tool (`src/tool-str-replace-editor.ts`, 328+):**
- `buildStrReplaceEditorTool(io: FileIO)` — `defineTool({ name: "str_replace_editor" })` with identical params (`command`, `path`, `view_range`, `old_str`, `new_str`, `insert_line`, `file_text`, no `encoding`)
- `view`: observation via `io.readText` + `recordOpenState`, `emitObserved`, BOM-stripped display, `view_range` slicing, auto-guess warning second block
- `str_replace`/`insert`: strict `requireObserved` gate (`E_BLIND_REPLACE` if no prior `view`/`read` at current version), `E_NO_MATCH`/`E_AMBIGUOUS_MATCH` for `old_str`, BOM-preserving `restoreBom` (FEFF-aware insert now splits stripped text — fix #1), UTF-8 default for `create`, `E_UNSUPPORTED` for `undo_edit`
- Shares seams: `file-encoding-state.ts` (`decodeForOpen`, `prepareForSave`, `recordOpenState`, `invalidateIfStale`), `ctxFsIO`, `render-text-warning.ts`

**Source — Integration:**
- `src/index.ts`: `installAgentTools` registers third shadow `hashStrReplaceDef` via `agent.ctx.tools.register` (nearest-layer-wins), passes to `createSelfHealWatcher`
- `src/self-heal.ts`: generalizes restore blocks → `restoreTool()` loop for `read`/`edit`/`str_replace_editor` (fixes #4/#5 triplication), watches optional `hashStrReplaceDef`
- `src/file-encoding-state.ts`: shared `restoreBom`/`prepareForSave` seam for BOM+lineEnding (fix #2)
- `src/tool-read.ts` + `src/render-text-warning.ts`: extract shared `renderTextWarning` helper (fix #7 — was verbatim copy), shared with shadow's `output.render`
- `src/tool-read.ts`/`tool-str-replace-editor.ts`: create existence via `statVersion` not full `readText` decode (fix #8), document double-RPC `readText+emitObserved` as design (fix #10, + `autoGuessWarning` 3-way slash-normalized fallback fix #3)

**Tests (149 + 106 + 38):**
- `tests/tool-str-replace-editor.test.ts`: BOM round-trip (EF BB BF preserved), GBK `view` via `autoGuess`, ambiguous short-GBK warning second block, `E_UNSUPPORTED_FILE` Top-3, blind `str_replace`/`insert` → `E_BLIND_REPLACE`, `old_str` exactly-once, `view_range` slicing
- `tests/contract/str-replace-editor.test.ts`: name/parity (no `encoding` param), unknown command → `E_BAD_COMMAND`
- `test/core/render-text-warning.test.ts`: shared render helper parity

## Architecture

```mermaid
graph LR
  subgraph Preset["Preset (built-in)"]
    BuiltInSRE["str_replace_editor<br/>(unencoded)"]
  end
  subgraph Agent["Agent Layer (shadow)"]
    ShadowSRE["str_replace_editor<br/>governed<br/>file-encoding-state"]
    Read["read<br/>hashline"]
    Edit["edit<br/>hashline"]
  end
  subgraph Seams["Shared Seams"]
    IO["ctxFsIO / FileIO"]
    State["file-encoding-state<br/>decodeForOpen / prepareForSave"]
    Heal["self-heal watcher"]
  end
  BuiltInSRE -. nearest-layer-wins .-> ShadowSRE
  ShadowSRE --> IO
  Read --> IO
  Edit --> IO
  ShadowSRE --> State
  Read --> State
  Heal --> ShadowSRE
  Heal --> Read
  Heal --> Edit
```

Agent `tools.register(ShadowSRE)` shadows preset at `agent/session-start`; `self-heal` restores on external takeover; preset guidance untouched (zero upstream coordination, per-agent unwind).

## Checklist

- [x] `pnpm run typecheck` PASS (`tsc --noEmit` + `tsconfig.test.json`)
- [x] `pnpm test` 119/1281 PASS
- [x] `pnpm run build` (`tsc -p tsconfig.json`) via pre-push/verify
- [x] `uv run python scripts/changelog-unreleased.py update` + amended `CHANGELOG.md` (pre-push guard)
- [x] Contract parity pinned (`tests/contract/str-replace-editor.test.ts` — name, 7 params, no `encoding`, `view_range` 1-indexed inclusive)
- [x] Code-review `code-review-mtu6jwdx-01ngw5` 10/10 addressed (CONFIRMED #1 BOM insert stripped, #3 autoGuess 3-way, #6 dead catch, #7 shared render, #8 statVersion perf, #10 double-RPC doc + PLAUSIBLE #2/#4/#5/#9)
- [ ] Upstream `dsh-tool-str-replace-editor` contract drift — if new `command`/param added, shadow must port (see `tests/contract/`)
