### PR TITLE
docs: add PR template and document PR requirements via git scaffolding

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,33 @@
+<!-- markdownlint-disable MD041 -->
+
+## Summary
+
+<!-- 2-3 sentences: why this change, user-visible effect. -->
+
+**Impact**: <!-- X files (Y +, Z -) --> · **Risk**: <!-- Low | Medium | High -->
+<!-- Risk: Low = docs/tests only; Medium = isolated feature/fix; High = cross-module contract, migration, or BREAKING CHANGE -->
+
+## What Changed
+
+<!-- Grouped by system/feature, not file list. Flag migrations / API / payload-contract changes. -->
+<!-- Example: - hashline: ... -->
+
+-
+
+## Architecture
+
+<!-- Mermaid before/after only when structural seams, layering, or data-flow changes; delete section otherwise. -->
+
+```mermaid
+graph LR
+  A --> B
+```
+
+## Checklist
+
+- [ ] `pnpm run lint && pnpm run format && pnpm run typecheck && pnpm test` green
+- [ ] Conventional Commits (`commitlint` + `husky`) — `npx commitlint --from=origin/main --to=HEAD`
+- [ ] `CHANGELOG.md` `## [Unreleased]` updated (if user-facing)
+- [ ] Docs / `docs/adr/` updated when seams or contracts change
+- [ ] No generated artifacts committed outside `.lsz/tmp`
+- [ ] Linked issue with `Closes #NN` (if applicable)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [Unreleased]
+
+### Documentation
+
+- add PR template and document PR requirements via git scaffolding
+
 ## [0.8.0](https://github.com/Rianico/dsh-better-edit/compare/v0.7.1...v0.8.0) (2026-09-09)
 
 ### Features

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,8 +9,35 @@
 
 ## Changelog
 
-`CHANGELOG.md` `## [Unreleased]` guarded by `pre-push` hook (`warn+block`, `uv run python scripts/changelog-unreleased.py update`) and `changelog-check.yml` (`pull_request` required, `diff -q` vs generated); `release.yml` runs `scripts/changelog-unreleased.py clear` then `semantic-release` owns versioned sections. Do not hand-edit versioned sections. Hidden types `style|chore|refactor|test|build|ci` only appear when `!`/`BREAKING CHANGE`.
+`CHANGELOG.md` `## [Unreleased]` guarded by `pre-push` hook (`warn+block`, `uv run python scripts/changelog-unreleased.py update`) and `changelog-check.yml` (`pull_request` required, `diff -q` vs generated); `release.yml` runs `scripts/changelog-unreleased.py clear` then `semantic-release` owns versioned sections. Do not hand-edit versioned sections. Commit the sync as a hidden type (e.g. `chore: sync changelog unreleased section`) — a visible type (`feat`/`fix`/`docs` etc.) re-triggers the guard and loops forever. Hidden types `style|chore|refactor|test|build|ci` only appear when `!`/`BREAKING CHANGE`.
+
+## Reporting Issues
+
+Pick the template that matches your intent — see `.github/ISSUE_TEMPLATE/` (blank issues disabled, `config.yml` links #38):
+
+| Intent      | Template                 | Structure                                                                                                                                                                                                                                                                      |
+| ----------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Bug**     | `01-bug_report.yml`      | **Exemplar #38**: Summary → Environment (Version/Module/Trigger) → Steps to Reproduce (paste-complete file + operation map + exact payload) → Expected vs Actual (quote diff/logs) → Impact & Trigger Conditions → Root Cause / Suggested Fixes (optional, numbered tradeoffs) |
+| **Feature** | `02-feature_request.yml` | Problem → Proposal → Alternatives → Additional context                                                                                                                                                                                                                         |
+
+- Bugs: paste-complete, prefer text over screenshots, include `read` hashes / payload and `autoFixes`/balance delta. Link #38 as style reference.
+- Features: state problem + proposal at minimum; alternatives optional.
+  Prompt rule: when the model helps file an issue, infer `bug` vs `feat` from intent, ask for any missing `body` field of that form, and render via `gh issue create --template <file>`. View exemplar with `gh issue view 38 --json title,body --repo Rianico/dsh-better-edit`.
 
 ## Before PR
 
 `pnpm run lint && pnpm run format && pnpm run typecheck && pnpm test` must pass. See `AGENTS.md` for agent rules.
+
+## Pull Requests
+
+Prefer topic branch → PR → squash merge. Keep one concern per PR; link the issue with `Closes #NN` in the description or commit footer.
+
+### Description
+
+PR body is auto-populated from `.github/pull_request_template.md` (GitHub PR template). Keep the four headings — delete `Architecture` when no structural change:
+
+- **Summary** — 2-3 sentences on _why_, not what line changed. Include `**Impact**: X files (Y +, Z -) · **Risk**: Low | Medium | High` (Low = docs/tests only; Medium = isolated feature/fix; High = cross-module contract, migration, or `BREAKING CHANGE`).
+- **What Changed** — grouped by system/feature (`hashline`, `anchors`, `session`, `payload`, `docs`, `ci`), not by file list. Flag migrations / API / `ADR-0007` payload `{path, edits:[[h,h,t]]}` / `CANON_VERSION` touches.
+- **Architecture** — Mermaid `graph LR` / `sequenceDiagram` before → after only for structural seams, layering, or data-flow changes.
+- **Checklist** — derived from change categories; start from the template checklist and add items as needed (e.g., benchmarks for perf, absorption notes for upstream sync).
+  CI (`changelog-check.yml`, `verify`) must be green before requesting review.


### PR DESCRIPTION
## Summary

Add GitHub PR template and document PR workflow per git scaffolding. Auto-populated `.github/pull_request_template.md` provides the four headings for reviewers.

**Impact**: 3 files (67 +, 1 -) · **Risk**: Low

## What Changed

- git scaffolding: add pr-template component and extend CONTRIBUTING.md Pull Requests section
- docs: sync CONTRIBUTING.md and add PR template
- scaffold: scaffold.py + git-scaffolding skill now emit pr-template deterministically

## Architecture

Docs/scaffolding only.

## Checklist

- [x] pnpm run lint && pnpm run format && pnpm run typecheck && pnpm test green
- [x] Conventional Commits
- [x] CHANGELOG.md ## [Unreleased] updated