### PR TITLE
fix(str-replace): stamp the sandbox policy on shadow writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [Unreleased]
+
+### Fixed
+
+- **str-replace:** stamp the sandbox policy on shadow writes
+
 ## [0.8.1](https://github.com/Rianico/dsh-better-edit/compare/v0.8.0...v0.8.1) (2026-09-11)
 
 ### Bug Fixes

--- a/src/index.ts
+++ b/src/index.ts
@@ -119,7 +119,7 @@ function installAgentTools(rootCtx: Context, agent: Agent): void {
     disposers.push(agent.ctx.tools.register(hashEditDef));
     // Governed shadow of the preset's built-in str_replace_editor
     // (ADR-0015): identical contract, encoding-governed mutations.
-    const hashStrReplaceDef = buildStrReplaceEditorTool(io);
+    const hashStrReplaceDef = buildStrReplaceEditorTool(io, sandbox);
     disposers.push(agent.ctx.tools.register(hashStrReplaceDef));
     disposers.push(registerUndoTool(rootCtx, agent.ctx, io, sandbox));
     disposers.push(registerWriteHook(rootCtx, agent.ctx, io));

--- a/src/tool-str-replace-editor.ts
+++ b/src/tool-str-replace-editor.ts
@@ -13,11 +13,18 @@
  * - `create` defaults to UTF-8 without BOM.
  * - `undo_edit` is out of scope → `E_UNSUPPORTED` (use `undo_last_edit`).
  *
+ * - `create` / `str_replace` / `insert` stamp the per-call sandbox policy from
+ *   `FsSandboxController` (the calling session's workspace root plus any
+ *   approved one-shot escalation), matching the built-in and the hashline
+ *   `edit` / `undo_last_edit` paths; unconfined deployments stamp `undefined`.
+ *
  * See ADR-0015.
  * @module dsh-better-edit/tool-str-replace-editor
  */
 
 import { defineTool } from "@deepseek-ai/dsh-tools";
+import type { ToolExecution } from "@deepseek-ai/dsh-tools";
+import type { FsEscalationArgs, FsSandboxController } from "./sandbox.js";
 import type { FileIO } from "./fs-bridge.js";
 import { getAutoGuessFooter } from "./fs-bridge.js";
 import {
@@ -103,6 +110,34 @@ async function requireObserved(
   }
 }
 
+/**
+ * Governed save: resolve the per-call sandbox policy — the session's standing
+ * mode stamped with the calling session's workspace root, or an approved
+ * one-shot escalation grant — and hand it to the provider write; a sandbox
+ * denial is remapped to the shared `[sandbox: …]` marker plus the escalation
+ * hint so the caller can retry once.
+ *
+ * Without it the confined backend falls back to the deployment default root,
+ * so a write inside the session workspace is denied under `workspace-write`
+ * even though the built-in `str_replace_editor` (which carries the policy)
+ * succeeds there. Mirrors the hashline `edit` / `undo_last_edit` path.
+ */
+async function writeGoverned(
+  io: FileIO,
+  sandbox: FsSandboxController,
+  absolutePath: string,
+  content: string,
+  args: FsEscalationArgs,
+  exec: ToolExecution,
+): Promise<void> {
+  const policy = await sandbox.resolvePolicy("str_replace_editor", args, exec);
+  try {
+    await io.writeText(absolutePath, content, exec.signal, exec, policy);
+  } catch (error) {
+    throw sandbox.mapError(error, policy);
+  }
+}
+
 function countOccurrences(haystack: string, needle: string): number {
   if (needle.length === 0) return 0;
   let count = 0;
@@ -131,7 +166,7 @@ function autoGuessWarning(absolutePath: string, rawPath: string): string | undef
   );
 }
 
-export function buildStrReplaceEditorTool(io: FileIO) {
+export function buildStrReplaceEditorTool(io: FileIO, sandbox: FsSandboxController) {
   return defineTool({
     name: "str_replace_editor",
     description: STR_REPLACE_EDITOR_DESCRIPTION,
@@ -166,6 +201,7 @@ export function buildStrReplaceEditorTool(io: FileIO) {
         type: "string",
         description: "Full content for create",
       },
+      ...(sandbox.escalationModes.length > 0 ? sandbox.schemaFields() : {}),
     },
     output: {
       schema: {
@@ -242,7 +278,7 @@ export function buildStrReplaceEditorTool(io: FileIO) {
             );
           }
           // Governed default: UTF-8 without BOM (no memo → no BOM).
-          await io.writeText(absolutePath, fileText, signal, exec);
+          await writeGoverned(io, sandbox, absolutePath, fileText, rec as FsEscalationArgs, exec);
           try {
             const version = await io.statVersion(absolutePath, signal);
             recordOpenState(absolutePath, fileText, "utf8", false, version);
@@ -287,7 +323,7 @@ export function buildStrReplaceEditorTool(io: FileIO) {
             );
           }
           const next = restoreForSave(current.replace(oldStr, newStr), absolutePath);
-          await io.writeText(absolutePath, next, signal, exec);
+          await writeGoverned(io, sandbox, absolutePath, next, rec as FsEscalationArgs, exec);
           return { text: `Replaced 1 occurrence in ${rawPath}.` };
         }
 
@@ -322,7 +358,7 @@ export function buildStrReplaceEditorTool(io: FileIO) {
         let out2 = lines.join("\n");
         if (endsWithNL && out2.length > 0) out2 += "\n";
         const next = restoreForSave(out2, absolutePath);
-        await io.writeText(absolutePath, next, signal, exec);
+        await writeGoverned(io, sandbox, absolutePath, next, rec as FsEscalationArgs, exec);
         return { text: `Inserted ${added.length} line(s) at line ${insertAt} in ${rawPath}.` };
       });
     },
@@ -333,6 +369,7 @@ export function buildStrReplaceEditorTool(io: FileIO) {
 export function registerStrReplaceEditorTool(
   agentCtx: { tools: { register(def: unknown): () => void } },
   io: FileIO,
+  sandbox: FsSandboxController,
 ): () => void {
-  return agentCtx.tools.register(buildStrReplaceEditorTool(io));
+  return agentCtx.tools.register(buildStrReplaceEditorTool(io, sandbox));
 }

--- a/test/core/render-text-warning.test.ts
+++ b/test/core/render-text-warning.test.ts
@@ -3,6 +3,7 @@ import { renderTextWarning } from "../../src/render-text-warning.js";
 import { buildReadTool } from "../../src/tool-read.js";
 import { buildStrReplaceEditorTool } from "../../src/tool-str-replace-editor.js";
 import { localIO } from "../../src/fs-bridge.js";
+import { makeTestSandbox } from "../support/fixtures.js";
 
 describe("renderTextWarning shared render (report #7)", () => {
   it("renders a bare string as one block", () => {
@@ -22,7 +23,7 @@ describe("renderTextWarning shared render (report #7)", () => {
     const read = buildReadTool(io) as unknown as {
       output: { render: (a: unknown, v: unknown) => unknown };
     };
-    const editor = buildStrReplaceEditorTool(io) as unknown as {
+    const editor = buildStrReplaceEditorTool(io, makeTestSandbox()) as unknown as {
       output: { render: (a: unknown, v: unknown) => unknown };
     };
     for (const value of ["bare", { text: "body" }, { text: "body", warning: "warn" }] as const) {

--- a/test/core/str-replace-sandbox-policy.test.ts
+++ b/test/core/str-replace-sandbox-policy.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Regression for the shadow `str_replace_editor` missing sandbox policy.
+ *
+ * The built-in `str_replace_editor` and the hashline `edit` / `undo_last_edit`
+ * paths stamp `ctx.sandboxPolicy.resolve({ session })` onto every provider
+ * write. The shadow did not, so a confining backend fell back to the deployment
+ * default root and denied every `create` / `str_replace` / `insert` under
+ * `workspace-write` — including targets inside the session workspace.
+ *
+ * The fake `ctx.fs` below enforces the real boundary — `writeText` refuses
+ * unless the per-call policy is present and covers the target — so dropping the
+ * policy again (the bug) fails these tests instead of only the real host.
+ * @module dsh-better-edit/str-replace-sandbox-policy.test
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FsError } from "@deepseek-ai/dsh-fs";
+import type { Context } from "@deepseek-ai/cordis";
+import {
+  clearAutoGuessFooter,
+  clearEncodingState,
+  ctxFsIO,
+  localIO,
+  type FileIO,
+} from "../../src/fs-bridge.js";
+import { FsSandboxController } from "../../src/sandbox.js";
+import { buildStrReplaceEditorTool } from "../../src/tool-str-replace-editor.js";
+import { makeTestSandbox } from "../support/fixtures.js";
+
+const WS_ROOT = "/abs/ws";
+const OUTSIDE = "/outside";
+
+interface StampedPolicy {
+  mode: string;
+  workspaceRoot: string;
+}
+
+/** In-memory confining `ctx.fs`: BOM-stripping reads + workspace-write writes. */
+function makeConfinedFs() {
+  const files = new Map<string, { bytes: Buffer; version: number }>();
+  const writes: Array<{ path: string; content: string; policy: StampedPolicy | undefined }> = [];
+  let seq = 1;
+  const keyOf = (t: unknown): string =>
+    typeof t === "string"
+      ? t
+      : ((t as { targetKey?: string }).targetKey ??
+        (t as { displayPath?: string }).displayPath ??
+        "");
+  const fs = {
+    resolve: vi.fn(async (p: string) => ({ targetKey: String(p), displayPath: String(p) })),
+    processPath: vi.fn((t: unknown) => keyOf(t)),
+    readText: vi.fn(async (t: unknown) => {
+      const f = files.get(keyOf(t));
+      if (!f) throw Object.assign(new Error("not found"), { code: "FS_NOT_FOUND" });
+      const raw = new TextDecoder("utf-8", { fatal: true }).decode(f.bytes);
+      return raw.startsWith("\uFEFF") ? raw.slice(1) : raw;
+    }),
+    stat: vi.fn(async (t: unknown) => {
+      const f = files.get(keyOf(t));
+      if (!f) throw Object.assign(new Error("not found"), { code: "FS_NOT_FOUND" });
+      return { version: `v${f.version}`, type: "file", size: f.bytes.length };
+    }),
+    writeText: vi.fn(
+      async (
+        t: unknown,
+        content: string,
+        _intent?: unknown,
+        _signal?: unknown,
+        policy?: StampedPolicy,
+      ) => {
+        const p = keyOf(t);
+        writes.push({ path: p, content, policy });
+        // A missing policy falls back to the deployment default root, whose
+        // workspace-write boundary does not cover the session workspace.
+        const root = policy?.mode === "danger-full-access" ? undefined : policy?.workspaceRoot;
+        const contained =
+          policy !== undefined &&
+          (policy.mode === "danger-full-access" ||
+            (root !== undefined && (p === root || p.startsWith(`${root}/`))));
+        if (!contained) {
+          throw new FsError(
+            `cannot write "${p}": file access denied under workspace-write mode`,
+            "FS_SANDBOX_DENIED" as never,
+          );
+        }
+        const cur = files.get(p);
+        const version = (cur?.version ?? 0) + 1;
+        files.set(p, { bytes: Buffer.from(content, "utf-8"), version });
+        return { version: `v${version}`, operation: "update", before: "", after: content };
+      },
+    ),
+  };
+  return {
+    fs,
+    writes,
+    seed(p: string, text: string) {
+      files.set(p, { bytes: Buffer.from(text, "utf-8"), version: seq++ });
+    },
+    readText(p: string) {
+      return files.get(p)!.bytes.toString("utf-8");
+    },
+  };
+}
+
+/** A confining composition: `ctx.fs.sandboxMode` set + `sandboxPolicy` service. */
+function makeConfinedCtx() {
+  const policyResolve = vi.fn((request?: { session?: { header?: { cwd?: string } } }) => ({
+    mode: "workspace-write",
+    workspaceRoot: request?.session?.header?.cwd ?? WS_ROOT,
+  }));
+  const approvalRequest = vi.fn(async () => "allowed-once");
+  const ctx = {
+    fs: { sandboxMode: "workspace-write" },
+    get: (service: string) =>
+      service === "sandboxPolicy"
+        ? { resolve: policyResolve }
+        : service === "approval"
+          ? { request: approvalRequest }
+          : undefined,
+  };
+  return { ctx, policyResolve, approvalRequest };
+}
+
+/** The host-plane context `ctxFsIO` needs (`fs/write-intent` waterfall + `fs/observed`). */
+function makeIoCtx() {
+  return { waterfall: vi.fn(async () => undefined), emit: vi.fn(() => {}) } as unknown as Context;
+}
+
+function fakeExec(cwd: string, session = "sre-sandbox") {
+  return {
+    signal: new AbortController().signal,
+    callId: "call-1",
+    agent: { id: session, session: { id: session, header: { cwd } } },
+  } as never;
+}
+
+function paramsOf(tool: unknown): Record<string, unknown> {
+  const p = (tool as { parameters: unknown }).parameters as Record<string, unknown>;
+  if (p && typeof p === "object" && "properties" in p)
+    return p["properties"] as Record<string, unknown>;
+  return p;
+}
+
+function confinedTool() {
+  const fake = makeConfinedFs();
+  const composition = makeConfinedCtx();
+  const io: FileIO = ctxFsIO(fake.fs as never, makeIoCtx());
+  const tool = buildStrReplaceEditorTool(io, new FsSandboxController(composition.ctx as never));
+  return { fake, tool, ...composition };
+}
+
+beforeEach(() => {
+  clearEncodingState();
+  clearAutoGuessFooter();
+});
+
+describe("shadow str_replace_editor stamps the sandbox policy", () => {
+  it("view -> str_replace carries the session workspace root", async () => {
+    const { fake, tool, policyResolve } = confinedTool();
+    const p = `${WS_ROOT}/f.txt`;
+    fake.seed(p, "alpha\r\nbravo\r\ncharlie\r\n");
+    const exec = fakeExec(WS_ROOT);
+
+    await tool.execute({ command: "view", path: p }, exec);
+    const res = (await tool.execute(
+      { command: "str_replace", path: p, old_str: "bravo", new_str: "BRAVO" },
+      exec,
+    )) as unknown as { text: string };
+
+    expect(res.text).toMatch(/Replaced 1 occurrence/);
+    expect(fake.readText(p)).toContain("BRAVO");
+    expect(policyResolve).toHaveBeenCalled();
+    const stamped = fake.writes[fake.writes.length - 1]!;
+    expect(stamped.policy?.mode).toBe("workspace-write");
+    expect(stamped.policy?.workspaceRoot).toBe(WS_ROOT);
+  });
+
+  it("insert carries the policy", async () => {
+    const { fake, tool } = confinedTool();
+    const p = `${WS_ROOT}/insert.txt`;
+    fake.seed(p, "alpha\nbravo\n");
+    const exec = fakeExec(WS_ROOT);
+
+    await tool.execute({ command: "view", path: p }, exec);
+    const res = (await tool.execute(
+      { command: "insert", path: p, insert_line: 1, new_str: "top" },
+      exec,
+    )) as unknown as { text: string };
+
+    expect(res.text).toMatch(/Inserted/);
+    expect(fake.readText(p)).toContain("top");
+    expect(fake.writes[fake.writes.length - 1]!.policy?.workspaceRoot).toBe(WS_ROOT);
+  });
+
+  it("create carries the policy", async () => {
+    const { fake, tool } = confinedTool();
+    const p = `${WS_ROOT}/created.txt`;
+    const exec = fakeExec(WS_ROOT);
+
+    const res = (await tool.execute(
+      { command: "create", path: p, file_text: "fresh\n" },
+      exec,
+    )) as unknown as { text: string };
+
+    expect(res.text).toMatch(/Created/);
+    expect(fake.readText(p)).toBe("fresh\n");
+    expect(fake.writes[fake.writes.length - 1]!.policy?.workspaceRoot).toBe(WS_ROOT);
+  });
+
+  it("a write outside the workspace fails with the shared sandbox marker + hint", async () => {
+    const { fake, tool } = confinedTool();
+    const p = `${OUTSIDE}/evil.txt`;
+    fake.seed(p, "alpha\nbravo\n");
+    const exec = fakeExec(WS_ROOT);
+
+    await tool.execute({ command: "view", path: p }, exec);
+    const error = (await tool
+      .execute({ command: "str_replace", path: p, old_str: "bravo", new_str: "BRAVO" }, exec)
+      .catch((e: unknown) => e)) as Error;
+
+    expect(error.message).toContain("[sandbox: file access denied under workspace-write mode]");
+    expect(error.message).toContain("escalation available");
+    expect(fake.readText(p)).toContain("bravo");
+  });
+
+  it("an approved one-shot escalation widens exactly this call", async () => {
+    const { fake, tool, approvalRequest } = confinedTool();
+    const p = `${OUTSIDE}/escalated.txt`;
+    fake.seed(p, "alpha\nbravo\n");
+    const exec = fakeExec(WS_ROOT);
+
+    await tool.execute({ command: "view", path: p }, exec);
+    const res = (await tool.execute(
+      {
+        command: "str_replace",
+        path: p,
+        old_str: "bravo",
+        new_str: "BRAVO",
+        sandbox_permissions: "danger-full-access",
+        justification: "the target file lives outside the session workspace",
+      },
+      exec,
+    )) as unknown as { text: string };
+
+    expect(res.text).toMatch(/Replaced 1 occurrence/);
+    expect(approvalRequest).toHaveBeenCalledTimes(1);
+    expect(fake.writes[fake.writes.length - 1]!.policy?.mode).toBe("danger-full-access");
+    expect(fake.readText(p)).toContain("BRAVO");
+  });
+
+  it("a non-widening escalation is rejected before any write", async () => {
+    const { fake, tool, approvalRequest } = confinedTool();
+    const p = `${WS_ROOT}/narrow.txt`;
+    fake.seed(p, "alpha\nbravo\n");
+    const exec = fakeExec(WS_ROOT);
+
+    await tool.execute({ command: "view", path: p }, exec);
+    const error = (await tool
+      .execute(
+        {
+          command: "str_replace",
+          path: p,
+          old_str: "bravo",
+          new_str: "BRAVO",
+          sandbox_permissions: "workspace-write",
+          justification: "same mode as the standing policy",
+        },
+        exec,
+      )
+      .catch((e: unknown) => e)) as Error;
+
+    expect(error.message).toMatch(/not strictly wider/);
+    expect(approvalRequest).not.toHaveBeenCalled();
+    expect(fake.readText(p)).toContain("bravo");
+  });
+
+  it("advertises the escalation params only under a confining composition", () => {
+    const confined = paramsOf(confinedTool().tool);
+    expect(confined).toHaveProperty("sandbox_permissions");
+    expect(confined).toHaveProperty("justification");
+
+    const open = paramsOf(buildStrReplaceEditorTool(localIO(), makeTestSandbox()));
+    expect(open).not.toHaveProperty("sandbox_permissions");
+    expect(open).not.toHaveProperty("justification");
+  });
+});

--- a/test/core/str-replace-version-gate.test.ts
+++ b/test/core/str-replace-version-gate.test.ts
@@ -13,6 +13,7 @@ import type { Context } from "@deepseek-ai/cordis";
 import { ctxFsIO, type FileIO } from "../../src/fs-bridge.js";
 import { clearEncodingState, clearAutoGuessFooter } from "../../src/fs-bridge.js";
 import { buildStrReplaceEditorTool } from "../../src/tool-str-replace-editor.js";
+import { makeTestSandbox } from "../support/fixtures.js";
 
 function fakeExec(cwd: string, session = "sre-vgate") {
   return {
@@ -101,7 +102,7 @@ describe("issue #69: ctxFsIO version semantics authorize shadow writes", () => {
       ]),
     );
     const io: FileIO = ctxFsIO(fake.fs as never, makeCtx());
-    const tool = buildStrReplaceEditorTool(io);
+    const tool = buildStrReplaceEditorTool(io, makeTestSandbox());
     const exec = fakeExec("/abs");
     await tool.execute({ command: "view", path: p }, exec);
     const res = (await tool.execute(
@@ -122,7 +123,7 @@ describe("issue #69: ctxFsIO version semantics authorize shadow writes", () => {
     const p = "/abs/nobom.txt";
     fake.seed(p, Buffer.from("alpha\r\nbravo\r\ncharlie\r\n", "utf-8"));
     const io: FileIO = ctxFsIO(fake.fs as never, makeCtx());
-    const tool = buildStrReplaceEditorTool(io);
+    const tool = buildStrReplaceEditorTool(io, makeTestSandbox());
     const exec = fakeExec("/abs");
     await tool.execute({ command: "view", path: p }, exec);
     const res = (await tool.execute(
@@ -138,7 +139,7 @@ describe("issue #69: ctxFsIO version semantics authorize shadow writes", () => {
     const p = "/abs/hash.txt";
     fake.seed(p, Buffer.from("alpha\r\nbravo\r\ncharlie\r\n", "utf-8"));
     const io: FileIO = ctxFsIO(fake.fs as never, makeCtx());
-    const tool = buildStrReplaceEditorTool(io);
+    const tool = buildStrReplaceEditorTool(io, makeTestSandbox());
     const exec = fakeExec("/abs");
     // hashline read observation path: same io.readText seam the read tool uses
     await io.readText(p);
@@ -154,7 +155,7 @@ describe("issue #69: ctxFsIO version semantics authorize shadow writes", () => {
     const p = "/abs/drift.txt";
     fake.seed(p, Buffer.from("alpha\r\nbravo\r\ncharlie\r\n", "utf-8"));
     const io: FileIO = ctxFsIO(fake.fs as never, makeCtx());
-    const tool = buildStrReplaceEditorTool(io);
+    const tool = buildStrReplaceEditorTool(io, makeTestSandbox());
     const exec = fakeExec("/abs");
     await tool.execute({ command: "view", path: p }, exec);
     fake.externalWrite(p, Buffer.from("alpha\r\nCHANGED\r\ncharlie\r\n", "utf-8"));

--- a/test/support/fixtures.ts
+++ b/test/support/fixtures.ts
@@ -209,7 +209,7 @@ function wrapTool(
  * A sandbox controller for tests: no confining backend, so no escalation
  * fields are advertised and `resolvePolicy` returns undefined (unconfined).
  */
-function makeTestSandbox() {
+export function makeTestSandbox() {
   return new FsSandboxController({
     fs: { sandboxMode: undefined },
     get: () => undefined,

--- a/tests/contract/str-replace-editor.test.ts
+++ b/tests/contract/str-replace-editor.test.ts
@@ -4,6 +4,11 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { localIO, clearEncodingState, clearAutoGuessFooter } from "../../src/fs-bridge.js";
 import { buildStrReplaceEditorTool } from "../../src/tool-str-replace-editor.js";
+import { FsSandboxController } from "../../src/sandbox.js";
+
+/** No confining backend: no escalation fields, `resolvePolicy` → undefined. */
+const noSandbox = () =>
+  new FsSandboxController({ fs: { sandboxMode: undefined }, get: () => undefined } as never);
 
 function fakeExec(cwd: string, session = "sre-contract") {
   return {
@@ -21,7 +26,7 @@ describe("str_replace_editor contract parity", () => {
     return p;
   }
   it("tool name is str_replace_editor with built-in command params and no encoding param", () => {
-    const tool = buildStrReplaceEditorTool(localIO()) as unknown as {
+    const tool = buildStrReplaceEditorTool(localIO(), noSandbox()) as unknown as {
       name: string;
       parameters: Record<string, unknown>;
     };
@@ -48,7 +53,7 @@ describe("str_replace_editor contract parity", () => {
       clearAutoGuessFooter();
       const p = join(dir, "f.txt");
       await writeFile(p, "l1\nl2\nl3\nl4\n", "utf-8");
-      const tool = buildStrReplaceEditorTool(localIO());
+      const tool = buildStrReplaceEditorTool(localIO(), noSandbox());
       const exec = fakeExec(dir);
       const res = (await tool.execute(
         { command: "view", path: p, view_range: [2, 3] },
@@ -69,7 +74,7 @@ describe("str_replace_editor contract parity", () => {
       clearEncodingState();
       clearAutoGuessFooter();
       const io = localIO();
-      const tool = buildStrReplaceEditorTool(io);
+      const tool = buildStrReplaceEditorTool(io, noSandbox());
       const exec = fakeExec(dir);
       const created = join(dir, "new.txt");
       const c = (await tool.execute(
@@ -98,7 +103,7 @@ describe("str_replace_editor contract parity", () => {
   });
 
   it("unknown command rejected", async () => {
-    const tool = buildStrReplaceEditorTool(localIO());
+    const tool = buildStrReplaceEditorTool(localIO(), noSandbox());
     await expect(
       tool.execute({ command: "delete", path: "x" }, fakeExec(tmpdir())),
     ).rejects.toThrow(/E_BAD_COMMAND|unknown command/i);

--- a/tests/tool-str-replace-editor.test.ts
+++ b/tests/tool-str-replace-editor.test.ts
@@ -6,6 +6,11 @@ import iconv from "iconv-lite";
 import { localIO, clearEncodingState, clearAutoGuessFooter } from "../src/fs-bridge.js";
 import { _resetConfigCache } from "../src/store-config.js";
 import { buildStrReplaceEditorTool } from "../src/tool-str-replace-editor.js";
+import { FsSandboxController } from "../src/sandbox.js";
+
+/** No confining backend: no escalation fields, `resolvePolicy` → undefined. */
+const noSandbox = () =>
+  new FsSandboxController({ fs: { sandboxMode: undefined }, get: () => undefined } as never);
 
 function fakeExec(cwd: string, session = "sre-test") {
   return {
@@ -40,7 +45,7 @@ describe("str_replace_editor shadow tool (TDD red)", () => {
       Buffer.concat([Buffer.from([0xef, 0xbb, 0xbf]), Buffer.from("hello\nworld\n", "utf-8")]),
     );
     const io = localIO();
-    const tool = buildStrReplaceEditorTool(io);
+    const tool = buildStrReplaceEditorTool(io, noSandbox());
     const exec = fakeExec(dir);
     await tool.execute({ command: "view", path: p }, exec);
     const res = (await tool.execute(
@@ -65,7 +70,7 @@ describe("str_replace_editor shadow tool (TDD red)", () => {
     process.env.DSH_BETTER_EDIT_AUTO_GUESS_ENCODING = "true";
     _resetConfigCache();
     const io = localIO();
-    const tool = buildStrReplaceEditorTool(io);
+    const tool = buildStrReplaceEditorTool(io, noSandbox());
     const res = (await tool.execute({ command: "view", path: p }, fakeExec(dir))) as unknown as {
       text: string;
       warning?: string;
@@ -80,7 +85,7 @@ describe("str_replace_editor shadow tool (TDD red)", () => {
     await writeFile(p, iconv.encode("你好世界", "gbk"));
     process.env.DSH_BETTER_EDIT_AUTO_GUESS_ENCODING = "true";
     _resetConfigCache();
-    const tool = buildStrReplaceEditorTool(localIO());
+    const tool = buildStrReplaceEditorTool(localIO(), noSandbox());
     const res = (await tool.execute({ command: "view", path: p }, fakeExec(dir))) as unknown as {
       text: string;
       warning?: string;
@@ -104,7 +109,7 @@ describe("str_replace_editor shadow tool (TDD red)", () => {
         );
       },
     } as unknown as ReturnType<typeof localIO>;
-    const tool = buildStrReplaceEditorTool(throwingIO);
+    const tool = buildStrReplaceEditorTool(throwingIO, noSandbox());
     await expect(
       tool.execute({ command: "view", path: join(dir, "x.bin") }, fakeExec(dir)),
     ).rejects.toThrow(/E_UNSUPPORTED_FILE/);
@@ -114,7 +119,7 @@ describe("str_replace_editor shadow tool (TDD red)", () => {
     const p = join(dir, "blind.txt");
     await writeFile(p, "alpha\nbeta\n", "utf-8");
     const io = localIO();
-    const tool = buildStrReplaceEditorTool(io);
+    const tool = buildStrReplaceEditorTool(io, noSandbox());
     await expect(
       tool.execute(
         { command: "str_replace", path: p, old_str: "beta", new_str: "BETA" },
@@ -127,7 +132,7 @@ describe("str_replace_editor shadow tool (TDD red)", () => {
   it("blind insert without prior view -> E_BLIND_REPLACE", async () => {
     const p = join(dir, "blind2.txt");
     await writeFile(p, "a\nb\n", "utf-8");
-    const tool = buildStrReplaceEditorTool(localIO());
+    const tool = buildStrReplaceEditorTool(localIO(), noSandbox());
     await expect(
       tool.execute({ command: "insert", path: p, insert_line: 1, new_str: "x" }, fakeExec(dir)),
     ).rejects.toThrow(/E_BLIND_REPLACE/);
@@ -136,7 +141,7 @@ describe("str_replace_editor shadow tool (TDD red)", () => {
   it("old_str must match exactly once", async () => {
     const p = join(dir, "dup.txt");
     await writeFile(p, "same\nsame\n", "utf-8");
-    const tool = buildStrReplaceEditorTool(localIO());
+    const tool = buildStrReplaceEditorTool(localIO(), noSandbox());
     const exec = fakeExec(dir);
     await tool.execute({ command: "view", path: p }, exec);
     await expect(


### PR DESCRIPTION
## Summary

The shadow `str_replace_editor` (ADR-0015) called `io.writeText` without the
per-call sandbox policy, so on a confining backend every `create` /
`str_replace` / `insert` was denied — even for targets inside the session
workspace. The built-in `@deepseek-ai/dsh-tool-str-replace-editor` and the
hashline `edit` / `undo_last_edit` paths both stamp
`ctx.sandboxPolicy.resolve({ session })`, so the shadow broke the contract
parity ADR-0015 promises.

Reproduced on dsh-better-edit 0.8.1 (i.e. after #70 fixed the read-first
gate): `view` succeeds, then `str_replace` fails with
`cannot write "...": file access denied under workspace-write mode`, while a
hashline `edit` on the same file in the same session workspace succeeds.
`create` fails the same way, so the shadow had no working write command at all.
The session's standing mode was `danger-full-access` (a hashline `edit` wrote in
the same workspace), yet the error named `workspace-write`: the fallback is the
deployment default, proving the session policy never reached the write.

**Impact**: 9 files (363 +, 23 -) · **Risk**: Medium

**中文**

影子 `str_replace_editor`（ADR-0015）调用 `io.writeText` 时没有带上本次调用的
沙箱策略，因此在受约束后端上 `create` / `str_replace` / `insert` 全部被拒绝 ——
即使目标就在会话工作区内。内置 `@deepseek-ai/dsh-tool-str-replace-editor` 与
hashline 的 `edit` / `undo_last_edit` 都会 stamp
`ctx.sandboxPolicy.resolve({ session })`，所以影子破坏了 ADR-0015 承诺的
contract parity。

复现环境：dsh-better-edit 0.8.1（即 #70 修好 read-first gate 之后）——`view`
成功，紧接着 `str_replace` 报
`cannot write "...": file access denied under workspace-write mode`；而同一会话
工作区内对同一文件走 hashline `edit` 可以成功。`create` 同样失败，等于影子没有
任何可用的写命令。实测时会话的 standing mode 是 `danger-full-access`（同一工作区内
hashline `edit` 可写），但报错却指名 `workspace-write` —— 回退用的是部署默认，证明
会话策略根本没有到达写入层。

**影响**：9 个文件（+363 / -23）· **风险**：中（隔离的特性修复）

## What Changed

- **str-replace: mutations carry the policy.** Every `create` / `str_replace` /
  `insert` now goes through one governed save:
  `FsSandboxController.resolvePolicy("str_replace_editor", args, exec)` →
  `io.writeText(path, content, signal, exec, policy)` →
  `sandbox.mapError(error, policy)`. The policy carries the calling session's
  workspace root, or an approved one-shot escalation grant.
- **str-replace: denial vocabulary.** A `FS_SANDBOX_DENIED` is remapped to the
  shared `[sandbox: file access denied under <mode> mode]` marker plus the
  escalation hint, matching the built-in tool, so the model can retry once with
  `sandbox_permissions` instead of looping on `view`.
- **str-replace: escalation schema.** `sandbox_permissions` / `justification`
  are advertised only when a confining backend is mounted
  (`sandbox.escalationModes.length > 0`) — the same conditional `edit` uses.
- **Wiring.** `buildStrReplaceEditorTool(io, sandbox)` and
  `registerStrReplaceEditorTool(agentCtx, io, sandbox)`, mirroring
  `buildEditTool` / `registerUndoTool`; `src/index.ts` passes the controller it
  already constructs for `edit` / `undo_last_edit`.
- **Tests.** New `test/core/str-replace-sandbox-policy.test.ts` drives the tool
  through a fake `ctx.fs` that enforces the boundary: `writeText` denies any
  write whose per-call policy is missing or does not cover the target, so
  dropping the policy again fails CI instead of only a real host. It covers
  `str_replace` / `insert` / `create` stamping the session root, an
  out-of-workspace denial (marker + hint, file untouched), a non-widening
  escalation rejected before any write, an approved `danger-full-access` grant
  widening exactly one call, and the conditional escalation params. Existing
  call sites were updated for the new signature.

No payload-contract, migration, or API change: the command surface and existing
parameters are unchanged, and the two escalation fields appear only under a
confining composition.

**中文**

- **str-replace：写操作携带策略。** `create` / `str_replace` / `insert` 统一走一次
  governed save：`FsSandboxController.resolvePolicy("str_replace_editor", args,
  exec)` → `io.writeText(path, content, signal, exec, policy)` →
  `sandbox.mapError(error, policy)`。策略携带调用会话的 workspace root，或一次
  经批准的升级授权。
- **str-replace：拒绝词汇统一。** `FS_SANDBOX_DENIED` 被重映射为共享的
  `[sandbox: file access denied under <mode> mode]` 标记 + 升级提示，与内置工具
  一致 —— 模型可以带 `sandbox_permissions` 重试一次，而不是反复 `view`。
- **str-replace：升级参数。** 仅当挂载了受约束后端
  （`sandbox.escalationModes.length > 0`）才广告 `sandbox_permissions` /
  `justification`，与 `edit` 完全相同的条件。
- **接线。** `buildStrReplaceEditorTool(io, sandbox)`、
  `registerStrReplaceEditorTool(agentCtx, io, sandbox)`，对齐 `buildEditTool` /
  `registerUndoTool`；`src/index.ts` 复用它已经为 `edit` / `undo_last_edit`
  构造好的 controller。
- **测试。** 新增 `test/core/str-replace-sandbox-policy.test.ts`：用一个真正执行
  边界的 fake `ctx.fs` 驱动工具（per-call 策略缺失、或不覆盖目标，即拒绝写入），
  因此再次丢掉策略会在 CI 变红，而不是只在真机上失败。覆盖
  `str_replace` / `insert` / `create` 都 stamp 会话根、越界写入被拒（marker +
  hint，文件字节未变）、非加宽升级在写入前被拒、批准的 `danger-full-access` 只
  放宽一次、以及升级参数的条件广告。既有调用点已适配新签名。

无 payload 契约、迁移或 API 变更：命令面与既有参数不变，两个升级字段只在受约束
组合下出现。

## Architecture

No layering change: the shadow now resolves the sandbox policy through the same
seam the hashline tools already use, so the session workspace root (or an
approved one-shot grant) reaches the provider write.

Before — the policy was never passed, so the confining backend fell back to the
deployment default root:

```mermaid
graph LR
  A["str_replace_editor shadow"] --> B["io.writeText(path, text, signal, exec)"]
  B --> C["ctx.fs: sandboxPolicy ?? deployment default"]
```

After — the policy is resolved per call and stamped onto the write, with
denials mapped to the shared marker:

```mermaid
graph LR
  A["str_replace_editor shadow"] --> B["sandbox.resolvePolicy(session)"]
  A --> C["io.writeText(..., exec, policy)"]
  B --> C
  C --> D["ctx.fs: session root / approved grant"]
  C --> E["sandbox.mapError -> [sandbox: ...] marker"]
```

**中文**

分层未变；影子现在与 hashline 的 `edit` / `undo_last_edit` 走同一条沙箱策略 seam ——
会话 workspace root（或一次经批准的升级授权）由此到达 provider 写入。

（上方英文段的 Before / After 两张 mermaid 图对应下面两行，此处不重复）

Before（图见上）—— 策略从未被传入，受约束后端因此回退到部署默认 root：

After（图见上）—— 每次调用都解析策略并 stamp 到写入上，拒绝映射为共享 marker。

## Checklist

- [x] `pnpm run typecheck` green (`tsc --noEmit` + `tsc -p tsconfig.test.json`)
- [x] Related suites green: `test/core/str-replace-sandbox-policy.test.ts`,
      `test/core/str-replace-version-gate.test.ts`,
      `test/core/render-text-warning.test.ts`,
      `tests/tool-str-replace-editor.test.ts`,
      `tests/contract/str-replace-editor.test.ts` (25 passed)
- [x] Regression proof: removing the policy from the single `io.writeText` call
      makes 4 of the 7 new tests fail (mutation-checked, then restored)
- [x] Conventional Commits: `npx commitlint --from=upstream/main --to=HEAD` green;
      PR title is 59 chars (limit 72)
- [x] No generated artifacts committed (`lib/` is gitignored)
- [x] `pnpm test` full suite: 1258 passed / 32 failed locally, all pre-existing
      and unrelated — the same 27 failures reproduce on a clean `v0.8.1`
      checkout (`hash-store`/sqlite, `paths`, `canonical-path`, `served-state`,
      `snapshot-store`), i.e. a local Windows environment issue, not this change;
      committed blobs are LF (`git ls-files --eol` = `i/lf w/crlf`) so CI's
      `pnpm run format` is unaffected
- [x] `CHANGELOG.md` `## [Unreleased]` synced with
      `python scripts/changelog-unreleased.py update` (commit
      `chore: sync changelog unreleased section`); versioned sections are
      release-generated and untouched
- [ ] `docs/adr/`: ADR-0015 can gain one sentence stating that the shadow also
      stamps the sandbox policy as part of contract parity (happy to add it here)

**中文**

- [x] `pnpm run typecheck` 通过（`tsc --noEmit` + `tsc -p tsconfig.test.json`）
- [x] 相关测试全绿：`test/core/str-replace-sandbox-policy.test.ts`、
      `test/core/str-replace-version-gate.test.ts`、
      `test/core/render-text-warning.test.ts`、
      `tests/tool-str-replace-editor.test.ts`、
      `tests/contract/str-replace-editor.test.ts`（25 passed）
- [x] 回归证明：把 `io.writeText` 那一处的 policy 去掉 → 新测试 7 条里 4 条立刻
      失败（已做 mutation 验证并恢复）
- [x] Conventional Commits：`npx commitlint --from=upstream/main --to=HEAD` 通过；
      PR 标题 59 字符（上限 72）
- [x] 未提交生成物（`lib/` 已在 gitignore 中）
- [x] `pnpm test` 全量：本机 1258 passed / 32 failed，全部为预存失败且与本改动
      无关 —— 在干净的 `v0.8.1` 检出上同样的 27 条失败可复现
      （`hash-store`/sqlite、`paths`、`canonical-path`、`served-state`、
      `snapshot-store`），属本机 Windows 环境问题；入库 blob 为 LF
      （`git ls-files --eol` = `i/lf w/crlf`），不影响 CI 的 `pnpm run format`
- [x] `CHANGELOG.md` 的 `## [Unreleased]` 已用
      `python scripts/changelog-unreleased.py update` 同步（提交
      `chore: sync changelog unreleased section`）；versioned 段落由发布流程生成，
      未手动修改
- [ ] `docs/adr/`：可以在 ADR-0015 补一句"影子同样 stamp 沙箱策略，属
      contract parity 的一部分"（需要的话我在这里补上）

## Notes for the reviewer

- This is a follow-up to #70: that fix restored the read-first gate, which then
  exposed this second, independent failure (the write never reached the disk
  before because `E_BLIND_REPLACE` fired first).
- `verify` (lint/format/typecheck/test/audit) only runs from `release.yml` on
  `repository_dispatch`/`workflow_dispatch`, so it does not report on this PR;
  the PR-time required check is `changelog-check.yml`, which is satisfied above.
- Linked issue: #71, closed by the `Closes #71` line at the end of this description.

**中文**

- 这是 #70 的后续：那个修复恢复了 read-first gate，随后暴露出这第二个、独立的
  失败（此前 `E_BLIND_REPLACE` 先触发，写入根本没走到磁盘）。
- `verify`（lint/format/typecheck/test/audit）只在 `release.yml` 的
  `repository_dispatch`/`workflow_dispatch` 上跑，不会在本 PR 上报结果；PR 阶段
  的 required check 是 `changelog-check.yml`，已满足。
- 关联 issue：[#71](https://github.com/Rianico/dsh-better-edit/issues/71)，由文末 `Closes #71` 关联。

Closes #71

<!-- Linked issue: #71 — CONTRIBUTING.md requires a linked issue; the "Closes #71" line above references it. -->
