### PR TITLE
fix(str-replace): record real fs version so view/read authorizes str_replace/insert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,27 +1,28 @@
 ## [Unreleased]
 
-### Bug Fixes
+### Fixed
 
-- **str-replace:** record real fs version on ctxFsIO reads so view/read authorizes str_replace/insert, closes [#69](https://github.com/Rianico/dsh-better-edit/issues/69)
+- **str-replace:** record real fs version on ctxFsIO reads, closes #69
 
 ### Documentation
 
-- add PR template and document PR requirements via git scaffolding
+- **changelog:** note #69 read-first gate version fix
+- add PR template and document PR requirements via git scaffolding (#68)
 
 ## [0.8.0](https://github.com/Rianico/dsh-better-edit/compare/v0.7.1...v0.8.0) (2026-09-09)
 
 ### Features
 
-* **edit:** accept object-form edits entries ({remove_from, remove_to, replacement_text}), closes [#64](https://github.com/Rianico/dsh-better-edit/issues/64) ([#66](https://github.com/Rianico/dsh-better-edit/issues/66)) ([a14ef4c](https://github.com/Rianico/dsh-better-edit/commit/a14ef4cee1c4d8126f40516624b6811d57041bf8))
-* **str-replace:** add governed editor shadow ([#67](https://github.com/Rianico/dsh-better-edit/issues/67)) ([a015629](https://github.com/Rianico/dsh-better-edit/commit/a0156296ce615069f10acf60e3d96c4dc3fa9e14))
+- **edit:** accept object-form edits entries ({remove_from, remove_to, replacement_text}), closes [#64](https://github.com/Rianico/dsh-better-edit/issues/64) ([#66](https://github.com/Rianico/dsh-better-edit/issues/66)) ([a14ef4c](https://github.com/Rianico/dsh-better-edit/commit/a14ef4cee1c4d8126f40516624b6811d57041bf8))
+- **str-replace:** add governed editor shadow ([#67](https://github.com/Rianico/dsh-better-edit/issues/67)) ([a015629](https://github.com/Rianico/dsh-better-edit/commit/a0156296ce615069f10acf60e3d96c4dc3fa9e14))
 
 ### Bug Fixes
 
-* **script:** correct repo inference and headless dispatch for gh-release ([b517646](https://github.com/Rianico/dsh-better-edit/commit/b5176465f8363ff80bb48e96cdfa86e6254f2ebf)), closes [#51](https://github.com/Rianico/dsh-better-edit/issues/51)
+- **script:** correct repo inference and headless dispatch for gh-release ([b517646](https://github.com/Rianico/dsh-better-edit/commit/b5176465f8363ff80bb48e96cdfa86e6254f2ebf)), closes [#51](https://github.com/Rianico/dsh-better-edit/issues/51)
 
 ### Documentation
 
-* **agents:** sync AGENTS.md — remove tag-first releasing, fix git guide and upstream cursor ([d1088d1](https://github.com/Rianico/dsh-better-edit/commit/d1088d1f43f151f80f204fc5189268a5945066f8))
+- **agents:** sync AGENTS.md — remove tag-first releasing, fix git guide and upstream cursor ([d1088d1](https://github.com/Rianico/dsh-better-edit/commit/d1088d1f43f151f80f204fc5189268a5945066f8))
 
 ## [0.7.1](https://github.com/Rianico/dsh-better-edit/compare/v0.7.0...v0.7.1) (2026-09-06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Bug Fixes
+
+- **str-replace:** record real fs version on ctxFsIO reads so view/read authorizes str_replace/insert, closes [#69](https://github.com/Rianico/dsh-better-edit/issues/69)
+
 ### Documentation
 
 - add PR template and document PR requirements via git scaffolding

--- a/src/fs-bridge.ts
+++ b/src/fs-bridge.ts
@@ -159,12 +159,18 @@ async function restoreStrippedUtf8Bom(
   target: FsTarget,
   text: string,
   signal?: AbortSignal,
-): Promise<string> {
-  if (text.startsWith(UTF8_BOM)) return text;
+): Promise<{ text: string; version: string | undefined }> {
+  // BOM already preserved: one metadata stat for the read-first gate version
+  // (issue #69). No byte probe here — readBytes stays forbidden in this branch.
+  if (text.startsWith(UTF8_BOM)) {
+    const info = await fs.stat(target, signal).catch(() => undefined);
+    return { text, version: info?.version as string | undefined };
+  }
 
   const info = await fs.stat(target, signal);
+  const version = info?.version as string | undefined;
   if (info?.size === undefined || info.size !== Buffer.byteLength(text, "utf-8") + UTF8_BOM_LEN) {
-    return text;
+    return { text, version };
   }
 
   const bytes = await fs.readBytes(target, signal, info.size);
@@ -175,12 +181,12 @@ async function restoreStrippedUtf8Bom(
     bytes[1] !== UTF8_BOM_BYTES[1] ||
     bytes[2] !== UTF8_BOM_BYTES[2]
   ) {
-    return text;
+    return { text, version };
   }
   for (let i = 0; i < encodedText.length; i += 1) {
-    if (bytes[i + UTF8_BOM_LEN] !== encodedText[i]) return text;
+    if (bytes[i + UTF8_BOM_LEN] !== encodedText[i]) return { text, version };
   }
-  return `${UTF8_BOM}${text}`;
+  return { text: `${UTF8_BOM}${text}`, version };
 }
 
 /** FileIO over the deployment's `ctx.fs` service. */
@@ -217,7 +223,21 @@ export function ctxFsIO(fs: FileSystem, ctx: Context): FileIO {
           decoded.hasBOM,
           info?.version as string | undefined,
         );
-        if (decoded.footer) recordFooter(targetKey, decoded.footer);
+        // Gate looks up by resolved absolutePath; targetKey may differ
+        // (symlink/case) — mirror under both keys (issue #69 note).
+        if (targetKey !== absolutePath) {
+          recordOpenState(
+            absolutePath,
+            decoded.text,
+            decoded.encoding,
+            decoded.hasBOM,
+            info?.version as string | undefined,
+          );
+        }
+        if (decoded.footer) {
+          recordFooter(targetKey, decoded.footer);
+          if (targetKey !== absolutePath) recordFooter(absolutePath, decoded.footer);
+        }
         return decoded.text;
       }
 
@@ -226,21 +246,25 @@ export function ctxFsIO(fs: FileSystem, ctx: Context): FileIO {
           ...(signal === undefined ? {} : { signal }),
         });
         const text = await fs.readText(target, signal);
-        const restored = await restoreStrippedUtf8Bom(fs, target, text, signal);
+        // Thread the restore path's stat version into the encoding memo so the
+        // read-first gate validates against the real version (issue #69 fix 2).
+        // The BOM-preserved branch stats for version only — no byte probe.
+        const { text: restored, version } = await restoreStrippedUtf8Bom(fs, target, text, signal);
         // record file encoding state for round-trip (BOM + lineEnding)
-        // Do not probe fs.stat when BOM is already preserved — keep the no-probe guarantee
-        // tested in fs-bridge.policy.test.ts (keeps a BOM already preserved without probing)
         try {
           const targetKey = String(
             (target as unknown as { targetKey?: string }).targetKey ?? absolutePath,
           );
           const hasBOM = restored.startsWith(UTF8_BOM);
           const clean = hasBOM ? restored.slice(1) : restored;
-          // use seam to record with correct lineEnding detection; version left undefined
-          // to avoid extra stat (the success path must stay probe-free when BOM preserved)
-          recordOpenState(targetKey, clean, hasBOM ? "utf8bom" : "utf8", hasBOM, undefined);
+          // use seam to record with correct lineEnding detection
+          recordOpenState(targetKey, clean, hasBOM ? "utf8bom" : "utf8", hasBOM, version);
+          if (targetKey !== absolutePath) {
+            recordOpenState(absolutePath, clean, hasBOM ? "utf8bom" : "utf8", hasBOM, version);
+          }
           // clear any stale autoGuess footer on clean UTF-8 read
           _clearAutoGuessFooter(targetKey);
+          if (targetKey !== absolutePath) _clearAutoGuessFooter(absolutePath);
         } catch {
           // best-effort
         }
@@ -269,7 +293,19 @@ export function ctxFsIO(fs: FileSystem, ctx: Context): FileIO {
             decoded.hasBOM,
             info?.version as string | undefined,
           );
-          if (decoded.footer) recordFooter(targetKey, decoded.footer);
+          if (targetKey !== absolutePath) {
+            recordOpenState(
+              absolutePath,
+              decoded.text,
+              decoded.encoding,
+              decoded.hasBOM,
+              info?.version as string | undefined,
+            );
+          }
+          if (decoded.footer) {
+            recordFooter(targetKey, decoded.footer);
+            if (targetKey !== absolutePath) recordFooter(absolutePath, decoded.footer);
+          }
           return decoded.text;
         }
         return mapFsError(error, absolutePath);
@@ -286,6 +322,8 @@ export function ctxFsIO(fs: FileSystem, ctx: Context): FileIO {
         );
         const info = await fs.stat(targetTmp, signal).catch(() => undefined);
         invalidateIfStale(key, info?.version as string | undefined);
+        if (key !== absolutePath)
+          invalidateIfStale(absolutePath, info?.version as string | undefined);
       } catch {} // biome-ignore: best-effort
 
       try {

--- a/test/core/fs-bridge.policy.test.ts
+++ b/test/core/fs-bridge.policy.test.ts
@@ -7,9 +7,13 @@
  * @module dsh-better-edit/fs-bridge.policy.test
  */
 
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi, beforeEach } from "vitest";
 import type { Context } from "@deepseek-ai/cordis";
-import { ctxFsIO, type FileIO } from "../../src/fs-bridge.js";
+import { ctxFsIO, type FileIO, getEncodingState, clearEncodingState } from "../../src/fs-bridge.js";
+
+beforeEach(() => {
+  clearEncodingState();
+});
 
 /** A mock `ctx.fs` recording every call and returning scripted results. */
 function makeFs(overrides: Partial<Record<string, unknown>> = {}) {
@@ -169,15 +173,18 @@ describe("ctxFsIO readText", () => {
     await expect(io.readText("/abs/file.txt")).rejects.toBe(error);
   });
 
-  it("keeps a BOM already preserved by the backend without probing metadata", async () => {
+  it("keeps a BOM already preserved by the backend without probing bytes (version stat allowed)", async () => {
     const text = "\uFEFFhello\n";
     const { fs } = makeFs({ readText: vi.fn(async () => text) });
     const { ctx } = makeCtx();
     const io: FileIO = ctxFsIO(fs as never, ctx);
 
     await expect(io.readText("/abs/file.txt")).resolves.toBe(text);
-    expect(fs.stat).not.toHaveBeenCalled();
+    // No byte probe: BOM restoration must not read raw bytes when already preserved.
     expect(fs.readBytes).not.toHaveBeenCalled();
+    // A version-only stat is required so the read-first gate records the real
+    // version instead of undefined (issue #69 fix 2) — drift stays detectable.
+    expect(getEncodingState("tk-1")?.version).toBe("v1");
   });
 });
 

--- a/test/core/str-replace-version-gate.test.ts
+++ b/test/core/str-replace-version-gate.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Regression for #69: shadow `str_replace_editor` read-first gate vs
+ * `version: undefined` encoding state.
+ *
+ * Uses a fake `ctx.fs` with production `ctxFsIO` version semantics
+ * (dsh-fs-local strips BOM via TextDecoder, versions are non-empty strings):
+ * `view`/`read` must authorize `str_replace`/`insert`, while an external
+ * change must still fail loud with E_BLIND_REPLACE.
+ * @module dsh-better-edit/str-replace-version-gate.test
+ */
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { Context } from "@deepseek-ai/cordis";
+import { ctxFsIO, type FileIO } from "../../src/fs-bridge.js";
+import { clearEncodingState, clearAutoGuessFooter } from "../../src/fs-bridge.js";
+import { buildStrReplaceEditorTool } from "../../src/tool-str-replace-editor.js";
+
+function fakeExec(cwd: string, session = "sre-vgate") {
+  return {
+    signal: new AbortController().signal,
+    agent: { id: session, session: { id: session, header: { cwd } } },
+  } as never;
+}
+
+/** In-memory fake ctx.fs mimicking dsh-fs-local: BOM-stripping readText + versioned stat. */
+function makeProdFs() {
+  const files = new Map<string, { bytes: Buffer; version: number }>();
+  let seq = 1;
+  const pathOf = (t: unknown) =>
+    typeof t === "string" ? t : ((t as { displayPath?: string }).displayPath ?? "/abs/file.txt");
+  const fs = {
+    resolve: vi.fn(async (p: string) => ({
+      targetKey: `/abs/${String(p).split("/").pop()}`,
+      displayPath: p,
+    })),
+    processPath: vi.fn((t: unknown) => pathOf(t)),
+    readText: vi.fn(async (t: unknown) => {
+      const p = pathOf(t);
+      const f = files.get(p);
+      if (!f) throw Object.assign(new Error("not found"), { code: "FS_NOT_FOUND" });
+      // dsh-fs-local decodes with TextDecoder utf-8 fatal, ignoreBOM:false -> swallows EF BB BF
+      const raw = new TextDecoder("utf-8", { fatal: true }).decode(f.bytes);
+      return raw.startsWith("\uFEFF") ? raw.slice(1) : raw;
+    }),
+    readBytes: vi.fn(async (t: unknown, _s?: unknown, n?: number) => {
+      const p = pathOf(t);
+      const f = files.get(p);
+      if (!f) throw Object.assign(new Error("not found"), { code: "FS_NOT_FOUND" });
+      return new Uint8Array(f.bytes.subarray(0, n ?? f.bytes.length));
+    }),
+    stat: vi.fn(async (t: unknown) => {
+      const p = pathOf(t);
+      const f = files.get(p);
+      if (!f) throw Object.assign(new Error("not found"), { code: "FS_NOT_FOUND" });
+      return { version: `v${f.version}`, type: "file", size: f.bytes.length };
+    }),
+    writeText: vi.fn(async (t: unknown, content: string) => {
+      const p = pathOf(t);
+      const cur = files.get(p);
+      const version = (cur?.version ?? 0) + 1;
+      files.set(p, { bytes: Buffer.from(content, "utf-8"), version });
+      return { version: `v${version}`, operation: "update", before: "", after: content };
+    }),
+  };
+  return {
+    fs,
+    seed(p: string, bytes: Buffer) {
+      files.set(p, { bytes, version: seq++ });
+    },
+    externalWrite(p: string, bytes: Buffer) {
+      const cur = files.get(p);
+      files.set(p, { bytes, version: (cur?.version ?? 0) + 100 });
+    },
+    readRaw(p: string) {
+      return files.get(p)!.bytes;
+    },
+  };
+}
+
+function makeCtx() {
+  const ctx = {
+    waterfall: vi.fn(async () => undefined),
+    emit: vi.fn(() => {}),
+  } as unknown as Context;
+  return ctx;
+}
+
+beforeEach(() => {
+  clearEncodingState();
+  clearAutoGuessFooter();
+});
+
+describe("issue #69: ctxFsIO version semantics authorize shadow writes", () => {
+  it("view -> str_replace succeeds on BOM-stripped production path, preserving BOM+CRLF", async () => {
+    const fake = makeProdFs();
+    const p = "/abs/bom.txt";
+    fake.seed(
+      p,
+      Buffer.concat([
+        Buffer.from([0xef, 0xbb, 0xbf]),
+        Buffer.from("alpha\r\nbravo\r\ncharlie\r\n", "utf-8"),
+      ]),
+    );
+    const io: FileIO = ctxFsIO(fake.fs as never, makeCtx());
+    const tool = buildStrReplaceEditorTool(io);
+    const exec = fakeExec("/abs");
+    await tool.execute({ command: "view", path: p }, exec);
+    const res = (await tool.execute(
+      { command: "str_replace", path: p, old_str: "bravo", new_str: "bravo-edited" },
+      exec,
+    )) as unknown as { text: string };
+    expect(res.text).toMatch(/Replaced 1 occurrence/);
+    const raw = fake.readRaw(p);
+    expect(raw[0]).toBe(0xef);
+    expect(raw[1]).toBe(0xbb);
+    expect(raw[2]).toBe(0xbf);
+    expect(raw.toString("utf-8")).toContain("bravo-edited");
+    expect(raw.toString("utf-8")).toContain("\r\n");
+  });
+
+  it("view -> insert succeeds on no-BOM production path", async () => {
+    const fake = makeProdFs();
+    const p = "/abs/nobom.txt";
+    fake.seed(p, Buffer.from("alpha\r\nbravo\r\ncharlie\r\n", "utf-8"));
+    const io: FileIO = ctxFsIO(fake.fs as never, makeCtx());
+    const tool = buildStrReplaceEditorTool(io);
+    const exec = fakeExec("/abs");
+    await tool.execute({ command: "view", path: p }, exec);
+    const res = (await tool.execute(
+      { command: "insert", path: p, insert_line: 2, new_str: "inserted" },
+      exec,
+    )) as unknown as { text: string };
+    expect(res.text).toMatch(/Inserted/);
+    expect(fake.readRaw(p).toString("utf-8")).toContain("inserted");
+  });
+
+  it("hashline read (io.readText) -> str_replace works", async () => {
+    const fake = makeProdFs();
+    const p = "/abs/hash.txt";
+    fake.seed(p, Buffer.from("alpha\r\nbravo\r\ncharlie\r\n", "utf-8"));
+    const io: FileIO = ctxFsIO(fake.fs as never, makeCtx());
+    const tool = buildStrReplaceEditorTool(io);
+    const exec = fakeExec("/abs");
+    // hashline read observation path: same io.readText seam the read tool uses
+    await io.readText(p);
+    const res = (await tool.execute(
+      { command: "str_replace", path: p, old_str: "bravo", new_str: "BRAVO" },
+      exec,
+    )) as unknown as { text: string };
+    expect(res.text).toMatch(/Replaced 1 occurrence/);
+  });
+
+  it("external change after view still fails loud with E_BLIND_REPLACE", async () => {
+    const fake = makeProdFs();
+    const p = "/abs/drift.txt";
+    fake.seed(p, Buffer.from("alpha\r\nbravo\r\ncharlie\r\n", "utf-8"));
+    const io: FileIO = ctxFsIO(fake.fs as never, makeCtx());
+    const tool = buildStrReplaceEditorTool(io);
+    const exec = fakeExec("/abs");
+    await tool.execute({ command: "view", path: p }, exec);
+    fake.externalWrite(p, Buffer.from("alpha\r\nCHANGED\r\ncharlie\r\n", "utf-8"));
+    await expect(
+      tool.execute({ command: "str_replace", path: p, old_str: "alpha", new_str: "ALPHA" }, exec),
+    ).rejects.toThrow(/E_BLIND_REPLACE/);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #69. The shadow `str_replace_editor` rejected every `str_replace` / `insert` with `E_BLIND_REPLACE`, because `ctxFsIO.readText` recorded encoding state with `version: undefined` while `invalidateIfStale` compared against the real `statVersion` — so the memo was deleted before `requireObserved` could ever see it. The gate is now satisfied on both observation paths (`view` and hashline `read`) while still failing loud on external drift.

**Impact**: 4 files (236 +, 22 -) · **Risk**: Medium

## What Changed

- **fs-bridge (`ctxFsIO`)**: `restoreStrippedUtf8Bom` now returns `{ text, version }`, threading the stat version already taken on the main path into `recordOpenState` (issue-suggested fix 2). The BOM-already-preserved branch stats for version only — `readBytes` stays forbidden there, preserving the no-probe guarantee in `test/core/fs-bridge.policy.test.ts`.
- **fs-bridge key parity**: memos and footers are mirrored under both `targetKey` and the resolved `absolutePath`, and `writeText` invalidates both, covering the symlink/case mismatch flagged in the issue.
- **tests**: new `test/core/str-replace-version-gate.test.ts` runs the regression suite against a **fake `ctxFsIO`** (production version semantics) — BOM/no-BOM `view` → write round-trips, hashline `read` → write, and post-external-change `E_BLIND_REPLACE`. The prior suites used `localIO`, whose `readText`/`statVersion` share a source, which is exactly why the defect escaped CI.
- **policy test**: updated to permit the version-only stat while keeping the byte-probe ban.

No payload-contract, seam, or migration changes — `HashAssign` / `SessionView` / `FileView` / `Mutation` / `AnchorPipeline` are untouched.

## Checklist

- [x] `pnpm run lint && pnpm run format && pnpm run typecheck && pnpm test` green
- [x] Conventional Commits (`commitlint` + `husky`) — `npx commitlint --from=origin/main --to=HEAD`
- [x] `CHANGELOG.md` `## [Unreleased]` updated (generated form, pre-push green)
- [x] Docs / `docs/adr/` updated when seams or contracts change — no seam/contract change
- [x] No generated artifacts committed outside `.lsz/tmp`
- [x] Linked issue with `Closes #69`

## Acceptance criteria

| # | Criterion | Evidence |
|---|---|---|
| 1 | `view` → `str_replace`/`insert` succeeds, BOM/lineEnding preserved | `test/core/str-replace-version-gate.test.ts` BOM + no-BOM round-trips |
| 2 | hashline `read` → `str_replace` works | same suite, read→write case |
| 3 | Gate still fails loud after external change | drift case asserts `E_BLIND_REPLACE`; real version is recorded, so drift is detectable |
| 4 | Regression tests cover production IO path | fake `ctxFsIO`, not `localIO` |

## Verification

- `pnpm run typecheck` — pass
- `pnpm test` — 121 files / 1290 tests pass
- `pnpm run build` — pass
- `pnpm run format:check` — pass

Converged autonomously in 2 gate rounds via `converge-goal` (run `converge-goal-mtwqthsd-ihhl5p`); round 1 failed `format:check` on pre-existing `*` bullets in `CHANGELOG.md`, remediated in round 2.

Closes #69